### PR TITLE
feat: v0.7.0-v0.9.0 — skills, hooks, tasks, auto-permission, codebase index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-11
+
+### Added
+
+- **Skill framework**: Markdown `.md` files with YAML frontmatter define reusable prompt skills. `discover_skills()` scans `~/.godspeed/skills/` and `.godspeed/skills/`, project overrides global. `/{trigger}` commands inject skill content into conversation. `/skills` lists available skills. Tab-completion for skill triggers.
+- **Auto-permission learning**: `ApprovalTracker` counts repeated user approvals per pattern. After 3 approvals, suggests adding as permanent allow rule. `append_allow_rule()` persists to `.godspeed/settings.yaml`. Thread-safe, session-scoped.
+- **Hook system**: `HookDefinition` pydantic model with 4 event types (`pre_tool_call`, `post_tool_call`, `pre_session`, `post_session`). `HookExecutor` runs shell commands with template variables (`{tool_name}`, `{session_id}`, `{cwd}`). Pre-tool hooks can block execution. Configurable timeout (1-300s). Wired into agent loop and CLI lifecycle.
+- **Task tracking**: `TaskStore` (in-memory, sequential IDs) + `TaskTool` (create/update/list/complete). `/tasks` command shows themed Rich table. Registered as built-in LOW-risk tool.
+- **Codebase index**: Optional ChromaDB-backed semantic search (`[index]` extra). AST-based chunking for Python, sliding window for other languages. `CodeSearchTool` for natural language code queries. Background indexing, `/reindex` command, stale detection.
+- **Architecture document**: `GODSPEED_ARCHITECTURE.md` — 6-part reference covering core loop, security model, tool system, intelligence, autonomy, and memory/TUI. Mermaid diagrams. HTML comment delimiters for chunk loading.
+- `hooks` field in `GodspeedSettings` for YAML hook configuration
+- `chromadb` optional dependency under `[index]` extra
+- 734 tests, ~90% coverage
+
 ## [0.6.0] - 2026-04-11
 
 ### Added

--- a/GODSPEED_ARCHITECTURE.md
+++ b/GODSPEED_ARCHITECTURE.md
@@ -1,0 +1,664 @@
+# Godspeed Architecture (v0.6.0)
+
+> Security-first coding agent. Hand-rolled ReAct loop. No framework overhead.
+> 53 modules · 6,988 LOC · 626 tests · 90% coverage
+
+---
+
+<!-- PART 1: Core Loop -->
+
+## Part 1: Core Loop
+
+**Files**: `agent/loop.py` (365 lines), `agent/conversation.py` (121 lines)
+
+### ReAct Cycle
+
+The agent loop (`async agent_loop()`) follows the pattern proven by mini-swe-agent (74%+ SWE-bench):
+
+```
+User input → Conversation → LLM call → Tool calls? → Execute → Loop
+                                      → Text only?  → Return (done)
+```
+
+```mermaid
+flowchart TD
+    A[User Input] --> B[Add to Conversation]
+    B --> C{Near Token Limit?}
+    C -->|Yes| D[Compact Conversation]
+    C -->|No| E[LLM Call]
+    D --> E
+    E --> F{Has Tool Calls?}
+    F -->|No| G[Return Final Text]
+    F -->|Yes| H[Check Permissions]
+    H -->|Denied| I[Record Denial]
+    H -->|Allowed| J[Execute Tool]
+    I --> K{More Tool Calls?}
+    J --> L[Auto-Verify if .py]
+    L --> M[Auto-Stash if 3+ writes]
+    M --> N[Stuck Loop Check]
+    N --> K
+    K -->|Yes| H
+    K -->|No| O{Under Iteration Limit?}
+    O -->|Yes| C
+    O -->|No| P[Return Max Iterations Error]
+```
+
+### Constants
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `MAX_ITERATIONS` | 50 | Per `agent_loop()` invocation |
+| `MAX_RETRIES` | 3 | Malformed tool call tolerance |
+| `STUCK_LOOP_THRESHOLD` | 3 | Identical errors before intervention |
+| `AUTO_STASH_THRESHOLD` | 3 | Consecutive writes before git stash |
+
+### Five Callback Types
+
+All optional parameters to `agent_loop()`:
+
+| Type | Signature | When |
+|------|-----------|------|
+| `OnAssistantText` | `(str) → None` | Final complete text (non-streaming only) |
+| `OnToolCall` | `(str, dict) → None` | Before tool execution |
+| `OnToolResult` | `(str, ToolResult) → None` | After tool execution |
+| `OnPermissionDenied` | `(str, str) → None` | Permission engine blocks a call |
+| `OnChunk` | `(str) → None` | Each streaming text delta |
+
+**Streaming vs Batch**: When `on_assistant_chunk` is provided, uses `llm_client.stream_chat()` (async generator). Otherwise uses `llm_client.chat()` (batch). The `on_assistant_text` callback is skipped when streaming was used (prevents double-render).
+
+### Pause/Resume
+
+Optional `pause_event: asyncio.Event` parameter. When cleared, the loop waits at the top of each iteration via `await pause_event.wait()`. Set the event to resume. Used by `/pause`, `/resume`, and `/guidance` commands for human-in-the-loop control.
+
+### Stuck-Loop Detection
+
+Tracks recent error hashes (SHA-256). When `STUCK_LOOP_THRESHOLD` identical consecutive errors occur, injects a user message: *"You have failed 3 times with the same error. Stop, explain what is wrong, and try a completely different approach."* Resets on any non-error result.
+
+### Auto-Verify
+
+After successful `file_edit` or `file_write` on `.py`/`.pyi` files, automatically dispatches the `verify` tool. Results feed back into conversation for self-correction. Silently skipped if verify tool not registered.
+
+### Auto-Stash
+
+Tracks consecutive write operations. After `AUTO_STASH_THRESHOLD` consecutive writes, calls `git stash` once per loop invocation. Injects a tool result explaining the stash. Resets counter on any non-write tool.
+
+### Conversation Management
+
+`Conversation` wraps message history with token-aware compaction:
+
+- **`add_user_message(content)`** / **`add_assistant_message(content, tool_calls)`** / **`add_tool_result(tool_call_id, content)`** — standard message append
+- **`compact(summary)`** — replaces history with summary, logs token reduction
+- **`is_near_limit`** — `token_count >= max_tokens * compaction_threshold` (default 0.8)
+- **`messages`** property — returns `[system_message, *history]`
+
+Token counting via `count_message_tokens(messages, model)` from the tokenizer module.
+
+---
+
+<!-- PART 2: Security Model -->
+
+## Part 2: Security Model
+
+**Files**: `security/permissions.py` (197 lines), `security/dangerous.py` (139 lines), `security/secrets.py` (176 lines)
+
+### Permission Evaluation Order
+
+Deny-first, 6-step evaluation:
+
+```mermaid
+flowchart TD
+    A[Tool Call] --> B{Deny Rules Match?}
+    B -->|Yes| C[DENY]
+    B -->|No| D{Shell + Dangerous Command?}
+    D -->|Yes| C
+    D -->|No| E{Session Grant Active?}
+    E -->|Yes| F[ALLOW]
+    E -->|No| G{Allow Rules Match?}
+    G -->|Yes| F
+    G -->|No| H{Ask Rules Match?}
+    H -->|Yes| I[ASK User]
+    H -->|No| J{Risk Level Default}
+    J -->|READ_ONLY| F
+    J -->|LOW| I
+    J -->|HIGH| I
+    J -->|DESTRUCTIVE| C
+```
+
+### Risk Levels
+
+```python
+class RiskLevel(StrEnum):
+    READ_ONLY = "read_only"   # Auto-allow, no prompt
+    LOW = "low"               # Ask once, then session-allow
+    HIGH = "high"             # Ask every time (default)
+    DESTRUCTIVE = "destructive"  # Deny by default
+```
+
+### Permission Engine
+
+```python
+class PermissionEngine:
+    def evaluate(tool_call) -> PermissionDecision  # 6-step chain
+    def grant_session_permission(pattern)           # TTL=3600s, fnmatch
+    def revoke_session_permission(pattern)
+    def revoke_session_permissions()                # Clear all
+```
+
+`PermissionDecision` supports string comparison: `decision == "allow"`. Has `.action` and `.reason` fields.
+
+**Plan Mode**: When `permission_engine.plan_mode = True`, all non-`READ_ONLY` tools are blocked. Toggled by `/plan` command.
+
+**Session Grants**: Pattern-based (fnmatch), TTL of 3600 seconds (1 hour). Thread-safe with `threading.Lock`. Expired grants cleaned on next check.
+
+### Dangerous Command Detection
+
+50+ compiled regex patterns in `dangerous.py`. Categories:
+
+| Category | Examples |
+|----------|----------|
+| Filesystem | `rm -rf /`, `chmod 777`, `mkfs.` |
+| Disk | `dd if=`, raw writes to `/dev/sd*` |
+| Pipe-to-shell | `curl \| sh`, `wget \| python` |
+| SQL | `DROP TABLE`, `DELETE FROM`, `TRUNCATE` |
+| Git | `git push --force`, `git reset --hard` |
+| System | `kill -9`, `systemctl stop`, `eval(` |
+| Privilege | `sudo`, `su -` |
+| Reverse shell | `nc -l`, `ncat` |
+| Supply chain | `npm publish`, `pip install --force-reinstall`, `twine upload` |
+| Container | `docker run --privileged`, `docker system prune` |
+| Kubernetes | `kubectl delete` |
+
+**Function**: `detect_dangerous_command(command: str) -> list[str]` — returns matched danger descriptions. Empty list = safe.
+
+### Secret Detection & Redaction
+
+4-layer protection:
+
+1. **File access deny rules** — permission engine blocks reads of `.env`, credential files
+2. **Context cleaning** — redact secrets before LLM sees content
+3. **Output filtering** — scan LLM responses for leaked secrets
+4. **Audit log redaction** — secrets never written to audit trail
+
+30+ secret patterns: API keys (Claude, OpenAI, AWS, GitHub, GitLab, Slack, Stripe, HuggingFace, etc.), private keys (RSA, OpenSSH, PKCS8), database connection strings (PostgreSQL, MySQL, MongoDB), Bearer/JWT tokens, environment variable assignments (`password=`, `api_key=`, etc.).
+
+**High-entropy detection**: Shannon entropy ≥ 4.5 bits/char on strings ≥ 20 chars.
+
+```python
+class SecretFinding:
+    secret_type: str   # e.g. "openai_api_key"
+    match: str         # the matched text
+    start: int         # byte offset
+    end: int           # byte offset
+
+detect_secrets(text) -> list[SecretFinding]
+redact_secrets(text) -> str  # replaces with [REDACTED]
+```
+
+---
+
+<!-- PART 3: Tool System -->
+
+## Part 3: Tool System
+
+**Files**: `tools/base.py` (166 lines), `tools/registry.py` (89 lines)
+
+### Tool ABC
+
+Every tool implements this interface:
+
+```python
+class Tool(abc.ABC):
+    @property
+    def name(self) -> str              # Unique identifier
+    @property
+    def description(self) -> str       # For LLM system prompt
+    @property
+    def risk_level(self) -> RiskLevel  # READ_ONLY / LOW / HIGH / DESTRUCTIVE
+
+    def get_schema(self) -> dict       # JSON Schema (OpenAI function-calling format)
+    async def execute(self, arguments: dict, context: ToolContext) -> ToolResult
+```
+
+### Data Models
+
+```python
+class ToolCall(BaseModel):
+    tool_name: str
+    arguments: dict[str, Any] = {}
+    call_id: str = ""
+    def format_for_permission(self) -> str
+        # Returns "ToolName(arg_summary)" for pattern matching
+        # Priority: command > file_path > action > first_string_value
+
+class ToolResult(BaseModel):
+    output: str = ""
+    error: str | None = None
+    is_error: bool = False
+    @classmethod ok(output) -> ToolResult       # Success factory
+    @classmethod failure(error) -> ToolResult   # Error factory
+
+class ToolContext(BaseModel):
+    cwd: Path
+    session_id: str
+    permissions: PermissionEvaluator | None = None
+    audit: AuditRecorder | None = None
+```
+
+### Tool Registry
+
+```mermaid
+flowchart LR
+    A[agent_loop] -->|dispatch| B[ToolRegistry]
+    B -->|get| C[Tool instance]
+    C -->|execute| D[ToolResult]
+    B -->|get_schemas| E[LLM-ready JSON]
+```
+
+```python
+class ToolRegistry:
+    register(tool)              # Add tool, ValueError on duplicate
+    get(name) -> Tool | None
+    has_tool(name) -> bool
+    list_tools() -> list[Tool]
+    get_schemas() -> list[dict]  # [{"type": "function", "function": {...}}]
+    async dispatch(tool_call, context) -> ToolResult
+```
+
+### Built-In Tools (9)
+
+| Tool | Risk Level | Purpose |
+|------|-----------|---------|
+| `file_read` | READ_ONLY | Read file content with line numbers |
+| `file_write` | LOW | Create or overwrite file |
+| `file_edit` | LOW | Search/replace in existing file |
+| `shell` | HIGH | Run bash commands (cwd-sandboxed) |
+| `git` | HIGH | Git operations (status, commit, diff, stash, etc.) |
+| `glob_search` | READ_ONLY | Find files by glob pattern |
+| `grep_search` | READ_ONLY | Search file content with regex |
+| `repo_map` | READ_ONLY | Tree-sitter symbol extraction |
+| `verify` | READ_ONLY | Run linter checks (ruff for Python) |
+
+Plus `spawn_agent` (HIGH) when sub-agents are enabled, and any MCP tools (HIGH) when MCP servers are configured.
+
+---
+
+<!-- PART 4: Intelligence -->
+
+## Part 4: Intelligence
+
+**Files**: `agent/system_prompt.py` (85 lines), `context/compaction.py` (98 lines), `llm/client.py` (382 lines), `context/checkpoint.py` (80 lines), `context/repo_map.py` (238 lines), `tools/verify.py` (87 lines)
+
+### System Prompt Assembly
+
+`build_system_prompt()` constructs the full prompt from 5 layers:
+
+1. **Core prompt** — role, security mindset, tool usage guidelines
+2. **Plan mode prompt** — restricts to read-only tools (if active)
+3. **Working directory** — `cwd` for file path context
+4. **Project instructions** — from `GODSPEED.md` in project root
+5. **Tool descriptions** — name, description, risk_level for each registered tool
+
+### Model-Aware Compaction
+
+Three tiers based on context window size:
+
+| Tier | Context Window | Strategy |
+|------|---------------|----------|
+| Small | ≤ 32K tokens | Aggressive — keep only current task, file paths, last error. Target < 500 words |
+| Medium | 32K – 100K | Balanced — keep architecture decisions, modified paths, unresolved issues, last 3 tool results |
+| Large | > 100K | Detailed — preserve rationale, code patterns, all modified paths, summarized tool results |
+
+**Thresholds**: `SMALL_CONTEXT_THRESHOLD = 32,768`, `LARGE_CONTEXT_THRESHOLD = 100,000`
+
+Compaction triggers when `conversation.is_near_limit` (80% of max tokens). A separate LLM call summarizes history, then `conversation.compact(summary)` replaces old messages.
+
+### LLM Client & Model Routing
+
+```python
+class LLMClient:
+    model: str                          # Primary model
+    fallback_models: list[str]          # Fallback chain
+    router: ModelRouter | None          # Task-type routing
+    total_input_tokens: int             # Running total
+    total_output_tokens: int
+
+    async chat(messages, tools, task_type) -> ChatResponse
+    async stream_chat(messages, tools) -> AsyncGenerator[ChatResponse]
+```
+
+**Backend**: LiteLLM (200+ providers — Claude, GPT, Gemini, Ollama, etc.)
+
+**Model Routing**: `ModelRouter` maps task types (plan, edit, chat) to specific models. Falls back to default model for unmapped types.
+
+**Fallback Chain**: On failure, retries primary after 1s sleep, then tries each fallback model in order. Skips retries entirely if connection error detected (server unreachable).
+
+**Ollama Upgrade**: Models prefixed `ollama/` are upgraded to `ollama_chat/` for tool-capable chat completions.
+
+### Checkpoint Save/Restore
+
+```python
+save_checkpoint(name, system_prompt, messages, model, token_count, project_dir) -> Path
+load_checkpoint(name, project_dir) -> dict | None
+list_checkpoints(project_dir) -> list[dict]  # name, timestamp, model, token_count
+delete_checkpoint(name, project_dir) -> bool
+```
+
+**Storage**: JSON files at `.godspeed/checkpoints/{safe_name}.checkpoint.json`. Filename sanitized for filesystem safety.
+
+### Repo Map (Tree-Sitter)
+
+```python
+class RepoMapper:
+    parse_file(file_path) -> list[Symbol]
+    map_directory(directory, max_depth=5, pattern="") -> str
+```
+
+`Symbol` dataclass: `name`, `kind` (function/class/method/type), `line` (1-based), `children`.
+
+**Languages**: Python, JavaScript/TypeScript, Go via `tree_sitter_language_pack`.
+
+**Graceful degradation**: Returns empty map if tree-sitter not installed. Agent can still use grep/glob.
+
+### Verification Cascade
+
+`VerifyTool` runs `ruff check --select=E,W,F` on Python files. Auto-triggered after `file_edit`/`file_write` on `.py`/`.pyi` files. Results feed back into conversation so the agent self-corrects lint errors in the next iteration.
+
+---
+
+<!-- PART 5: Autonomy -->
+
+## Part 5: Autonomy
+
+**Files**: `agent/coordinator.py` (140 lines), `tools/spawn_agent.py`, `mcp/client.py` (119 lines), `mcp/tool_adapter.py` (85 lines)
+
+### Sub-Agent Architecture
+
+```python
+class AgentCoordinator:
+    max_depth: int = 3          # MAX_SUB_AGENT_DEPTH
+    iteration_limit: int = 25   # SUB_AGENT_ITERATION_LIMIT
+
+    async spawn(task, depth=0) -> str
+    async spawn_parallel(tasks, depth=0) -> list[str]
+```
+
+Each sub-agent gets:
+- **Isolated** `Conversation` (own context window)
+- **Shared** `ToolRegistry` and `ToolContext` (same tools, same permissions)
+- **Reduced** iteration limit (25 vs 50 for main agent)
+
+**Depth enforcement**: `MAX_SUB_AGENT_DEPTH = 3`. Main → Level 1 → Level 2 → Level 3 (stops). Deeper spawn attempts return an error.
+
+### Parallel Spawn
+
+```python
+async spawn_parallel(tasks, depth=0) -> list[str]:
+    return await asyncio.gather(*[spawn(t, depth) for t in tasks])
+```
+
+Results returned in order. No cancellation on individual failure — each sub-agent runs independently.
+
+### SpawnAgentTool
+
+Registered as a standard tool: `name="spawn_agent"`, `risk_level=HIGH`. The agent calls it like any other tool to delegate work. Arguments: `task` (string description), optionally `parallel_tasks` (list of strings).
+
+### MCP Client (Model Context Protocol)
+
+```python
+class MCPServerConfig:
+    name: str
+    command: str                     # e.g. "npx", "python"
+    args: list[str] | None           # e.g. ["-m", "mcp_server"]
+    env: dict[str, str] | None
+    transport: str = "stdio"         # Only stdio supported
+
+class MCPClient:
+    async connect(config) -> list[MCPToolDefinition]
+    async call_tool(server_name, tool_name, arguments) -> str
+    async disconnect_all()
+```
+
+**Transport**: Stdio — spawns subprocess, communicates via stdin/stdout JSON-RPC.
+
+**Graceful degradation**: Returns empty tool list if `mcp` package not installed.
+
+### MCP Tool Adapter
+
+Bridges MCP tools into Godspeed's tool system:
+
+```python
+class MCPToolAdapter(Tool):
+    name = "mcp_{server_name}_{tool_name}"
+    risk_level = RiskLevel.HIGH   # External server code — always HIGH
+    async execute(arguments, context) -> ToolResult
+```
+
+`adapt_mcp_tools(definitions, mcp_client) -> list[MCPToolAdapter]` converts discovered MCP tools into registerable Godspeed tools.
+
+### Human-in-the-Loop
+
+Three TUI commands enable mid-session intervention:
+
+| Command | Effect |
+|---------|--------|
+| `/pause` | Clears `pause_event` — loop waits at next iteration |
+| `/resume` | Sets `pause_event` — loop continues |
+| `/guidance <msg>` | Injects message into conversation, then resumes |
+
+---
+
+<!-- PART 6: Memory & TUI -->
+
+## Part 6: Memory & TUI
+
+**Files**: `memory/user_memory.py` (174 lines), `memory/session.py` (161 lines), `memory/corrections.py` (89 lines), `tui/theme.py` (103 lines), `tui/output.py` (245 lines), `tui/commands.py` (478 lines), `tui/completions.py` (97 lines)
+
+### User Memory (Persistent)
+
+SQLite database at `~/.godspeed/memory.db` with WAL mode for concurrent reads.
+
+**Tables**:
+
+```sql
+CREATE TABLE preferences (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE corrections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    original TEXT NOT NULL,
+    corrected TEXT NOT NULL,
+    context TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL
+);
+```
+
+```python
+class UserMemory:
+    # Preferences (key/value store)
+    get(key, default=None) -> str | None
+    set(key, value) -> None
+    delete(key) -> bool
+    list_preferences() -> list[dict]
+
+    # Corrections (learning from mistakes)
+    record_correction(original, corrected, context="") -> int
+    get_corrections(limit=10) -> list[dict]
+    delete_correction(correction_id) -> bool
+    correction_count() -> int
+```
+
+### Session Memory
+
+Same SQLite database. Two additional tables:
+
+```sql
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    model TEXT NOT NULL,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    project_dir TEXT NOT NULL DEFAULT '',
+    summary TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE session_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT REFERENCES sessions(id),
+    event_type TEXT NOT NULL,
+    detail TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL
+);
+```
+
+Event types: `session_start`, `session_end`, `tool_call`, `tool_error`, `user_correction`, `compaction`.
+
+### Correction Tracking
+
+Heuristic detection of user corrections via 11 negation patterns:
+
+`no`, `don't`, `stop`, `not`, `instead`, `wrong`, `actually`, `please don't/stop/use`, `never`, `always`, `prefer`
+
+`is_likely_correction(message)` returns True if message matches a pattern and is 2–100 words.
+
+`CorrectionTracker`:
+- `check_for_correction(user_message, last_agent_action)` — auto-detect & record, returns correction ID or None
+- `format_for_system_prompt(n=5)` — formats top N corrections for system prompt injection
+
+### Midnight Gold Theme
+
+Single source of truth for all Rich/prompt-toolkit styling:
+
+**Palette**:
+
+| Constant | Value | Use |
+|----------|-------|-----|
+| `PRIMARY` | `gold1` | Brand color |
+| `SECONDARY` | `steel_blue` | Panels, structure |
+| `SUCCESS` | `green3` | Success states |
+| `ERROR` | `indian_red1` | Errors |
+| `WARNING` | `dark_orange` | Caution |
+| `MUTED` | `grey58` | Secondary text |
+| `ACCENT` | `cornflower_blue` | Interactive elements |
+
+**Semantic styles**: `BOLD_PRIMARY`, `BOLD_ERROR`, `BOLD_SUCCESS`, `BOLD_WARNING`, `BORDER_BRAND`, `BORDER_TOOL`, `BORDER_SUCCESS`, `BORDER_ERROR`, `BORDER_WARNING`, `BORDER_INFO`, `TABLE_HEADER`, `TABLE_BORDER`, `TABLE_KEY`, `TABLE_VALUE`, `PERM_ALLOW`, `PERM_DENY`, `PERM_ASK`, `PERM_SESSION`, `CTX_OK`, `CTX_WARN`, `CTX_CRITICAL`, `DIM`, `SYNTAX_THEME` (monokai).
+
+**Brand**: `PROMPT_ICON = "⚡"`, `PROMPT_TEXT = "godspeed"`, `BRAND_TAGLINE = "Security-first coding agent"`.
+
+Helpers: `styled(text, style)` → Rich markup, `brand(version)` → branded string, `icon_prompt(state)` → prompt-toolkit HTML.
+
+### Rich Output
+
+`tui/output.py` provides all rendering functions:
+
+| Function | Purpose |
+|----------|---------|
+| `format_welcome()` | Branded banner with model, tools, deny rules |
+| `format_assistant_text()` | Rich Markdown rendering |
+| `format_tool_call()` | Panel with tool name + JSON args |
+| `format_tool_result()` | Panel with result (truncated >2000 chars) |
+| `format_permission_prompt()` | Contextual preview (diff, code, path) |
+| `format_permission_denied()` | Red denial notice |
+| `format_stats()` | Token usage table |
+| `format_error()` | Bold red error |
+
+### Slash Commands (16)
+
+| Command | Purpose |
+|---------|---------|
+| `/help` | Show all commands |
+| `/model [name]` | Show or switch active model |
+| `/clear` | Wipe conversation history |
+| `/undo` | `git reset --soft HEAD~1` |
+| `/audit` | Show audit stats, verify hash chain |
+| `/permissions` | Table of DENY/ALLOW/ASK/SESSION rules |
+| `/extend [N]` | Set max iterations (default 50) |
+| `/context` | Token usage (count/max, percentage) |
+| `/plan` | Toggle plan mode (read-only) |
+| `/checkpoint [name]` | Save checkpoint or list all |
+| `/restore <name>` | Load checkpoint, restore conversation |
+| `/pause` | Pause agent at next iteration |
+| `/resume` | Resume paused agent |
+| `/guidance <msg>` | Inject guidance, resume agent |
+| `/quit` | Exit with session stats |
+| `/exit` | Alias for `/quit` |
+
+### Tab Completions
+
+`GodspeedCompleter` provides prompt-toolkit completions for:
+- Slash commands (when input starts with `/`)
+- File paths (when in argument position)
+
+### TUI Application
+
+`TUIApp` orchestrates the full interactive loop:
+
+1. Show welcome banner
+2. Create `PromptSession` (prompt-toolkit) with key bindings
+3. Loop: read input → dispatch command or run `agent_loop()`
+4. `_ThinkingSpinner`: Rich Status spinner shown before first LLM output, auto-clears via `wrap()` pattern
+5. `_InteractivePermissionProxy`: wraps `PermissionEngine` to prompt user on ASK decisions
+
+Key bindings: Enter (submit), Escape+Enter (newline), Ctrl+C (abort input).
+
+---
+
+## Audit Trail
+
+**File**: `audit/trail.py`
+
+Hash-chained audit log for tamper detection:
+
+- Every event gets SHA-256 hash of `previous_hash + event_data`
+- Events: `session_start`, `session_end`, `tool_call` (with latency), errors
+- `/audit` command verifies chain integrity
+- Secrets redacted before recording
+
+---
+
+## Configuration
+
+**File**: `config.py`
+
+Pydantic-settings with YAML merge (3 layers):
+
+1. **Global**: `~/.godspeed/settings.yaml`
+2. **Project**: `.godspeed/settings.yaml`
+3. **Environment**: `GODSPEED_*` env vars
+
+```yaml
+model: "ollama_chat/qwen3:8b"
+fallback_models: ["ollama_chat/gemma3:4b"]
+permissions:
+  deny: ["rm -rf *", "sudo *"]
+  allow: ["file_read(*)", "glob_search(*)"]
+  ask: ["shell(*)"]
+mcp_servers:
+  - name: filesystem
+    command: npx
+    args: ["-y", "@anthropic/mcp-server-filesystem"]
+model_routing:
+  plan: "claude-sonnet-4-20250514"
+  edit: "ollama_chat/qwen3:8b"
+  chat: "ollama_chat/gemma3:4b"
+```
+
+---
+
+## CLI Entry Points
+
+**File**: `cli.py`
+
+Click-based CLI with subcommands:
+
+| Command | Purpose |
+|---------|---------|
+| `godspeed` | Launch interactive TUI |
+| `godspeed init` | Create `~/.godspeed/` + default settings |
+| `godspeed version` | Print version |
+| `godspeed models` | List available models (cost/context/free) |
+| `godspeed audit verify` | Verify audit chain integrity |
+
+`_run_app()` wires everything: settings → LLM client → tools → permissions → audit → conversation → TUIApp.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed"
-version = "0.6.0"
+version = "0.9.0"
 description = "Security-first open-source coding agent with 4-tier permissions, hash-chained audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"
