### PR TITLE
fix: prevent double-render of assistant text when streaming

### DIFF
--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -122,7 +122,8 @@ async def agent_loop(
             final_text = response.content
             if final_text:
                 conversation.add_assistant_message(content=final_text)
-                if on_assistant_text:
+                # Skip Markdown re-render if we already streamed the text
+                if on_assistant_text and on_assistant_chunk is None:
                     on_assistant_text(final_text)
             return final_text
 


### PR DESCRIPTION
## Summary
- When streaming was enabled, assistant text was rendered twice: once via `on_assistant_chunk` (streamed) and again via `on_assistant_text` (Markdown re-render)
- Fix: skip `on_assistant_text` callback when `on_assistant_chunk` was used, since text was already displayed

## Test plan
- [x] `pytest tests/ -x -q` — 626 passed
- [x] Manual test: Godspeed no longer repeats assistant responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)