### PR TITLE
fix: detect Windows drive letter paths on all platforms

### DIFF
--- a/src/godspeed/tools/path_utils.py
+++ b/src/godspeed/tools/path_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -14,6 +15,13 @@ def resolve_tool_path(file_path: str, cwd: Path) -> Path:
     Raises:
         ValueError: If the resolved path is outside the project directory.
     """
+    # Reject Windows drive letter paths on any platform (e.g., C:\... or D:/)
+    if re.match(r"^[A-Za-z]:[\\\/]", str(file_path)):
+        raise ValueError(
+            f"Access denied: path '{file_path}' is a Windows absolute path "
+            f"which is outside the project directory '{cwd.resolve()}'"
+        )
+
     path = Path(file_path)
     resolved = path.resolve() if path.is_absolute() else (cwd / path).resolve()
     cwd_resolved = cwd.resolve()

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -77,7 +77,6 @@ class TestPathTraversal:
         except (ValueError, OSError):
             pass  # Expected on most platforms
 
-    @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-only path behavior")
     def test_windows_drive_escape(self, tmp_path: Path) -> None:
         """Windows drive letter absolute paths should be caught."""
         with pytest.raises(ValueError, match="outside the project"):


### PR DESCRIPTION
## Summary
- `resolve_tool_path` now explicitly rejects Windows drive letter paths (e.g., `C:\...`) via regex on **all platforms**, not just Windows
- Removes `@pytest.mark.skipif(platform.system() != "Windows")` from `test_windows_drive_escape` so the test runs on Linux CI
- Fixes CI failure: `tests/test_adversarial.py::TestPathTraversal::test_windows_drive_escape`

## Test plan
- [ ] CI passes on Linux (the previously failing test now works cross-platform)
- [ ] Existing path traversal tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)