@@ -67,6 +67,9 @@ context = [
 ]
 mcp = [
     "mcp>=1.27.0,<2.0",
+]
+index = [
+    "chromadb>=1.0.0,<2.0",
 ]
 
 [project.scripts]

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.6.0"
+__version__ = "0.9.0"

--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -47,6 +47,7 @@ async def agent_loop(
     on_assistant_chunk: OnChunk | None = None,
     max_iterations: int | None = None,
     pause_event: asyncio.Event | None = None,
+    hook_executor: Any | None = None,
 ) -> str:
     """Run the agent loop until the model stops calling tools.
 
@@ -172,10 +173,29 @@ async def agent_loop(
             if on_tool_call:
                 on_tool_call(tool_call.tool_name, tool_call.arguments)
 
+            # Pre-tool hook: can block execution
+            if hook_executor is not None:
+                hook_ok = await asyncio.get_event_loop().run_in_executor(
+                    None, hook_executor.run_pre_tool, tool_call.tool_name
+                )
+                if not hook_ok:
+                    logger.info("Pre-tool hook blocked tool=%s", tool_call.tool_name)
+                    conversation.add_tool_result(
+                        tool_call_id=tool_call.call_id,
+                        content="BLOCKED: Pre-tool hook returned non-zero exit.",
+                    )
+                    continue
+
             # Execute tool with latency tracking
             t0 = time.monotonic()
             result = await tool_registry.dispatch(tool_call, tool_context)
             latency_ms = (time.monotonic() - t0) * 1000
+
+            # Post-tool hook
+            if hook_executor is not None:
+                await asyncio.get_event_loop().run_in_executor(
+                    None, hook_executor.run_post_tool, tool_call.tool_name
+                )
 
             if on_tool_result:
                 on_tool_result(tool_call.tool_name, result)

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -187,6 +187,14 @@ async def _run_app(
     # Tools
     registry, risk_levels = _build_tool_registry()
 
+    # Task tracking
+    from godspeed.tools.tasks import TaskStore, TaskTool
+
+    task_store = TaskStore()
+    task_tool = TaskTool(task_store)
+    registry.register(task_tool)
+    risk_levels[task_tool.name] = task_tool.risk_level
+
     # Permission engine
     permission_engine = PermissionEngine(
         deny_patterns=settings.permissions.deny,
@@ -301,6 +309,20 @@ async def _run_app(
     skills = discover_skills(skill_dirs)
     skill_completions = [(f"/{s.trigger}", s.description) for s in skills]
 
+    # Hook executor
+    hook_executor = None
+    if settings.hooks:
+        from godspeed.hooks.config import HookDefinition
+        from godspeed.hooks.executor import HookExecutor
+
+        hook_defs = [HookDefinition(**h) for h in settings.hooks]
+        hook_executor = HookExecutor(
+            hooks=hook_defs,
+            cwd=effective_project_dir,
+            session_id=session_id,
+        )
+        hook_executor.run_pre_session()
+
     # Launch TUI
     app = TUIApp(
         llm_client=llm_client,
@@ -312,8 +334,14 @@ async def _run_app(
         session_id=session_id,
         skills=skills,
         extra_completions=skill_completions,
+        hook_executor=hook_executor,
+        task_store=task_store,
     )
     await app.run()
+
+    # Post-session hooks
+    if hook_executor is not None:
+        hook_executor.run_post_session()
 
 
 @click.group(invoke_without_command=True)

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -299,6 +299,23 @@ async def _run_app(
     registry.register(spawn_tool)
     risk_levels[spawn_tool.name] = spawn_tool.risk_level
 
+    # Codebase index (optional — requires chromadb)
+    codebase_index = None
+    from godspeed.context.codebase_index import CodebaseIndex
+
+    codebase_index = CodebaseIndex(project_dir=effective_project_dir)
+    if codebase_index.is_available:
+        from godspeed.tools.code_search import CodeSearchTool
+
+        code_search_tool = CodeSearchTool(codebase_index)
+        registry.register(code_search_tool)
+        risk_levels[code_search_tool.name] = code_search_tool.risk_level
+
+        # Auto-reindex in background if stale
+        if codebase_index.needs_reindex():
+            logger.info("Codebase index is stale, rebuilding in background")
+            asyncio.get_event_loop().create_task(codebase_index.build_index_async())
+
     # Discover skills
     from godspeed.skills.loader import discover_skills
 
@@ -336,6 +353,7 @@ async def _run_app(
         extra_completions=skill_completions,
         hook_executor=hook_executor,
         task_store=task_store,
+        codebase_index=codebase_index,
     )
     await app.run()
 

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -291,6 +291,16 @@ async def _run_app(
     registry.register(spawn_tool)
     risk_levels[spawn_tool.name] = spawn_tool.risk_level
 
+    # Discover skills
+    from godspeed.skills.loader import discover_skills
+
+    skill_dirs = [
+        settings.global_dir / "skills",
+        effective_project_dir / ".godspeed" / "skills",
+    ]
+    skills = discover_skills(skill_dirs)
+    skill_completions = [(f"/{s.trigger}", s.description) for s in skills]
+
     # Launch TUI
     app = TUIApp(
         llm_client=llm_client,
@@ -300,6 +310,8 @@ async def _run_app(
         permission_engine=permission_engine,
         audit_trail=audit_trail,
         session_id=session_id,
+        skills=skills,
+        extra_completions=skill_completions,
     )
     await app.run()
 

--- a/src/godspeed/config.py
+++ b/src/godspeed/config.py
@@ -159,6 +159,9 @@ class GodspeedSettings(BaseSettings):
     # MCP servers
     mcp_servers: list[dict[str, Any]] = Field(default_factory=list)
 
+    # Hooks — shell commands at lifecycle events
+    hooks: list[dict[str, Any]] = Field(default_factory=list)
+
     # Memory
     memory_enabled: bool = True
 

--- a/src/godspeed/config.py
+++ b/src/godspeed/config.py
@@ -215,6 +215,47 @@ class GodspeedSettings(BaseSettings):
         return merged
 
 
+def append_allow_rule(pattern: str, project_dir: Path | None = None) -> bool:
+    """Append an allow rule to the project or global settings.yaml.
+
+    Reads existing YAML, adds the pattern to permissions.allow, writes back.
+    Preserves existing content. Returns True on success.
+
+    Args:
+        pattern: Permission pattern to add (e.g. "Shell(git status)").
+        project_dir: Project directory for .godspeed/settings.yaml.
+            Falls back to global settings if None or project config missing.
+    """
+    # Determine which settings file to write to
+    if project_dir is not None:
+        settings_path = project_dir / ".godspeed" / "settings.yaml"
+    else:
+        settings_path = DEFAULT_GLOBAL_DIR / "settings.yaml"
+
+    try:
+        if settings_path.exists():
+            with open(settings_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+        else:
+            settings_path.parent.mkdir(parents=True, exist_ok=True)
+            data = {}
+
+        permissions = data.setdefault("permissions", {})
+        allow_list = permissions.setdefault("allow", [])
+
+        if pattern not in allow_list:
+            allow_list.append(pattern)
+
+        with open(settings_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+
+        logger.info("Appended allow rule '%s' to %s", pattern, settings_path)
+        return True
+    except OSError as exc:
+        logger.warning("Failed to write allow rule: %s", exc)
+        return False
+
+
 def _merge_configs(base: dict[str, Any], override: dict[str, Any]) -> None:
     """Merge override into base. Deny rules are additive (project can't weaken global denies)."""
     for key, value in override.items():

--- a/src/godspeed/context/chunker.py
+++ b/src/godspeed/context/chunker.py
@@ -1,0 +1,168 @@
+"""File chunking for codebase indexing — AST-based for Python, sliding window for others."""
+
+from __future__ import annotations
+
+import ast
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_TOKENS = 512
+OVERLAP_TOKENS = 128
+
+
+@dataclass(frozen=True, slots=True)
+class Chunk:
+    """A chunk of source code from a file."""
+
+    content: str
+    file_path: str
+    start_line: int
+    end_line: int
+
+
+def chunk_file(path: Path, max_tokens: int = DEFAULT_MAX_TOKENS) -> list[Chunk]:
+    """Split a file into chunks for indexing.
+
+    Python files are split by top-level functions/classes via AST.
+    Other files use a sliding window approach.
+
+    Args:
+        path: Path to the file.
+        max_tokens: Approximate max tokens per chunk (word-based estimate).
+
+    Returns:
+        List of Chunk objects.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("Cannot read file %s: %s", path, exc)
+        return []
+
+    if not text.strip():
+        return []
+
+    file_str = str(path)
+
+    if path.suffix in (".py", ".pyi"):
+        chunks = _chunk_python(text, file_str, max_tokens)
+        if chunks:
+            return chunks
+
+    return _chunk_sliding_window(text, file_str, max_tokens)
+
+
+def _chunk_python(text: str, file_path: str, max_tokens: int) -> list[Chunk]:
+    """Split Python files by top-level definitions (functions, classes)."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+
+    lines = text.splitlines(keepends=True)
+    chunks: list[Chunk] = []
+
+    # Collect top-level node ranges
+    nodes: list[tuple[int, int]] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            start = node.lineno - 1  # 0-based
+            end = node.end_lineno or node.lineno
+            nodes.append((start, end))
+
+    if not nodes:
+        # No top-level definitions — treat as single chunk
+        return _chunk_sliding_window(text, file_path, max_tokens)
+
+    # Add module-level code before first definition
+    if nodes[0][0] > 0:
+        header = "".join(lines[: nodes[0][0]])
+        if header.strip():
+            chunks.append(
+                Chunk(
+                    content=header,
+                    file_path=file_path,
+                    start_line=1,
+                    end_line=nodes[0][0],
+                )
+            )
+
+    # Each top-level definition
+    for start, end in nodes:
+        content = "".join(lines[start:end])
+        if content.strip():
+            # If chunk is too large, split with sliding window
+            word_count = len(content.split())
+            if word_count > max_tokens:
+                sub_chunks = _chunk_sliding_window(
+                    content, file_path, max_tokens, line_offset=start
+                )
+                chunks.extend(sub_chunks)
+            else:
+                chunks.append(
+                    Chunk(
+                        content=content,
+                        file_path=file_path,
+                        start_line=start + 1,
+                        end_line=end,
+                    )
+                )
+
+    return chunks
+
+
+def _chunk_sliding_window(
+    text: str,
+    file_path: str,
+    max_tokens: int,
+    line_offset: int = 0,
+) -> list[Chunk]:
+    """Split text into overlapping chunks by line count.
+
+    Uses word count as a token estimate. Overlap ensures context
+    is preserved across chunk boundaries.
+    """
+    lines = text.splitlines(keepends=True)
+    if not lines:
+        return []
+
+    chunks: list[Chunk] = []
+    i = 0
+
+    while i < len(lines):
+        # Accumulate lines until we hit max_tokens
+        chunk_lines: list[str] = []
+        word_count = 0
+        start_idx = i
+
+        while i < len(lines) and word_count < max_tokens:
+            chunk_lines.append(lines[i])
+            word_count += len(lines[i].split())
+            i += 1
+
+        content = "".join(chunk_lines)
+        if content.strip():
+            chunks.append(
+                Chunk(
+                    content=content,
+                    file_path=file_path,
+                    start_line=start_idx + line_offset + 1,
+                    end_line=i + line_offset,
+                )
+            )
+
+        # Overlap: back up by OVERLAP_TOKENS worth of lines
+        if i < len(lines):
+            overlap_words = 0
+            backup = 0
+            for j in range(len(chunk_lines) - 1, -1, -1):
+                overlap_words += len(chunk_lines[j].split())
+                backup += 1
+                if overlap_words >= OVERLAP_TOKENS:
+                    break
+            i = max(start_idx + 1, i - backup)
+
+    return chunks

--- a/src/godspeed/context/codebase_index.py
+++ b/src/godspeed/context/codebase_index.py
@@ -1,0 +1,297 @@
+"""Persistent codebase index using ChromaDB for semantic code search."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from godspeed.context.chunker import chunk_file
+
+logger = logging.getLogger(__name__)
+
+# Default exclusions for indexing
+DEFAULT_EXCLUDES = [
+    "node_modules",
+    ".venv",
+    "__pycache__",
+    ".git",
+    ".godspeed",
+    "*.pyc",
+    "*.pyo",
+    ".egg-info",
+    "dist",
+    "build",
+]
+
+# File extensions to index
+INDEXABLE_EXTENSIONS = {
+    ".py",
+    ".pyi",
+    ".js",
+    ".ts",
+    ".jsx",
+    ".tsx",
+    ".go",
+    ".rs",
+    ".java",
+    ".c",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".rb",
+    ".php",
+    ".swift",
+    ".kt",
+    ".scala",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".json",
+    ".md",
+    ".txt",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".sql",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class SearchResult:
+    """A search result from the codebase index."""
+
+    file_path: str
+    start_line: int
+    end_line: int
+    content: str
+    score: float
+
+
+def _is_chromadb_available() -> bool:
+    """Check if chromadb is installed."""
+    try:
+        import chromadb  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+class CodebaseIndex:
+    """Persistent codebase index backed by ChromaDB.
+
+    Provides semantic search over source code. Gracefully degrades
+    if chromadb is not installed.
+
+    Args:
+        project_dir: Root directory of the project.
+        db_path: Path for ChromaDB persistent storage.
+            Defaults to ``project_dir/.godspeed/index/chroma``.
+    """
+
+    def __init__(
+        self,
+        project_dir: Path,
+        db_path: Path | None = None,
+    ) -> None:
+        self._project_dir = project_dir
+        self._db_path = db_path or (project_dir / ".godspeed" / "index" / "chroma")
+        self._collection: Any | None = None
+        self._client: Any | None = None
+        self._building = False
+        self._index_time: float | None = None
+
+    @property
+    def is_available(self) -> bool:
+        """Whether chromadb is installed and usable."""
+        return _is_chromadb_available()
+
+    @property
+    def is_building(self) -> bool:
+        """Whether the index is currently being built."""
+        return self._building
+
+    def _ensure_collection(self) -> Any:
+        """Get or create the ChromaDB collection."""
+        if self._collection is not None:
+            return self._collection
+
+        import chromadb
+
+        self._db_path.mkdir(parents=True, exist_ok=True)
+        self._client = chromadb.PersistentClient(path=str(self._db_path))
+        self._collection = self._client.get_or_create_collection(
+            name="codebase",
+            metadata={"hnsw:space": "cosine"},
+        )
+        return self._collection
+
+    def build_index(self, exclude: list[str] | None = None) -> int:
+        """Build the index by scanning and chunking all source files.
+
+        Args:
+            exclude: Additional directory/file patterns to exclude.
+
+        Returns:
+            Number of chunks indexed.
+        """
+        if not self.is_available:
+            logger.warning("ChromaDB not available. Install with: pip install godspeed[index]")
+            return 0
+
+        self._building = True
+        excludes = set(DEFAULT_EXCLUDES + (exclude or []))
+
+        try:
+            collection = self._ensure_collection()
+
+            # Clear existing data
+            existing = collection.count()
+            if existing > 0:
+                collection.delete(where={"indexed": True})
+
+            # Scan files
+            all_chunks = []
+            for path in self._iter_files(excludes):
+                chunks = chunk_file(path)
+                all_chunks.extend(chunks)
+
+            if not all_chunks:
+                logger.info("No files to index in %s", self._project_dir)
+                return 0
+
+            # Batch add to ChromaDB
+            batch_size = 100
+            total = 0
+            for i in range(0, len(all_chunks), batch_size):
+                batch = all_chunks[i : i + batch_size]
+                collection.add(
+                    ids=[f"chunk_{i + j}" for j in range(len(batch))],
+                    documents=[c.content for c in batch],
+                    metadatas=[
+                        {
+                            "file_path": c.file_path,
+                            "start_line": c.start_line,
+                            "end_line": c.end_line,
+                            "indexed": True,
+                        }
+                        for c in batch
+                    ],
+                )
+                total += len(batch)
+
+            self._index_time = time.time()
+            logger.info(
+                "Indexed %d chunks from %s",
+                total,
+                self._project_dir,
+            )
+            return total
+
+        finally:
+            self._building = False
+
+    async def build_index_async(self, exclude: list[str] | None = None) -> int:
+        """Build index in a background thread."""
+        return await asyncio.get_event_loop().run_in_executor(None, self.build_index, exclude)
+
+    def search(self, query: str, top_k: int = 5) -> list[SearchResult]:
+        """Search the codebase index.
+
+        Args:
+            query: Natural language search query.
+            top_k: Maximum number of results.
+
+        Returns:
+            Ranked list of SearchResult objects.
+        """
+        if not self.is_available:
+            return []
+
+        if self._building:
+            return []
+
+        try:
+            collection = self._ensure_collection()
+            if collection.count() == 0:
+                return []
+
+            results = collection.query(
+                query_texts=[query],
+                n_results=min(top_k, collection.count()),
+            )
+
+            search_results = []
+            if results and results["documents"] and results["documents"][0]:
+                docs = results["documents"][0]
+                metas = results["metadatas"][0] if results["metadatas"] else [{}] * len(docs)
+                dists = results["distances"][0] if results["distances"] else [0.0] * len(docs)
+
+                for doc, meta, dist in zip(docs, metas, dists, strict=False):
+                    score = max(0.0, 1.0 - dist)
+                    search_results.append(
+                        SearchResult(
+                            file_path=meta.get("file_path", ""),
+                            start_line=meta.get("start_line", 0),
+                            end_line=meta.get("end_line", 0),
+                            content=doc,
+                            score=round(score, 3),
+                        )
+                    )
+
+            return search_results
+
+        except Exception as exc:
+            logger.warning("Search failed: %s", exc)
+            return []
+
+    def needs_reindex(self) -> bool:
+        """Check if the index is stale (newer files exist than index time)."""
+        if self._index_time is None:
+            # Check if DB exists with data
+            if not self._db_path.exists():
+                return True
+            if self.is_available:
+                try:
+                    collection = self._ensure_collection()
+                    return collection.count() == 0
+                except Exception:
+                    return True
+            return True
+
+        # Check if any source file is newer than index
+        for path in self._iter_files(set(DEFAULT_EXCLUDES)):
+            try:
+                if path.stat().st_mtime > self._index_time:
+                    return True
+            except OSError:
+                continue
+
+        return False
+
+    def _iter_files(self, excludes: set[str]) -> list[Path]:
+        """Iterate indexable files, respecting exclusions."""
+        files = []
+        for path in self._project_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix not in INDEXABLE_EXTENSIONS:
+                continue
+
+            # Check exclusions
+            parts = path.relative_to(self._project_dir).parts
+            skip = False
+            for part in parts:
+                if part in excludes:
+                    skip = True
+                    break
+            if skip:
+                continue
+
+            files.append(path)
+
+        return sorted(files)

--- a/src/godspeed/hooks/__init__.py
+++ b/src/godspeed/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Hook system — run shell commands at agent lifecycle events."""

--- a/src/godspeed/hooks/config.py
+++ b/src/godspeed/hooks/config.py
@@ -1,0 +1,37 @@
+"""Hook configuration models."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class HookDefinition(BaseModel):
+    """A single hook that runs a shell command at a lifecycle event.
+
+    Events:
+        pre_tool_call: Before a tool executes. Non-zero exit blocks the call.
+        post_tool_call: After a tool executes.
+        pre_session: When a session starts.
+        post_session: When a session ends.
+
+    Template variables in ``command``:
+        {tool_name}: Name of the tool being called (tool events only).
+        {session_id}: Current session ID.
+        {cwd}: Working directory.
+        {project_dir}: Project directory (same as cwd).
+    """
+
+    event: Literal["pre_tool_call", "post_tool_call", "pre_session", "post_session"]
+    command: str
+    tools: list[str] | None = Field(
+        default=None,
+        description="Tool names to match. None = all tools.",
+    )
+    timeout: int = Field(
+        default=30,
+        ge=1,
+        le=300,
+        description="Max seconds for hook execution.",
+    )

--- a/src/godspeed/hooks/executor.py
+++ b/src/godspeed/hooks/executor.py
@@ -1,0 +1,139 @@
+"""Hook executor — runs shell commands at agent lifecycle events."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from godspeed.hooks.config import HookDefinition
+
+logger = logging.getLogger(__name__)
+
+
+class HookExecutor:
+    """Execute hooks at agent lifecycle events.
+
+    Pre-tool hooks can block tool execution by returning a non-zero exit code.
+    All hooks run synchronously in a subprocess with a timeout.
+
+    Args:
+        hooks: List of hook definitions to execute.
+        cwd: Working directory for subprocess execution.
+        session_id: Current session ID for template expansion.
+    """
+
+    def __init__(
+        self,
+        hooks: list[HookDefinition],
+        cwd: Path,
+        session_id: str,
+    ) -> None:
+        self._hooks = hooks
+        self._cwd = cwd
+        self._session_id = session_id
+
+    def run_pre_tool(self, tool_name: str) -> bool:
+        """Run pre_tool_call hooks. Returns True to proceed, False to abort."""
+        for hook in self._hooks:
+            if hook.event != "pre_tool_call":
+                continue
+            if not self._matches_tool(hook, tool_name):
+                continue
+
+            exit_code = self._execute(hook, {"tool_name": tool_name})
+            if exit_code != 0:
+                logger.warning(
+                    "Pre-tool hook blocked tool=%s command=%s exit=%d",
+                    tool_name,
+                    hook.command,
+                    exit_code,
+                )
+                return False
+        return True
+
+    def run_post_tool(self, tool_name: str, result: str = "") -> None:
+        """Run post_tool_call hooks."""
+        for hook in self._hooks:
+            if hook.event != "post_tool_call":
+                continue
+            if not self._matches_tool(hook, tool_name):
+                continue
+
+            self._execute(hook, {"tool_name": tool_name})
+
+    def run_pre_session(self) -> None:
+        """Run pre_session hooks."""
+        for hook in self._hooks:
+            if hook.event == "pre_session":
+                self._execute(hook, {})
+
+    def run_post_session(self) -> None:
+        """Run post_session hooks."""
+        for hook in self._hooks:
+            if hook.event == "post_session":
+                self._execute(hook, {})
+
+    def _matches_tool(self, hook: HookDefinition, tool_name: str) -> bool:
+        """Check if a hook applies to the given tool."""
+        return hook.tools is None or tool_name in hook.tools
+
+    def _execute(self, hook: HookDefinition, context: dict[str, str]) -> int:
+        """Execute a hook command with template variable expansion.
+
+        Returns the exit code (0 = success).
+        """
+        template_vars = {
+            "session_id": self._session_id,
+            "cwd": str(self._cwd),
+            "project_dir": str(self._cwd),
+            **context,
+        }
+
+        try:
+            command = hook.command.format(**template_vars)
+        except KeyError as exc:
+            logger.warning(
+                "Hook template error command=%s missing_var=%s",
+                hook.command,
+                exc,
+            )
+            return 1
+
+        logger.debug(
+            "Executing hook event=%s command=%s timeout=%d",
+            hook.event,
+            command,
+            hook.timeout,
+        )
+
+        try:
+            result = subprocess.run(  # noqa: S602
+                command,
+                shell=True,
+                cwd=self._cwd,
+                timeout=hook.timeout,
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout:
+                logger.debug("Hook stdout: %s", result.stdout.strip())
+            if result.stderr:
+                logger.debug("Hook stderr: %s", result.stderr.strip())
+            return result.returncode
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Hook timed out event=%s command=%s timeout=%ds",
+                hook.event,
+                command,
+                hook.timeout,
+            )
+            return 1
+        except OSError as exc:
+            logger.warning(
+                "Hook execution failed event=%s command=%s error=%s",
+                hook.event,
+                command,
+                exc,
+            )
+            return 1

--- a/src/godspeed/hooks/executor.py
+++ b/src/godspeed/hooks/executor.py
@@ -108,7 +108,7 @@ class HookExecutor:
         )
 
         try:
-            result = subprocess.run(  # noqa: S602
+            result = subprocess.run(  # noqa: S602  # nosec B602
                 command,
                 shell=True,
                 cwd=self._cwd,

--- a/src/godspeed/security/approval_tracker.py
+++ b/src/godspeed/security/approval_tracker.py
@@ -1,0 +1,63 @@
+"""Track repeated user approvals to suggest auto-permission rules."""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+class ApprovalTracker:
+    """Session-scoped tracker for repeated permission approvals.
+
+    When a user approves the same tool pattern multiple times, this tracker
+    can suggest adding it as a permanent allow rule.
+
+    Thread-safe — all mutations are guarded by a lock.
+    """
+
+    def __init__(self, threshold: int = 3) -> None:
+        self._threshold = threshold
+        self._counts: dict[str, int] = {}
+        self._suggested: set[str] = set()
+        self._lock = threading.Lock()
+
+    def record_approval(self, pattern: str) -> None:
+        """Record a user approval for a tool pattern."""
+        with self._lock:
+            self._counts[pattern] = self._counts.get(pattern, 0) + 1
+            logger.debug(
+                "Approval recorded pattern=%s count=%d",
+                pattern,
+                self._counts[pattern],
+            )
+
+    def should_suggest(self, pattern: str, threshold: int | None = None) -> bool:
+        """Check if we should suggest adding this pattern as a permanent rule.
+
+        Returns True exactly once per pattern when the threshold is reached.
+        """
+        effective_threshold = threshold if threshold is not None else self._threshold
+        with self._lock:
+            count = self._counts.get(pattern, 0)
+            if count >= effective_threshold and pattern not in self._suggested:
+                self._suggested.add(pattern)
+                logger.info(
+                    "Suggesting auto-permission for pattern=%s after %d approvals",
+                    pattern,
+                    count,
+                )
+                return True
+            return False
+
+    def get_count(self, pattern: str) -> int:
+        """Get the current approval count for a pattern."""
+        with self._lock:
+            return self._counts.get(pattern, 0)
+
+    def reset(self) -> None:
+        """Clear all tracked approvals and suggestions."""
+        with self._lock:
+            self._counts.clear()
+            self._suggested.clear()

--- a/src/godspeed/skills/__init__.py
+++ b/src/godspeed/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Skill framework — markdown prompt files that extend Godspeed's capabilities."""

--- a/src/godspeed/skills/commands.py
+++ b/src/godspeed/skills/commands.py
@@ -1,0 +1,76 @@
+"""Wire skill definitions into the TUI command system."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from godspeed.skills.loader import SkillDefinition
+from godspeed.tui.output import console
+from godspeed.tui.theme import BOLD_PRIMARY, DIM, MUTED, TABLE_BORDER
+
+logger = logging.getLogger(__name__)
+
+
+def register_skill_commands(
+    commands: Any,
+    conversation: Any,
+    skills: list[SkillDefinition],
+) -> None:
+    """Register slash commands for each discovered skill.
+
+    For each skill, registers ``/{trigger}`` that injects the skill content
+    as a user message and returns ``CommandResult(handled=False)`` so the
+    injected content flows through to ``agent_loop()``.
+
+    Also registers ``/skills`` to list available skills.
+
+    Args:
+        commands: Commands instance (duck-typed to avoid circular import).
+        conversation: Conversation instance for message injection.
+        skills: List of discovered skill definitions.
+    """
+    from godspeed.tui.commands import CommandResult
+
+    for skill in skills:
+
+        def _make_handler(s: SkillDefinition) -> Any:
+            def _handler(_args: str = "") -> CommandResult:
+                # Inject skill content as user message
+                content = f"[Skill: {s.name}]\n{s.content}"
+                conversation.add_user_message(content)
+                logger.info("Skill activated name=%s trigger=%s", s.name, s.trigger)
+                console.print(
+                    f"  [{DIM}]Activated skill:[/{DIM}] [{BOLD_PRIMARY}]{s.name}[/{BOLD_PRIMARY}]"
+                )
+                # handled=False so the TUI runs agent_loop with the injected message
+                return CommandResult(handled=False)
+
+            return _handler
+
+        commands.register(f"/{skill.trigger}", _make_handler(skill))
+        logger.debug("Registered skill command /%s → %s", skill.trigger, skill.name)
+
+    # Register /skills listing command
+    def _cmd_skills(_args: str = "") -> CommandResult:
+        if not skills:
+            console.print(f"  [{MUTED}]No skills installed.[/{MUTED}]")
+            console.print(
+                f"  [{DIM}]Add .md files to ~/.godspeed/skills/ or .godspeed/skills/[/{DIM}]"
+            )
+            return CommandResult()
+
+        from rich.table import Table
+
+        table = Table(title="Skills", border_style=TABLE_BORDER, expand=False)
+        table.add_column("Trigger", style=BOLD_PRIMARY)
+        table.add_column("Name")
+        table.add_column("Description", style=MUTED)
+
+        for s in sorted(skills, key=lambda x: x.trigger):
+            table.add_row(f"/{s.trigger}", s.name, s.description)
+
+        console.print(table)
+        return CommandResult()
+
+    commands.register("/skills", _cmd_skills)

--- a/src/godspeed/skills/loader.py
+++ b/src/godspeed/skills/loader.py
@@ -1,0 +1,120 @@
+"""Skill discovery and loading from markdown files with YAML frontmatter."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class SkillDefinition:
+    """A skill loaded from a markdown file."""
+
+    name: str
+    description: str
+    trigger: str
+    content: str
+
+
+def _parse_skill_file(path: Path) -> SkillDefinition | None:
+    """Parse a single .md skill file with YAML frontmatter.
+
+    Expected format:
+        ---
+        name: code-review
+        description: Review code for best practices
+        trigger: review
+        ---
+        Review the following code for...
+
+    Returns None if the file is malformed or missing required fields.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Cannot read skill file %s: %s", path, exc)
+        return None
+
+    # Parse YAML frontmatter between --- markers
+    stripped = text.strip()
+    if not stripped.startswith("---"):
+        logger.warning("Skill file %s missing YAML frontmatter (no leading ---)", path)
+        return None
+
+    # Find the closing --- marker
+    second_marker = stripped.find("---", 3)
+    if second_marker == -1:
+        logger.warning("Skill file %s missing closing --- marker", path)
+        return None
+
+    frontmatter_str = stripped[3:second_marker].strip()
+    body = stripped[second_marker + 3 :].strip()
+
+    try:
+        frontmatter = yaml.safe_load(frontmatter_str)
+    except yaml.YAMLError as exc:
+        logger.warning("Invalid YAML frontmatter in %s: %s", path, exc)
+        return None
+
+    if not isinstance(frontmatter, dict):
+        logger.warning("Skill file %s frontmatter is not a mapping", path)
+        return None
+
+    # Validate required fields
+    name = frontmatter.get("name")
+    description = frontmatter.get("description")
+    trigger = frontmatter.get("trigger")
+
+    if not all([name, description, trigger]):
+        missing = [f for f in ("name", "description", "trigger") if not frontmatter.get(f)]
+        logger.warning("Skill file %s missing required fields: %s", path, ", ".join(missing))
+        return None
+
+    if not body:
+        logger.warning("Skill file %s has empty content body", path)
+        return None
+
+    return SkillDefinition(
+        name=str(name),
+        description=str(description),
+        trigger=str(trigger),
+        content=body,
+    )
+
+
+def discover_skills(dirs: list[Path]) -> list[SkillDefinition]:
+    """Discover skills from directories, later dirs override earlier on same trigger.
+
+    Scan order: global (~/.godspeed/skills/) then project (.godspeed/skills/).
+    Project skills override global skills with the same trigger name.
+
+    Args:
+        dirs: Directories to scan for .md skill files.
+
+    Returns:
+        List of SkillDefinition objects, deduplicated by trigger.
+    """
+    skills_by_trigger: dict[str, SkillDefinition] = {}
+
+    for directory in dirs:
+        if not directory.is_dir():
+            continue
+
+        for md_file in sorted(directory.glob("*.md")):
+            skill = _parse_skill_file(md_file)
+            if skill is not None:
+                if skill.trigger in skills_by_trigger:
+                    logger.info(
+                        "Skill trigger '%s' overridden by %s",
+                        skill.trigger,
+                        md_file,
+                    )
+                skills_by_trigger[skill.trigger] = skill
+
+    logger.info("Discovered %d skills from %d directories", len(skills_by_trigger), len(dirs))
+    return list(skills_by_trigger.values())

--- a/src/godspeed/tools/code_search.py
+++ b/src/godspeed/tools/code_search.py
@@ -1,0 +1,91 @@
+"""Semantic code search tool backed by the codebase index."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+
+class CodeSearchTool(Tool):
+    """Semantic code search using the codebase vector index.
+
+    Falls back gracefully if the index is unavailable or building.
+    """
+
+    def __init__(self, index: Any) -> None:
+        self._index = index
+
+    @property
+    def name(self) -> str:
+        return "code_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search the codebase using natural language queries. "
+            "Returns relevant code snippets ranked by semantic similarity."
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural language search query.",
+                    },
+                    "top_k": {
+                        "type": "integer",
+                        "description": "Max results to return (default: 5).",
+                        "default": 5,
+                    },
+                },
+                "required": ["query"],
+            },
+        }
+
+    async def execute(
+        self,
+        arguments: dict[str, Any],
+        context: ToolContext,
+    ) -> ToolResult:
+        """Execute semantic code search."""
+        query = arguments.get("query", "")
+        if not query:
+            return ToolResult.failure("query is required")
+
+        top_k = arguments.get("top_k", 5)
+
+        if not self._index.is_available:
+            return ToolResult.failure(
+                "Codebase index not available. Install with: pip install godspeed[index]"
+            )
+
+        if self._index.is_building:
+            return ToolResult.ok("Index is being built. Use grep_search for now.")
+
+        results = self._index.search(query, top_k=top_k)
+        if not results:
+            return ToolResult.ok("No results found.")
+
+        lines = []
+        for r in results:
+            lines.append(f"## {r.file_path} (lines {r.start_line}-{r.end_line}, score: {r.score})")
+            # Truncate content to 10 lines
+            content_lines = r.content.splitlines()
+            if len(content_lines) > 10:
+                lines.extend(content_lines[:10])
+                lines.append(f"  ... ({len(content_lines) - 10} more lines)")
+            else:
+                lines.extend(content_lines)
+            lines.append("")
+
+        return ToolResult.ok("\n".join(lines))

--- a/src/godspeed/tools/tasks.py
+++ b/src/godspeed/tools/tasks.py
@@ -163,19 +163,19 @@ class TaskTool(Tool):
             status = arguments.get("status")
             if task_id is None or status is None:
                 return ToolResult.failure("task_id and status are required for update action")
-            task = self._store.update(int(task_id), status)
-            if task is None:
+            updated = self._store.update(int(task_id), status)
+            if updated is None:
                 return ToolResult.failure(f"Task {task_id} not found")
-            return ToolResult.ok(f"Updated task [{task.id}]: {task.title} → {task.status}")
+            return ToolResult.ok(f"Updated task [{updated.id}]: {updated.title} → {updated.status}")
 
         if action == "complete":
             task_id = arguments.get("task_id")
             if task_id is None:
                 return ToolResult.failure("task_id is required for complete action")
-            task = self._store.complete(int(task_id))
-            if task is None:
+            completed = self._store.complete(int(task_id))
+            if completed is None:
                 return ToolResult.failure(f"Task {task_id} not found")
-            return ToolResult.ok(f"Completed task [{task.id}]: {task.title}")
+            return ToolResult.ok(f"Completed task [{completed.id}]: {completed.title}")
 
         return ToolResult.failure(
             f"Unknown action: {action}. Use create, update, list, or complete."

--- a/src/godspeed/tools/tasks.py
+++ b/src/godspeed/tools/tasks.py
@@ -1,0 +1,182 @@
+"""Task tracking tool — in-memory task management for agent self-organization."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+
+@dataclass
+class Task:
+    """A tracked task."""
+
+    id: int
+    title: str
+    description: str = ""
+    status: str = "pending"
+    created_at: float = field(default_factory=time.time)
+
+
+class TaskStore:
+    """In-memory task store with sequential IDs."""
+
+    def __init__(self) -> None:
+        self._tasks: dict[int, Task] = {}
+        self._next_id = 1
+
+    def create(self, title: str, description: str = "") -> Task:
+        """Create a new task."""
+        task = Task(id=self._next_id, title=title, description=description)
+        self._tasks[self._next_id] = task
+        self._next_id += 1
+        return task
+
+    def get(self, task_id: int) -> Task | None:
+        """Get a task by ID."""
+        return self._tasks.get(task_id)
+
+    def update(self, task_id: int, status: str) -> Task | None:
+        """Update a task's status. Returns None if not found."""
+        task = self._tasks.get(task_id)
+        if task is not None:
+            task.status = status
+        return task
+
+    def complete(self, task_id: int) -> Task | None:
+        """Mark a task as completed."""
+        return self.update(task_id, "completed")
+
+    def list_active(self) -> list[Task]:
+        """List tasks that are not completed."""
+        return [t for t in self._tasks.values() if t.status != "completed"]
+
+    def list_all(self) -> list[Task]:
+        """List all tasks."""
+        return list(self._tasks.values())
+
+    def format_active(self) -> str | None:
+        """Format active tasks for system prompt injection.
+
+        Returns None if no active tasks.
+        """
+        active = self.list_active()
+        if not active:
+            return None
+
+        lines = []
+        for t in active:
+            status_icon = "🔄" if t.status == "in_progress" else "⏳"
+            lines.append(f"  {status_icon} [{t.id}] {t.title} ({t.status})")
+            if t.description:
+                lines.append(f"      {t.description}")
+
+        return "\n".join(lines)
+
+
+class TaskTool(Tool):
+    """Tool for creating and managing tasks during an agent session."""
+
+    def __init__(self, store: TaskStore) -> None:
+        self._store = store
+
+    @property
+    def name(self) -> str:
+        return "tasks"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Create, update, list, and complete tasks to track work progress. "
+            "Use this to break complex work into trackable steps."
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.LOW
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["create", "update", "list", "complete"],
+                        "description": "Action to perform.",
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Task title (for create).",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Task description (for create).",
+                    },
+                    "task_id": {
+                        "type": "integer",
+                        "description": "Task ID (for update/complete).",
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["pending", "in_progress", "completed"],
+                        "description": "New status (for update).",
+                    },
+                },
+                "required": ["action"],
+            },
+        }
+
+    async def execute(
+        self,
+        arguments: dict[str, Any],
+        context: ToolContext,
+    ) -> ToolResult:
+        """Execute a task action."""
+        action = arguments.get("action", "")
+
+        if action == "create":
+            title = arguments.get("title", "")
+            if not title:
+                return ToolResult.failure("title is required for create action")
+            desc = arguments.get("description", "")
+            task = self._store.create(title, desc)
+            return ToolResult.ok(f"Created task [{task.id}]: {task.title}")
+
+        if action == "list":
+            tasks = self._store.list_all()
+            if not tasks:
+                return ToolResult.ok("No tasks.")
+            lines = []
+            for t in tasks:
+                lines.append(f"[{t.id}] {t.title} — {t.status}")
+                if t.description:
+                    lines.append(f"    {t.description}")
+            return ToolResult.ok("\n".join(lines))
+
+        if action == "update":
+            task_id = arguments.get("task_id")
+            status = arguments.get("status")
+            if task_id is None or status is None:
+                return ToolResult.failure("task_id and status are required for update action")
+            task = self._store.update(int(task_id), status)
+            if task is None:
+                return ToolResult.failure(f"Task {task_id} not found")
+            return ToolResult.ok(f"Updated task [{task.id}]: {task.title} → {task.status}")
+
+        if action == "complete":
+            task_id = arguments.get("task_id")
+            if task_id is None:
+                return ToolResult.failure("task_id is required for complete action")
+            task = self._store.complete(int(task_id))
+            if task is None:
+                return ToolResult.failure(f"Task {task_id} not found")
+            return ToolResult.ok(f"Completed task [{task.id}]: {task.title}")
+
+        return ToolResult.failure(
+            f"Unknown action: {action}. Use create, update, list, or complete."
+        )

--- a/src/godspeed/tui/app.py
+++ b/src/godspeed/tui/app.py
@@ -76,6 +76,7 @@ class TUIApp:
         extra_completions: list[tuple[str, str]] | None = None,
         hook_executor: Any | None = None,
         task_store: Any | None = None,
+        codebase_index: Any | None = None,
     ) -> None:
         self._llm_client = llm_client
         self._tool_registry = tool_registry
@@ -99,9 +100,11 @@ class TUIApp:
             pause_event=self._pause_event,
         )
 
-        # Wire task store for /tasks command
+        # Wire task store and codebase index for commands
         if task_store is not None:
             self._commands._task_store = task_store
+        if codebase_index is not None:
+            self._commands._codebase_index = codebase_index
 
         # Register skill commands
         if skills:

--- a/src/godspeed/tui/app.py
+++ b/src/godspeed/tui/app.py
@@ -74,6 +74,8 @@ class TUIApp:
         session_id: str,
         skills: list[Any] | None = None,
         extra_completions: list[tuple[str, str]] | None = None,
+        hook_executor: Any | None = None,
+        task_store: Any | None = None,
     ) -> None:
         self._llm_client = llm_client
         self._tool_registry = tool_registry
@@ -97,6 +99,10 @@ class TUIApp:
             pause_event=self._pause_event,
         )
 
+        # Wire task store for /tasks command
+        if task_store is not None:
+            self._commands._task_store = task_store
+
         # Register skill commands
         if skills:
             from godspeed.skills.commands import register_skill_commands
@@ -108,6 +114,7 @@ class TUIApp:
             extra_commands=extra_completions,
         )
         self._key_bindings = _build_key_bindings()
+        self._hook_executor = hook_executor
 
         # Patch the permission check to handle ASK interactively
         self._original_permissions = tool_context.permissions
@@ -194,6 +201,7 @@ class TUIApp:
                     on_assistant_chunk=spinner.wrap(_on_assistant_chunk),
                     max_iterations=self._commands.max_iterations,
                     pause_event=self._pause_event,
+                    hook_executor=self._hook_executor,
                 )
                 console.print()  # End streaming output with newline
             except KeyboardInterrupt:

--- a/src/godspeed/tui/app.py
+++ b/src/godspeed/tui/app.py
@@ -72,6 +72,8 @@ class TUIApp:
         permission_engine: PermissionEngine | None,
         audit_trail: AuditTrail | None,
         session_id: str,
+        skills: list[Any] | None = None,
+        extra_completions: list[tuple[str, str]] | None = None,
     ) -> None:
         self._llm_client = llm_client
         self._tool_registry = tool_registry
@@ -95,13 +97,28 @@ class TUIApp:
             pause_event=self._pause_event,
         )
 
-        self._completer = GodspeedCompleter(cwd=tool_context.cwd)
+        # Register skill commands
+        if skills:
+            from godspeed.skills.commands import register_skill_commands
+
+            register_skill_commands(self._commands, conversation, skills)
+
+        self._completer = GodspeedCompleter(
+            cwd=tool_context.cwd,
+            extra_commands=extra_completions,
+        )
         self._key_bindings = _build_key_bindings()
 
         # Patch the permission check to handle ASK interactively
         self._original_permissions = tool_context.permissions
         if permission_engine is not None:
-            tool_context.permissions = _InteractivePermissionProxy(permission_engine)
+            from godspeed.security.approval_tracker import ApprovalTracker
+
+            self._approval_tracker = ApprovalTracker()
+            tool_context.permissions = _InteractivePermissionProxy(
+                permission_engine,
+                approval_tracker=self._approval_tracker,
+            )
 
     async def run(self) -> None:
         """Run the main TUI loop."""
@@ -277,10 +294,18 @@ class _InteractivePermissionProxy:
 
     When the permission engine returns ASK, this proxy prompts the user
     via the terminal and either grants, denies, or creates a session-scoped grant.
+
+    Optionally tracks repeated approvals via ApprovalTracker and suggests
+    adding patterns as permanent allow rules after a configurable threshold.
     """
 
-    def __init__(self, engine: PermissionEngine) -> None:
+    def __init__(
+        self,
+        engine: PermissionEngine,
+        approval_tracker: Any | None = None,
+    ) -> None:
         self._engine = engine
+        self._tracker = approval_tracker
 
     def evaluate(self, tool_call: Any) -> PermissionDecision:
         """Evaluate permissions, prompting the user for ASK decisions."""
@@ -297,6 +322,12 @@ class _InteractivePermissionProxy:
             answer = "n"
 
         if answer in ("y", "yes"):
+            # Track approval for auto-permission suggestion
+            pattern = tool_call.format_for_permission()
+            if self._tracker is not None:
+                self._tracker.record_approval(pattern)
+                if self._tracker.should_suggest(pattern):
+                    self._suggest_auto_permission(pattern)
             return PermissionDecision(ALLOW, "user approved")
         if answer in ("a", "always"):
             pattern = tool_call.format_for_permission()
@@ -304,3 +335,38 @@ class _InteractivePermissionProxy:
             return PermissionDecision(ALLOW, f"session grant: {pattern}")
 
         return PermissionDecision("deny", "user denied")
+
+    def _suggest_auto_permission(self, pattern: str) -> None:
+        """Suggest adding a pattern as a permanent allow rule."""
+        # Skip if already in allow rules
+        for rule in self._engine.allow_rules:
+            if rule == pattern:
+                return
+
+        from godspeed.tui.theme import ACCENT, SUCCESS
+
+        console.print(
+            f"\n  [{ACCENT}]You've approved [{SUCCESS}]{pattern}"
+            f"[/{SUCCESS}] multiple times.[/{ACCENT}]"
+        )
+        console.print(f"  [{ACCENT}]Add to permanent allow rules? (y/n)[/{ACCENT}]")
+        try:
+            answer = console.input(f"[{BOLD_WARNING}]  > [/{BOLD_WARNING}]").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            answer = "n"
+
+        if answer in ("y", "yes"):
+            from godspeed.config import append_allow_rule
+
+            success = append_allow_rule(pattern)
+            if success:
+                # Also update engine in-memory
+                self._engine.allow_rules.append(pattern)
+                console.print(f"  [{SUCCESS}]Added to allow rules.[/{SUCCESS}]")
+            else:
+                from godspeed.tui.theme import WARNING
+
+                console.print(
+                    f"  [{WARNING}]Could not persist rule. Added for this session only.[/{WARNING}]"
+                )
+                self._engine.grant_session_permission(pattern)

--- a/src/godspeed/tui/commands.py
+++ b/src/godspeed/tui/commands.py
@@ -95,8 +95,12 @@ class Commands:
         self._handlers["/pause"] = self._cmd_pause
         self._handlers["/resume"] = self._cmd_resume
         self._handlers["/guidance"] = self._cmd_guidance
+        self._handlers["/tasks"] = self._cmd_tasks
         self._handlers["/quit"] = self._cmd_quit
         self._handlers["/exit"] = self._cmd_quit
+
+    # Task store reference — set externally after Commands init
+    _task_store: Any | None = None
 
     def register(self, name: str, handler: CommandHandler) -> None:
         """Register a custom slash command."""
@@ -465,6 +469,36 @@ class Commands:
             console.print(f"  [{BOLD_SUCCESS}]Agent resumed with guidance.[/{BOLD_SUCCESS}]")
 
         return CommandResult(handled=True)
+
+    def _cmd_tasks(self, _args: str = "") -> CommandResult:
+        """Show current task list."""
+        if self._task_store is None:
+            console.print(f"  [{MUTED}]Task tracking not enabled.[/{MUTED}]")
+            return CommandResult()
+
+        tasks = self._task_store.list_all()
+        if not tasks:
+            console.print(f"  [{MUTED}]No tasks.[/{MUTED}]")
+            return CommandResult()
+
+        from rich.table import Table
+
+        table = Table(title="Tasks", border_style=TABLE_BORDER, expand=False)
+        table.add_column("ID", style=BOLD_PRIMARY, width=4)
+        table.add_column("Title")
+        table.add_column("Status")
+
+        for t in tasks:
+            if t.status == "completed":
+                status_style = f"[{SUCCESS}]{t.status}[/{SUCCESS}]"
+            elif t.status == "in_progress":
+                status_style = f"[{WARNING}]{t.status}[/{WARNING}]"
+            else:
+                status_style = f"[{MUTED}]{t.status}[/{MUTED}]"
+            table.add_row(str(t.id), t.title, status_style)
+
+        console.print(table)
+        return CommandResult()
 
     def _cmd_quit(self, _args: str = "") -> CommandResult:
         """Exit Godspeed."""

--- a/src/godspeed/tui/commands.py
+++ b/src/godspeed/tui/commands.py
@@ -96,11 +96,13 @@ class Commands:
         self._handlers["/resume"] = self._cmd_resume
         self._handlers["/guidance"] = self._cmd_guidance
         self._handlers["/tasks"] = self._cmd_tasks
+        self._handlers["/reindex"] = self._cmd_reindex
         self._handlers["/quit"] = self._cmd_quit
         self._handlers["/exit"] = self._cmd_quit
 
-    # Task store reference — set externally after Commands init
+    # External references — set after Commands init
     _task_store: Any | None = None
+    _codebase_index: Any | None = None
 
     def register(self, name: str, handler: CommandHandler) -> None:
         """Register a custom slash command."""
@@ -498,6 +500,31 @@ class Commands:
             table.add_row(str(t.id), t.title, status_style)
 
         console.print(table)
+        return CommandResult()
+
+    def _cmd_reindex(self, _args: str = "") -> CommandResult:
+        """Rebuild the codebase search index."""
+        if self._codebase_index is None:
+            console.print(f"  [{MUTED}]Codebase index not available.[/{MUTED}]")
+            console.print(f"  [{DIM}]Install with: pip install godspeed[index][/{DIM}]")
+            return CommandResult()
+
+        if not self._codebase_index.is_available:
+            console.print(
+                f"  [{ERROR}]ChromaDB not installed.[/{ERROR}] "
+                f"[{DIM}]pip install godspeed[index][/{DIM}]"
+            )
+            return CommandResult()
+
+        if self._codebase_index.is_building:
+            console.print(f"  [{WARNING}]Index is already building...[/{WARNING}]")
+            return CommandResult()
+
+        import asyncio
+
+        console.print(f"  [{DIM}]Rebuilding codebase index...[/{DIM}]")
+        asyncio.get_event_loop().create_task(self._codebase_index.build_index_async())
+        console.print(f"  [{SUCCESS}]Reindex started in background.[/{SUCCESS}]")
         return CommandResult()
 
     def _cmd_quit(self, _args: str = "") -> CommandResult:

--- a/src/godspeed/tui/completions.py
+++ b/src/godspeed/tui/completions.py
@@ -31,8 +31,13 @@ class GodspeedCompleter(Completer):
     - File paths as arguments to certain commands
     """
 
-    def __init__(self, cwd: Path | None = None) -> None:
+    def __init__(
+        self,
+        cwd: Path | None = None,
+        extra_commands: list[tuple[str, str]] | None = None,
+    ) -> None:
         self._cwd = cwd or Path(".")
+        self._extra_commands = extra_commands or []
 
     def get_completions(
         self, document: Document, complete_event: CompleteEvent
@@ -52,8 +57,9 @@ class GodspeedCompleter(Completer):
             yield from self._complete_file_paths(parts[1])
 
     def _complete_slash_commands(self, text: str) -> Iterable[Completion]:
-        """Complete slash commands."""
-        for cmd, description in SLASH_COMMANDS:
+        """Complete slash commands (built-in + dynamic skill commands)."""
+        all_commands = SLASH_COMMANDS + self._extra_commands
+        for cmd, description in all_commands:
             if cmd.startswith(text):
                 yield Completion(
                     cmd,

--- a/tests/test_auto_permission.py
+++ b/tests/test_auto_permission.py
@@ -1,0 +1,119 @@
+"""Tests for auto-permission suggestion flow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from godspeed.config import append_allow_rule
+from godspeed.security.approval_tracker import ApprovalTracker
+
+
+class TestAppendAllowRule:
+    """Test append_allow_rule() config persistence."""
+
+    def test_creates_new_file(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        result = append_allow_rule("Shell(git status)", project_dir=project)
+        assert result is True
+
+        settings_path = project / ".godspeed" / "settings.yaml"
+        assert settings_path.exists()
+        data = yaml.safe_load(settings_path.read_text(encoding="utf-8"))
+        assert "Shell(git status)" in data["permissions"]["allow"]
+
+    def test_appends_to_existing(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        godspeed_dir = project / ".godspeed"
+        godspeed_dir.mkdir(parents=True)
+        settings_path = godspeed_dir / "settings.yaml"
+        settings_path.write_text(
+            yaml.safe_dump(
+                {"permissions": {"allow": ["Shell(ruff *)"]}},
+                default_flow_style=False,
+            ),
+            encoding="utf-8",
+        )
+
+        result = append_allow_rule("Shell(git status)", project_dir=project)
+        assert result is True
+
+        data = yaml.safe_load(settings_path.read_text(encoding="utf-8"))
+        assert "Shell(ruff *)" in data["permissions"]["allow"]
+        assert "Shell(git status)" in data["permissions"]["allow"]
+
+    def test_no_duplicates(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        godspeed_dir = project / ".godspeed"
+        godspeed_dir.mkdir(parents=True)
+        settings_path = godspeed_dir / "settings.yaml"
+        settings_path.write_text(
+            yaml.safe_dump(
+                {"permissions": {"allow": ["Shell(git status)"]}},
+                default_flow_style=False,
+            ),
+            encoding="utf-8",
+        )
+
+        result = append_allow_rule("Shell(git status)", project_dir=project)
+        assert result is True
+
+        data = yaml.safe_load(settings_path.read_text(encoding="utf-8"))
+        assert data["permissions"]["allow"].count("Shell(git status)") == 1
+
+    def test_preserves_other_settings(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        godspeed_dir = project / ".godspeed"
+        godspeed_dir.mkdir(parents=True)
+        settings_path = godspeed_dir / "settings.yaml"
+        settings_path.write_text(
+            yaml.safe_dump(
+                {"model": "gpt-4o", "permissions": {"deny": ["rm -rf *"]}},
+                default_flow_style=False,
+            ),
+            encoding="utf-8",
+        )
+
+        append_allow_rule("Shell(git status)", project_dir=project)
+
+        data = yaml.safe_load(settings_path.read_text(encoding="utf-8"))
+        assert data["model"] == "gpt-4o"
+        assert "rm -rf *" in data["permissions"]["deny"]
+        assert "Shell(git status)" in data["permissions"]["allow"]
+
+
+class TestAutoPermissionFlow:
+    """Test the full approval tracking → suggestion flow."""
+
+    def test_three_approvals_triggers_suggestion(self) -> None:
+        tracker = ApprovalTracker(threshold=3)
+        pattern = "Shell(git status)"
+
+        for _ in range(3):
+            tracker.record_approval(pattern)
+
+        assert tracker.should_suggest(pattern)
+
+    def test_suggestion_only_fires_once(self) -> None:
+        tracker = ApprovalTracker(threshold=2)
+        pattern = "Shell(git status)"
+
+        tracker.record_approval(pattern)
+        tracker.record_approval(pattern)
+        assert tracker.should_suggest(pattern)
+
+        # Additional approvals don't re-trigger
+        tracker.record_approval(pattern)
+        assert not tracker.should_suggest(pattern)
+
+    def test_different_patterns_independent(self) -> None:
+        tracker = ApprovalTracker(threshold=2)
+
+        tracker.record_approval("Shell(git status)")
+        tracker.record_approval("Shell(npm test)")
+        tracker.record_approval("Shell(git status)")
+
+        assert tracker.should_suggest("Shell(git status)")
+        assert not tracker.should_suggest("Shell(npm test)")

--- a/tests/test_context/test_codebase_index.py
+++ b/tests/test_context/test_codebase_index.py
@@ -1,0 +1,117 @@
+"""Tests for codebase indexer and chunker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from godspeed.context.chunker import Chunk, chunk_file
+
+
+class TestChunkFile:
+    """Test file chunking."""
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.py"
+        f.write_text("", encoding="utf-8")
+        assert chunk_file(f) == []
+
+    def test_simple_python(self, tmp_path: Path) -> None:
+        f = tmp_path / "simple.py"
+        f.write_text(
+            "def hello():\n    return 'world'\n\ndef goodbye():\n    return 'bye'\n",
+            encoding="utf-8",
+        )
+        chunks = chunk_file(f)
+        assert len(chunks) >= 2
+        assert any("hello" in c.content for c in chunks)
+        assert any("goodbye" in c.content for c in chunks)
+
+    def test_python_with_class(self, tmp_path: Path) -> None:
+        f = tmp_path / "cls.py"
+        f.write_text(
+            "class Foo:\n    def bar(self):\n        pass\n\n"
+            "class Baz:\n    def qux(self):\n        pass\n",
+            encoding="utf-8",
+        )
+        chunks = chunk_file(f)
+        assert len(chunks) >= 2
+
+    def test_non_python_uses_sliding_window(self, tmp_path: Path) -> None:
+        f = tmp_path / "readme.md"
+        content = "Line\n" * 100
+        f.write_text(content, encoding="utf-8")
+        chunks = chunk_file(f, max_tokens=20)
+        assert len(chunks) >= 1
+        assert all(isinstance(c, Chunk) for c in chunks)
+
+    def test_chunk_has_correct_fields(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.py"
+        f.write_text("def foo():\n    pass\n", encoding="utf-8")
+        chunks = chunk_file(f)
+        assert len(chunks) >= 1
+        c = chunks[0]
+        assert c.file_path == str(f)
+        assert c.start_line >= 1
+        assert c.end_line >= c.start_line
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        assert chunk_file(tmp_path / "nonexistent.py") == []
+
+    def test_invalid_python_falls_back(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.py"
+        f.write_text("def (\n  invalid syntax\n", encoding="utf-8")
+        chunks = chunk_file(f)
+        # Falls back to sliding window
+        assert len(chunks) >= 1
+
+    def test_python_no_defs_falls_back(self, tmp_path: Path) -> None:
+        f = tmp_path / "script.py"
+        f.write_text("x = 1\ny = 2\nprint(x + y)\n", encoding="utf-8")
+        chunks = chunk_file(f)
+        assert len(chunks) >= 1
+
+    def test_chunk_frozen(self, tmp_path: Path) -> None:
+        c = Chunk(content="x", file_path="f", start_line=1, end_line=1)
+        with pytest.raises(AttributeError):
+            c.content = "y"  # type: ignore[misc]
+
+
+class TestCodebaseIndex:
+    """Test CodebaseIndex (without chromadb — graceful degradation)."""
+
+    def test_is_available_without_chromadb(self, tmp_path: Path) -> None:
+        from godspeed.context.codebase_index import CodebaseIndex
+
+        index = CodebaseIndex(project_dir=tmp_path)
+        # May be True or False depending on environment
+        assert isinstance(index.is_available, bool)
+
+    def test_search_without_chromadb_returns_empty(self, tmp_path: Path) -> None:
+        from godspeed.context.codebase_index import CodebaseIndex
+
+        index = CodebaseIndex(project_dir=tmp_path)
+        if not index.is_available:
+            results = index.search("test query")
+            assert results == []
+
+    def test_needs_reindex_no_db(self, tmp_path: Path) -> None:
+        from godspeed.context.codebase_index import CodebaseIndex
+
+        index = CodebaseIndex(project_dir=tmp_path)
+        assert index.needs_reindex() is True
+
+    def test_is_building_default_false(self, tmp_path: Path) -> None:
+        from godspeed.context.codebase_index import CodebaseIndex
+
+        index = CodebaseIndex(project_dir=tmp_path)
+        assert index.is_building is False
+
+    def test_build_index_without_chromadb(self, tmp_path: Path) -> None:
+        from godspeed.context.codebase_index import CodebaseIndex
+
+        index = CodebaseIndex(project_dir=tmp_path)
+        if not index.is_available:
+            count = index.build_index()
+            assert count == 0

--- a/tests/test_hooks/test_config.py
+++ b/tests/test_hooks/test_config.py
@@ -1,0 +1,63 @@
+"""Tests for hook configuration models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from godspeed.hooks.config import HookDefinition
+
+
+class TestHookDefinition:
+    """Test HookDefinition model."""
+
+    def test_valid_pre_tool_call(self) -> None:
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command="echo {tool_name}",
+            tools=["shell", "file_write"],
+            timeout=10,
+        )
+        assert hook.event == "pre_tool_call"
+        assert hook.tools == ["shell", "file_write"]
+        assert hook.timeout == 10
+
+    def test_valid_post_session(self) -> None:
+        hook = HookDefinition(
+            event="post_session",
+            command="./scripts/cleanup.sh",
+        )
+        assert hook.event == "post_session"
+        assert hook.tools is None
+        assert hook.timeout == 30
+
+    def test_all_event_types(self) -> None:
+        for event in ["pre_tool_call", "post_tool_call", "pre_session", "post_session"]:
+            hook = HookDefinition(event=event, command="echo test")
+            assert hook.event == event
+
+    def test_invalid_event_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            HookDefinition(event="invalid_event", command="echo test")
+
+    def test_default_timeout(self) -> None:
+        hook = HookDefinition(event="pre_session", command="echo test")
+        assert hook.timeout == 30
+
+    def test_default_tools_is_none(self) -> None:
+        hook = HookDefinition(event="pre_tool_call", command="echo test")
+        assert hook.tools is None
+
+    def test_timeout_bounds(self) -> None:
+        with pytest.raises(ValidationError):
+            HookDefinition(event="pre_session", command="echo", timeout=0)
+        with pytest.raises(ValidationError):
+            HookDefinition(event="pre_session", command="echo", timeout=301)
+
+    def test_template_variables_in_command(self) -> None:
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command="echo {tool_name} {session_id} {cwd}",
+        )
+        assert "{tool_name}" in hook.command
+        assert "{session_id}" in hook.command

--- a/tests/test_hooks/test_executor.py
+++ b/tests/test_hooks/test_executor.py
@@ -1,0 +1,177 @@
+"""Tests for hook executor."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from godspeed.hooks.config import HookDefinition
+from godspeed.hooks.executor import HookExecutor
+
+
+def _make_executor(
+    hooks: list[HookDefinition],
+    tmp_path: Path,
+) -> HookExecutor:
+    return HookExecutor(hooks=hooks, cwd=tmp_path, session_id="test-session-123")
+
+
+class TestPreToolHooks:
+    """Test pre_tool_call hook execution."""
+
+    def test_allows_when_no_hooks(self, tmp_path: Path) -> None:
+        executor = _make_executor([], tmp_path)
+        assert executor.run_pre_tool("shell") is True
+
+    def test_allows_on_success(self, tmp_path: Path) -> None:
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command=f"{sys.executable} -c \"print('ok')\"",
+        )
+        executor = _make_executor([hook], tmp_path)
+        assert executor.run_pre_tool("shell") is True
+
+    def test_blocks_on_failure(self, tmp_path: Path) -> None:
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command=f'{sys.executable} -c "raise SystemExit(1)"',
+        )
+        executor = _make_executor([hook], tmp_path)
+        assert executor.run_pre_tool("shell") is False
+
+    def test_tool_filter_matches(self, tmp_path: Path) -> None:
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command=f'{sys.executable} -c "raise SystemExit(1)"',
+            tools=["shell"],
+        )
+        executor = _make_executor([hook], tmp_path)
+        # Should block shell
+        assert executor.run_pre_tool("shell") is False
+        # Should allow file_read (not in tool list)
+        assert executor.run_pre_tool("file_read") is True
+
+    def test_tool_filter_none_matches_all(self, tmp_path: Path) -> None:
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command=f'{sys.executable} -c "raise SystemExit(1)"',
+            tools=None,
+        )
+        executor = _make_executor([hook], tmp_path)
+        assert executor.run_pre_tool("shell") is False
+        assert executor.run_pre_tool("file_read") is False
+
+    def test_template_variable_expansion(self, tmp_path: Path) -> None:
+        marker = tmp_path / "marker.txt"
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command=(
+                f'{sys.executable} -c "'
+                "import sys; "
+                f"open(r'{marker}', 'w').write(sys.argv[0])"
+                '" {tool_name}'
+            ),
+        )
+        executor = _make_executor([hook], tmp_path)
+        executor.run_pre_tool("shell")
+        # Hook ran successfully (marker file created)
+        assert marker.exists()
+
+
+class TestPostToolHooks:
+    """Test post_tool_call hook execution."""
+
+    def test_runs_post_hook(self, tmp_path: Path) -> None:
+        marker = tmp_path / "post_marker.txt"
+        hook = HookDefinition(
+            event="post_tool_call",
+            command=f"{sys.executable} -c \"open(r'{marker}', 'w').write('done')\"",
+        )
+        executor = _make_executor([hook], tmp_path)
+        executor.run_post_tool("shell")
+        assert marker.exists()
+        assert marker.read_text() == "done"
+
+    def test_post_hook_tool_filter(self, tmp_path: Path) -> None:
+        marker = tmp_path / "post_marker.txt"
+        hook = HookDefinition(
+            event="post_tool_call",
+            command=f"{sys.executable} -c \"open(r'{marker}', 'w').write('done')\"",
+            tools=["shell"],
+        )
+        executor = _make_executor([hook], tmp_path)
+        executor.run_post_tool("file_read")
+        assert not marker.exists()
+
+
+class TestSessionHooks:
+    """Test session lifecycle hooks."""
+
+    def test_pre_session(self, tmp_path: Path) -> None:
+        marker = tmp_path / "pre_session.txt"
+        hook = HookDefinition(
+            event="pre_session",
+            command=f"{sys.executable} -c \"open(r'{marker}', 'w').write('started')\"",
+        )
+        executor = _make_executor([hook], tmp_path)
+        executor.run_pre_session()
+        assert marker.exists()
+
+    def test_post_session(self, tmp_path: Path) -> None:
+        marker = tmp_path / "post_session.txt"
+        hook = HookDefinition(
+            event="post_session",
+            command=f"{sys.executable} -c \"open(r'{marker}', 'w').write('ended')\"",
+        )
+        executor = _make_executor([hook], tmp_path)
+        executor.run_post_session()
+        assert marker.exists()
+
+    def test_only_session_hooks_run(self, tmp_path: Path) -> None:
+        marker = tmp_path / "wrong.txt"
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command=f"{sys.executable} -c \"open(r'{marker}', 'w').write('wrong')\"",
+        )
+        executor = _make_executor([hook], tmp_path)
+        executor.run_pre_session()
+        executor.run_post_session()
+        assert not marker.exists()
+
+
+class TestHookTimeout:
+    """Test hook timeout handling."""
+
+    def test_timeout_returns_nonzero(self, tmp_path: Path) -> None:
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command=f'{sys.executable} -c "import time; time.sleep(10)"',
+            timeout=1,
+        )
+        executor = _make_executor([hook], tmp_path)
+        assert executor.run_pre_tool("shell") is False
+
+
+class TestHookErrors:
+    """Test hook error handling."""
+
+    def test_bad_template_variable(self, tmp_path: Path) -> None:
+        hook = HookDefinition(
+            event="pre_tool_call",
+            command="echo {nonexistent_var}",
+        )
+        executor = _make_executor([hook], tmp_path)
+        # Bad template returns exit code 1, blocking the tool
+        assert executor.run_pre_tool("shell") is False
+
+    def test_multiple_hooks_all_must_pass(self, tmp_path: Path) -> None:
+        hook1 = HookDefinition(
+            event="pre_tool_call",
+            command=f"{sys.executable} -c \"print('ok')\"",
+        )
+        hook2 = HookDefinition(
+            event="pre_tool_call",
+            command=f'{sys.executable} -c "raise SystemExit(1)"',
+        )
+        executor = _make_executor([hook1, hook2], tmp_path)
+        assert executor.run_pre_tool("shell") is False

--- a/tests/test_security/test_approval_tracker.py
+++ b/tests/test_security/test_approval_tracker.py
@@ -1,0 +1,99 @@
+"""Tests for the auto-permission approval tracker."""
+
+from __future__ import annotations
+
+import threading
+
+from godspeed.security.approval_tracker import ApprovalTracker
+
+
+class TestApprovalTracker:
+    """Test ApprovalTracker."""
+
+    def test_initial_count_is_zero(self) -> None:
+        tracker = ApprovalTracker()
+        assert tracker.get_count("Shell(git status)") == 0
+
+    def test_record_increments_count(self) -> None:
+        tracker = ApprovalTracker()
+        tracker.record_approval("Shell(git status)")
+        assert tracker.get_count("Shell(git status)") == 1
+        tracker.record_approval("Shell(git status)")
+        assert tracker.get_count("Shell(git status)") == 2
+
+    def test_separate_patterns_tracked_independently(self) -> None:
+        tracker = ApprovalTracker()
+        tracker.record_approval("Shell(git status)")
+        tracker.record_approval("Shell(npm test)")
+        assert tracker.get_count("Shell(git status)") == 1
+        assert tracker.get_count("Shell(npm test)") == 1
+
+    def test_should_suggest_at_threshold(self) -> None:
+        tracker = ApprovalTracker(threshold=3)
+        pattern = "Shell(git status)"
+        for _ in range(2):
+            tracker.record_approval(pattern)
+            assert not tracker.should_suggest(pattern)
+
+        tracker.record_approval(pattern)
+        assert tracker.should_suggest(pattern)
+
+    def test_should_suggest_only_once(self) -> None:
+        tracker = ApprovalTracker(threshold=2)
+        pattern = "Shell(git status)"
+        tracker.record_approval(pattern)
+        tracker.record_approval(pattern)
+
+        assert tracker.should_suggest(pattern)
+        # Second call returns False even with more approvals
+        tracker.record_approval(pattern)
+        assert not tracker.should_suggest(pattern)
+
+    def test_custom_threshold_override(self) -> None:
+        tracker = ApprovalTracker(threshold=5)
+        pattern = "Shell(git status)"
+        for _ in range(3):
+            tracker.record_approval(pattern)
+
+        # Default threshold is 5, but we override to 3
+        assert tracker.should_suggest(pattern, threshold=3)
+
+    def test_below_threshold_returns_false(self) -> None:
+        tracker = ApprovalTracker(threshold=3)
+        tracker.record_approval("Shell(git status)")
+        assert not tracker.should_suggest("Shell(git status)")
+
+    def test_reset_clears_all(self) -> None:
+        tracker = ApprovalTracker(threshold=2)
+        pattern = "Shell(git status)"
+        tracker.record_approval(pattern)
+        tracker.record_approval(pattern)
+        tracker.should_suggest(pattern)
+
+        tracker.reset()
+        assert tracker.get_count(pattern) == 0
+        # After reset, suggestion can trigger again
+        tracker.record_approval(pattern)
+        tracker.record_approval(pattern)
+        assert tracker.should_suggest(pattern)
+
+    def test_thread_safety(self) -> None:
+        tracker = ApprovalTracker(threshold=100)
+        pattern = "Shell(git status)"
+
+        def record_many() -> None:
+            for _ in range(100):
+                tracker.record_approval(pattern)
+
+        threads = [threading.Thread(target=record_many) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert tracker.get_count(pattern) == 1000
+
+    def test_should_suggest_with_zero_threshold(self) -> None:
+        tracker = ApprovalTracker(threshold=0)
+        # Even with 0 threshold, should suggest after first check
+        assert tracker.should_suggest("Shell(git status)")

--- a/tests/test_skills/test_commands.py
+++ b/tests/test_skills/test_commands.py
@@ -1,0 +1,105 @@
+"""Tests for skill command registration and dispatch."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from godspeed.skills.commands import register_skill_commands
+from godspeed.skills.loader import SkillDefinition
+
+
+def _make_skill(
+    name: str = "test-skill",
+    description: str = "A test skill",
+    trigger: str = "test",
+    content: str = "Do the test thing.",
+) -> SkillDefinition:
+    return SkillDefinition(
+        name=name,
+        description=description,
+        trigger=trigger,
+        content=content,
+    )
+
+
+class TestRegisterSkillCommands:
+    """Test register_skill_commands()."""
+
+    def test_registers_trigger_command(self) -> None:
+        commands = MagicMock()
+        conversation = MagicMock()
+        skills = [_make_skill()]
+        register_skill_commands(commands, conversation, skills)
+
+        # Should register /test and /skills
+        calls = commands.register.call_args_list
+        registered_names = [c[0][0] for c in calls]
+        assert "/test" in registered_names
+        assert "/skills" in registered_names
+
+    def test_trigger_injects_message(self) -> None:
+        commands = MagicMock()
+        conversation = MagicMock()
+        skill = _make_skill(name="review", trigger="review", content="Review the code.")
+        register_skill_commands(commands, conversation, [skill])
+
+        # Get the handler that was registered for /review
+        handler = None
+        for call in commands.register.call_args_list:
+            if call[0][0] == "/review":
+                handler = call[0][1]
+                break
+
+        assert handler is not None
+        result = handler()
+
+        # Should inject skill content into conversation
+        conversation.add_user_message.assert_called_once()
+        msg = conversation.add_user_message.call_args[0][0]
+        assert "[Skill: review]" in msg
+        assert "Review the code." in msg
+
+        # handled=False so agent_loop processes it
+        assert result.handled is False
+
+    def test_multiple_skills_registered(self) -> None:
+        commands = MagicMock()
+        conversation = MagicMock()
+        skills = [
+            _make_skill(trigger="review", name="review"),
+            _make_skill(trigger="test", name="test"),
+            _make_skill(trigger="deploy", name="deploy"),
+        ]
+        register_skill_commands(commands, conversation, skills)
+
+        registered_names = [c[0][0] for c in commands.register.call_args_list]
+        assert "/review" in registered_names
+        assert "/test" in registered_names
+        assert "/deploy" in registered_names
+        assert "/skills" in registered_names
+
+    def test_skills_command_with_no_skills(self) -> None:
+        commands = MagicMock()
+        conversation = MagicMock()
+        register_skill_commands(commands, conversation, [])
+
+        # Only /skills should be registered
+        registered_names = [c[0][0] for c in commands.register.call_args_list]
+        assert "/skills" in registered_names
+        assert len(registered_names) == 1
+
+    def test_skills_command_handler_returns_handled(self) -> None:
+        commands = MagicMock()
+        conversation = MagicMock()
+        register_skill_commands(commands, conversation, [_make_skill()])
+
+        # Get /skills handler
+        handler = None
+        for call in commands.register.call_args_list:
+            if call[0][0] == "/skills":
+                handler = call[0][1]
+                break
+
+        assert handler is not None
+        result = handler()
+        assert result.handled is True

--- a/tests/test_skills/test_loader.py
+++ b/tests/test_skills/test_loader.py
@@ -1,0 +1,217 @@
+"""Tests for skill discovery and loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from godspeed.skills.loader import SkillDefinition, _parse_skill_file, discover_skills
+
+
+@pytest.fixture()
+def skill_dir(tmp_path: Path) -> Path:
+    """Create a temp directory with valid skill files."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    return skills
+
+
+def _write_skill(directory: Path, filename: str, content: str) -> Path:
+    """Write a skill file and return its path."""
+    path = directory / filename
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestParseSkillFile:
+    """Test _parse_skill_file()."""
+
+    def test_valid_skill(self, skill_dir: Path) -> None:
+        path = _write_skill(
+            skill_dir,
+            "review.md",
+            "---\nname: code-review\ndescription: Review code\n"
+            "trigger: review\n---\nReview this code.",
+        )
+        skill = _parse_skill_file(path)
+        assert skill is not None
+        assert skill.name == "code-review"
+        assert skill.description == "Review code"
+        assert skill.trigger == "review"
+        assert skill.content == "Review this code."
+
+    def test_multiline_content(self, skill_dir: Path) -> None:
+        path = _write_skill(
+            skill_dir,
+            "multi.md",
+            "---\nname: multi\ndescription: Multi-line\n"
+            "trigger: multi\n---\nLine 1\n\nLine 2\nLine 3",
+        )
+        skill = _parse_skill_file(path)
+        assert skill is not None
+        assert "Line 1" in skill.content
+        assert "Line 3" in skill.content
+
+    def test_missing_frontmatter(self, skill_dir: Path) -> None:
+        path = _write_skill(skill_dir, "bad.md", "No frontmatter here.")
+        assert _parse_skill_file(path) is None
+
+    def test_missing_closing_marker(self, skill_dir: Path) -> None:
+        path = _write_skill(skill_dir, "bad.md", "---\nname: test\n\nNo closing marker")
+        assert _parse_skill_file(path) is None
+
+    def test_missing_required_fields(self, skill_dir: Path) -> None:
+        path = _write_skill(
+            skill_dir,
+            "bad.md",
+            "---\nname: test\n---\nContent without description or trigger.",
+        )
+        assert _parse_skill_file(path) is None
+
+    def test_empty_body(self, skill_dir: Path) -> None:
+        path = _write_skill(
+            skill_dir,
+            "empty.md",
+            "---\nname: empty\ndescription: Empty body\ntrigger: empty\n---\n",
+        )
+        assert _parse_skill_file(path) is None
+
+    def test_invalid_yaml(self, skill_dir: Path) -> None:
+        path = _write_skill(
+            skill_dir,
+            "bad_yaml.md",
+            "---\n[invalid yaml: {{{\n---\nContent.",
+        )
+        assert _parse_skill_file(path) is None
+
+    def test_non_dict_frontmatter(self, skill_dir: Path) -> None:
+        path = _write_skill(
+            skill_dir,
+            "list.md",
+            "---\n- item1\n- item2\n---\nContent.",
+        )
+        assert _parse_skill_file(path) is None
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        assert _parse_skill_file(tmp_path / "nonexistent.md") is None
+
+    def test_fields_coerced_to_string(self, skill_dir: Path) -> None:
+        path = _write_skill(
+            skill_dir,
+            "numeric.md",
+            "---\nname: 123\ndescription: 456\ntrigger: 789\n---\nContent.",
+        )
+        skill = _parse_skill_file(path)
+        assert skill is not None
+        assert skill.name == "123"
+        assert skill.trigger == "789"
+
+
+class TestDiscoverSkills:
+    """Test discover_skills()."""
+
+    def test_empty_directory(self, skill_dir: Path) -> None:
+        skills = discover_skills([skill_dir])
+        assert skills == []
+
+    def test_discovers_valid_skills(self, skill_dir: Path) -> None:
+        _write_skill(
+            skill_dir,
+            "review.md",
+            "---\nname: review\ndescription: Review code\ntrigger: review\n---\nReview code.",
+        )
+        _write_skill(
+            skill_dir,
+            "test.md",
+            "---\nname: test\ndescription: Run tests\ntrigger: test\n---\nRun tests.",
+        )
+        skills = discover_skills([skill_dir])
+        assert len(skills) == 2
+        triggers = {s.trigger for s in skills}
+        assert triggers == {"review", "test"}
+
+    def test_skips_invalid_files(self, skill_dir: Path) -> None:
+        _write_skill(
+            skill_dir,
+            "good.md",
+            "---\nname: good\ndescription: Good\ntrigger: good\n---\nContent.",
+        )
+        _write_skill(skill_dir, "bad.md", "No frontmatter")
+        skills = discover_skills([skill_dir])
+        assert len(skills) == 1
+        assert skills[0].trigger == "good"
+
+    def test_project_overrides_global(self, tmp_path: Path) -> None:
+        global_dir = tmp_path / "global"
+        project_dir = tmp_path / "project"
+        global_dir.mkdir()
+        project_dir.mkdir()
+
+        _write_skill(
+            global_dir,
+            "review.md",
+            "---\nname: global-review\ndescription: Global\ntrigger: review\n---\nGlobal review.",
+        )
+        _write_skill(
+            project_dir,
+            "review.md",
+            "---\nname: project-review\ndescription: Project\n"
+            "trigger: review\n---\nProject review.",
+        )
+
+        skills = discover_skills([global_dir, project_dir])
+        assert len(skills) == 1
+        assert skills[0].name == "project-review"
+        assert skills[0].content == "Project review."
+
+    def test_nonexistent_directory(self, tmp_path: Path) -> None:
+        skills = discover_skills([tmp_path / "nonexistent"])
+        assert skills == []
+
+    def test_ignores_non_md_files(self, skill_dir: Path) -> None:
+        _write_skill(
+            skill_dir,
+            "good.md",
+            "---\nname: good\ndescription: Good\ntrigger: good\n---\nContent.",
+        )
+        (skill_dir / "readme.txt").write_text("Not a skill", encoding="utf-8")
+        (skill_dir / "script.py").write_text("print('hello')", encoding="utf-8")
+        skills = discover_skills([skill_dir])
+        assert len(skills) == 1
+
+    def test_multiple_dirs_merge(self, tmp_path: Path) -> None:
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+
+        _write_skill(
+            dir_a,
+            "review.md",
+            "---\nname: review\ndescription: Review\ntrigger: review\n---\nReview.",
+        )
+        _write_skill(
+            dir_b,
+            "deploy.md",
+            "---\nname: deploy\ndescription: Deploy\ntrigger: deploy\n---\nDeploy.",
+        )
+
+        skills = discover_skills([dir_a, dir_b])
+        assert len(skills) == 2
+        triggers = {s.trigger for s in skills}
+        assert triggers == {"review", "deploy"}
+
+
+class TestSkillDefinition:
+    """Test SkillDefinition dataclass."""
+
+    def test_frozen(self) -> None:
+        skill = SkillDefinition(name="test", description="desc", trigger="test", content="body")
+        with pytest.raises(AttributeError):
+            skill.name = "changed"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        a = SkillDefinition(name="test", description="desc", trigger="t", content="c")
+        b = SkillDefinition(name="test", description="desc", trigger="t", content="c")
+        assert a == b

--- a/tests/test_tools/test_code_search.py
+++ b/tests/test_tools/test_code_search.py
@@ -1,0 +1,101 @@
+"""Tests for the code search tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from godspeed.tools.base import RiskLevel, ToolContext
+from godspeed.tools.code_search import CodeSearchTool
+
+
+@pytest.fixture()
+def context(tmp_path: Path) -> ToolContext:
+    return ToolContext(cwd=tmp_path, session_id="test-session")
+
+
+class TestCodeSearchTool:
+    """Test CodeSearchTool."""
+
+    def test_name_and_risk(self) -> None:
+        index = MagicMock()
+        tool = CodeSearchTool(index)
+        assert tool.name == "code_search"
+        assert tool.risk_level == RiskLevel.READ_ONLY
+
+    def test_schema_has_query(self) -> None:
+        index = MagicMock()
+        tool = CodeSearchTool(index)
+        schema = tool.get_schema()
+        assert "query" in schema["parameters"]["properties"]
+
+    @pytest.mark.asyncio()
+    async def test_missing_query(self, context: ToolContext) -> None:
+        index = MagicMock()
+        tool = CodeSearchTool(index)
+        result = await tool.execute({}, context)
+        assert result.is_error
+
+    @pytest.mark.asyncio()
+    async def test_unavailable_index(self, context: ToolContext) -> None:
+        index = MagicMock()
+        index.is_available = False
+        tool = CodeSearchTool(index)
+        result = await tool.execute({"query": "test"}, context)
+        assert result.is_error
+        assert "not available" in (result.error or "")
+
+    @pytest.mark.asyncio()
+    async def test_building_index(self, context: ToolContext) -> None:
+        index = MagicMock()
+        index.is_available = True
+        index.is_building = True
+        tool = CodeSearchTool(index)
+        result = await tool.execute({"query": "test"}, context)
+        assert not result.is_error
+        assert "being built" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_no_results(self, context: ToolContext) -> None:
+        index = MagicMock()
+        index.is_available = True
+        index.is_building = False
+        index.search.return_value = []
+        tool = CodeSearchTool(index)
+        result = await tool.execute({"query": "test"}, context)
+        assert "No results" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_with_results(self, context: ToolContext) -> None:
+        from godspeed.context.codebase_index import SearchResult
+
+        index = MagicMock()
+        index.is_available = True
+        index.is_building = False
+        index.search.return_value = [
+            SearchResult(
+                file_path="src/main.py",
+                start_line=10,
+                end_line=20,
+                content="def hello():\n    return 'world'",
+                score=0.95,
+            ),
+        ]
+        tool = CodeSearchTool(index)
+        result = await tool.execute({"query": "hello function"}, context)
+        assert not result.is_error
+        assert "main.py" in result.output
+        assert "0.95" in result.output
+        assert "hello" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_custom_top_k(self, context: ToolContext) -> None:
+        index = MagicMock()
+        index.is_available = True
+        index.is_building = False
+        index.search.return_value = []
+        tool = CodeSearchTool(index)
+        await tool.execute({"query": "test", "top_k": 3}, context)
+        index.search.assert_called_once_with("test", top_k=3)

--- a/tests/test_tools/test_tasks.py
+++ b/tests/test_tools/test_tasks.py
@@ -1,0 +1,173 @@
+"""Tests for task tracking tool and store."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from godspeed.tools.base import RiskLevel, ToolContext
+from godspeed.tools.tasks import TaskStore, TaskTool
+
+
+@pytest.fixture()
+def store() -> TaskStore:
+    return TaskStore()
+
+
+@pytest.fixture()
+def context(tmp_path: Path) -> ToolContext:
+    return ToolContext(cwd=tmp_path, session_id="test-session")
+
+
+class TestTaskStore:
+    """Test TaskStore."""
+
+    def test_create_task(self, store: TaskStore) -> None:
+        task = store.create("Fix bug", "The login page crashes")
+        assert task.id == 1
+        assert task.title == "Fix bug"
+        assert task.description == "The login page crashes"
+        assert task.status == "pending"
+
+    def test_sequential_ids(self, store: TaskStore) -> None:
+        t1 = store.create("Task 1")
+        t2 = store.create("Task 2")
+        t3 = store.create("Task 3")
+        assert t1.id == 1
+        assert t2.id == 2
+        assert t3.id == 3
+
+    def test_get_task(self, store: TaskStore) -> None:
+        store.create("Find me")
+        task = store.get(1)
+        assert task is not None
+        assert task.title == "Find me"
+
+    def test_get_nonexistent(self, store: TaskStore) -> None:
+        assert store.get(999) is None
+
+    def test_update_status(self, store: TaskStore) -> None:
+        store.create("Update me")
+        task = store.update(1, "in_progress")
+        assert task is not None
+        assert task.status == "in_progress"
+
+    def test_update_nonexistent(self, store: TaskStore) -> None:
+        assert store.update(999, "in_progress") is None
+
+    def test_complete(self, store: TaskStore) -> None:
+        store.create("Complete me")
+        task = store.complete(1)
+        assert task is not None
+        assert task.status == "completed"
+
+    def test_list_active(self, store: TaskStore) -> None:
+        store.create("Active 1")
+        store.create("Active 2")
+        store.create("Done")
+        store.complete(3)
+        active = store.list_active()
+        assert len(active) == 2
+        assert all(t.status != "completed" for t in active)
+
+    def test_list_all(self, store: TaskStore) -> None:
+        store.create("Task 1")
+        store.create("Task 2")
+        store.complete(1)
+        assert len(store.list_all()) == 2
+
+    def test_format_active_empty(self, store: TaskStore) -> None:
+        assert store.format_active() is None
+
+    def test_format_active_with_tasks(self, store: TaskStore) -> None:
+        store.create("Fix bug", "Important bug")
+        store.create("Write tests")
+        store.update(1, "in_progress")
+        result = store.format_active()
+        assert result is not None
+        assert "Fix bug" in result
+        assert "Write tests" in result
+        assert "in_progress" in result
+
+    def test_format_active_excludes_completed(self, store: TaskStore) -> None:
+        store.create("Done task")
+        store.complete(1)
+        assert store.format_active() is None
+
+
+class TestTaskTool:
+    """Test TaskTool execution."""
+
+    @pytest.fixture()
+    def tool(self, store: TaskStore) -> TaskTool:
+        return TaskTool(store)
+
+    def test_name_and_risk(self, tool: TaskTool) -> None:
+        assert tool.name == "tasks"
+        assert tool.risk_level == RiskLevel.LOW
+
+    def test_schema_has_action(self, tool: TaskTool) -> None:
+        schema = tool.get_schema()
+        assert "action" in schema["parameters"]["properties"]
+
+    @pytest.mark.asyncio()
+    async def test_create(self, tool: TaskTool, context: ToolContext) -> None:
+        result = await tool.execute(
+            {"action": "create", "title": "New task", "description": "Do it"},
+            context,
+        )
+        assert not result.is_error
+        assert "New task" in result.output
+        assert "[1]" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_create_without_title(self, tool: TaskTool, context: ToolContext) -> None:
+        result = await tool.execute({"action": "create"}, context)
+        assert result.is_error
+
+    @pytest.mark.asyncio()
+    async def test_list_empty(self, tool: TaskTool, context: ToolContext) -> None:
+        result = await tool.execute({"action": "list"}, context)
+        assert "No tasks" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_list_with_tasks(self, tool: TaskTool, context: ToolContext) -> None:
+        await tool.execute({"action": "create", "title": "Task A"}, context)
+        await tool.execute({"action": "create", "title": "Task B"}, context)
+        result = await tool.execute({"action": "list"}, context)
+        assert "Task A" in result.output
+        assert "Task B" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_update(self, tool: TaskTool, context: ToolContext) -> None:
+        await tool.execute({"action": "create", "title": "Update me"}, context)
+        result = await tool.execute(
+            {"action": "update", "task_id": 1, "status": "in_progress"},
+            context,
+        )
+        assert not result.is_error
+        assert "in_progress" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_update_missing_args(self, tool: TaskTool, context: ToolContext) -> None:
+        result = await tool.execute({"action": "update", "task_id": 1}, context)
+        assert result.is_error
+
+    @pytest.mark.asyncio()
+    async def test_complete(self, tool: TaskTool, context: ToolContext) -> None:
+        await tool.execute({"action": "create", "title": "Complete me"}, context)
+        result = await tool.execute({"action": "complete", "task_id": 1}, context)
+        assert not result.is_error
+        assert "Completed" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_complete_nonexistent(self, tool: TaskTool, context: ToolContext) -> None:
+        result = await tool.execute({"action": "complete", "task_id": 999}, context)
+        assert result.is_error
+
+    @pytest.mark.asyncio()
+    async def test_unknown_action(self, tool: TaskTool, context: ToolContext) -> None:
+        result = await tool.execute({"action": "invalid"}, context)
+        assert result.is_error
+        assert "Unknown action" in result.output or "Unknown action" in (result.error or "")


### PR DESCRIPTION
## Summary

Self-growing agent capabilities: the full v0.7.0–v0.9.0 roadmap (12 sessions, 5 commits, 32 files, +3301 lines).

### v0.7.0 — Skills + Auto-Permission Learning
- **Skill framework**: Markdown `.md` files with YAML frontmatter define reusable prompt skills. `discover_skills()` scans `~/.godspeed/skills/` and `.godspeed/skills/` (project overrides global). `/{trigger}` commands inject skill content. `/skills` lists available skills. Tab-completion.
- **Auto-permission learning**: `ApprovalTracker` counts repeated approvals per pattern. After 3 approvals, suggests adding as permanent allow rule. `append_allow_rule()` persists to `.godspeed/settings.yaml`. Thread-safe, session-scoped.

### v0.8.0 — Hooks + Task Tracking
- **Hook system**: `HookDefinition` pydantic model with 4 event types (`pre_tool_call`, `post_tool_call`, `pre_session`, `post_session`). Shell commands with template variables. Pre-tool hooks can block execution. Configurable timeout (1-300s). Wired into agent loop and CLI lifecycle.
- **Task tracking**: `TaskStore` + `TaskTool` (create/update/list/complete). `/tasks` command shows themed Rich table. Registered as built-in LOW-risk tool.

### v0.9.0 — Persistent Codebase Index
- **Codebase index**: Optional ChromaDB-backed semantic search (`[index]` extra). AST-based chunking for Python, sliding window for other languages. `CodeSearchTool` for natural language code queries. Background indexing, `/reindex` command, stale detection.

### Also included
- **Architecture document**: `GODSPEED_ARCHITECTURE.md` — 6-part reference with Mermaid diagrams (664 lines)
- **108 new tests** across 12 test files — 734 total, ~90% coverage

## New modules
| Module | Purpose |
|--------|---------|
| `skills/loader.py` | Skill discovery + YAML frontmatter parsing |
| `skills/commands.py` | `/{trigger}` handlers, `/skills` listing |
| `security/approval_tracker.py` | Auto-permission learning |
| `hooks/config.py` | Hook definition model |
| `hooks/executor.py` | Shell hook execution with template vars |
| `tools/tasks.py` | Task store + task tool |
| `context/chunker.py` | AST + sliding window code chunking |
| `context/codebase_index.py` | ChromaDB vector index |
| `tools/code_search.py` | Semantic code search tool |

## Test plan
- [x] `ruff check . --fix && ruff format .` — clean at every commit
- [x] 734 tests passing (`pytest tests/ -x -q`)
- [x] ~90% coverage maintained
- [x] No new dependencies required (chromadb is optional `[index]` extra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)