### PR TITLE
feat: v2.1.0 — 13 competitive features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-04-12
+
+### Added
+
+- **Extended thinking**: Pass `thinking` parameter to Anthropic/Claude models with configurable token budget. `/think [budget]` slash command to toggle. Thinking blocks displayed in collapsed dim panel.
+- **Notebook (.ipynb) support**: `file_read` detects `.ipynb` and renders cells as structured text with outputs. `notebook_edit` tool for cell-level operations (edit, add, delete, move).
+- **Image read tool**: `image_read` reads PNG/JPG/GIF/WebP files, returns base64-encoded content for vision-capable LLMs. Size limits (20MB reject, 5MB warning). Path traversal protection.
+- **PDF read tool**: `pdf_read` extracts text from PDF files with page range support (`pages: "1-5"`). 20-page-per-request limit. Graceful fallback when pymupdf not installed.
+- **Cost budget enforcement**: Hard cost limit via `max_cost_usd` config. `BudgetExceededError` stops agent when exceeded. `/budget [amount]` slash command to set/show budget.
+- **GitHub PR/issue tool**: `github` tool wraps `gh` CLI for create/list/view PRs and issues, add comments. 8 actions with structured JSON output. HIGH risk (modifies external state).
+- **Background command execution**: `shell` tool gains `background: true` parameter. `BackgroundRegistry` singleton tracks processes. `background_check` tool for status/output/kill.
+- **Unified diff apply tool**: `diff_apply` accepts unified diff format, applies hunks in reverse order. Multi-file support, fuzzy context matching (±3 lines), dry-run mode.
+- **Architect mode**: `/architect` toggles two-phase plan-then-execute pipeline. Phase 1 uses read-only tools for planning, Phase 2 uses full tools guided by the plan.
+- **Speculative tool execution**: During streaming, READ_ONLY tool calls are dispatched immediately before the full response completes. Results cached and consumed by the main loop — eliminates dispatch latency for reads.
+- **Risk-based parallel/serial dispatch**: Phase 3 partitions tool calls by risk level. READ_ONLY tools run in parallel via `asyncio.gather()`, write tools run sequentially. Maintains ordering.
+- **Cheapest-model compaction**: `_compact_conversation()` selects the cheapest model from the fallback chain for summarization. `get_cheapest_model()` in cost module.
+- **Typed event system**: `AgentEvent` union type with 11 frozen dataclass event types (ThinkingEvent, TextChunkEvent, ToolCallEvent, etc.) for composable agent loop consumption.
+- 250+ new tests (total: 1,200+ passing)
+
+### Changed
+
+- `agent_loop()` signature expanded: `on_thinking` callback, speculative cache for streaming
+- `LLMClient` tracks `thinking_budget`, `max_cost_usd`, `total_cost_usd`
+- `GodspeedSettings` includes `thinking_budget`, `max_cost_usd`, `architect_model`, `sandbox` fields
+- `_streaming_call()` accepts `tool_registry` and `speculative_cache` for speculative dispatch
+- `/help` updated with new commands under "Agent Control" section
+
+## [2.0.0] - 2026-04-11
+
+### Added
+
+- **Parallel tool execution**: When the LLM returns multiple tool calls, they execute concurrently via `asyncio.gather()`. 3-phase dispatch: parse → permission check (sequential) → execute (parallel). Config: `parallel_tool_calls: true` (default). Falls back to sequential for single calls or when disabled.
+- **Multimodal user messages**: `add_user_message()` accepts `str` or `list[dict]` content blocks. `build_image_content_block()` and `build_multimodal_message()` helpers for image URLs and base64 data URIs. Token counter estimates 765 tokens per image block.
+- **@-mention context injection**: `@file:path`, `@folder:path`, `@web:url` syntax in user input. Parsed via regex, resolved to content blocks injected into conversation. File/folder mentions validate paths via `resolve_tool_path()` (traversal protection). Web mentions enforce HTTPS-only with 100KB size limit.
+- **@-mention tab completion**: Typing `@` suggests mention types; `@file:` and `@folder:` complete file paths relative to project directory.
+- **Auto-commit workflow**: After configurable number of successful edits, generates a conventional commit message via LLM and commits with `Co-Authored-By: Godspeed <noreply@godspeed.dev>` attribution. Config: `auto_commit: false` (default off), `auto_commit_threshold: 5`.
+- **`/autocommit` slash command**: Toggle auto-commit on/off, set threshold. Listed in `/help` and tab-completable.
+- **Lint-fix retry loop**: Auto-verify now retries `ruff check --fix` up to N times for Python/JS files until clean. Config: `auto_fix_retries: 3` (default). Languages without deterministic fixers skip retry.
+- **MCP SSE/HTTP transport**: `MCPSSEClient` connects to remote MCP servers via HTTP/SSE alongside existing stdio transport. Config: `transport: "sse"`, `url`, `headers` fields in MCP server config. Backward compatible — missing `transport` field defaults to "stdio".
+- **Parallel tool TUI output**: `format_parallel_tool_calls()` shows grouped header with tool count and names. `format_parallel_results()` shows batch summary with success/error markers. Callbacks: `on_parallel_start`, `on_parallel_complete`.
+- **Deferred auto-verify/auto-stash for parallel mode**: Auto-verify runs sequentially after parallel batch completes. Auto-stash counts writes across batch.
+- 100+ new tests across 7 test files (total: 960+ passing)
+
+### Changed
+
+- `agent_loop()` signature expanded: `parallel_tool_calls`, `skip_user_message`, `auto_fix_retries`, `auto_commit`, `auto_commit_threshold`, `on_parallel_start`, `on_parallel_complete` parameters
+- `Conversation.add_user_message()` accepts multimodal content blocks (`list[dict]`)
+- Token counter handles `image_url` type blocks with flat 765-token estimate
+- `GodspeedSettings` includes new config fields for all v2.0 features
+
 ## [1.0.0] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Self-evolution system** (Units 20-27): Learn from execution traces to improve prompts, tool descriptions, and permissions automatically. Runs entirely on Ollama for $0 — optional API acceleration.
+  - **Trace analyzer**: Parse audit trail JSONL into failure patterns, latency stats, permission insights, and repeated tool sequences.
+  - **Evolution engine**: GEPA-style LLM-guided mutations for tool descriptions, system prompt sections, compaction prompts, and auto-generated skills.
+  - **Fitness evaluator**: A/B testing with LLM-as-judge scoring (0.5×correctness + 0.3×procedure + 0.2×conciseness). Length penalty for bloat.
+  - **Safety gate**: Size limit (<2x growth), semantic drift (Jaccard ≥0.3), fitness threshold, confidence check, human review for high-impact artifacts.
+  - **Evolution registry**: Append-only JSONL history with apply/revert/rollback. Originals backed up before mutation.
+  - **Runtime hot-swap**: Update tool descriptions in-memory via `ToolRegistry._description_overrides`. Prompt section overrides loaded on startup.
+  - **Cross-session learning**: Aggregate insights across sessions, model-specific analysis, regression detection with rollback/investigate/monitor recommendations.
+  - **Skill auto-generation**: Detect repeated multi-tool patterns (≥3 occurrences) → generate reusable skill markdown with YAML frontmatter.
+  - **Permission pattern learning**: Analyze denial/approval patterns → suggest allowlist optimizations with rationale.
+  - **Hardware-aware model selection**: Auto-detect VRAM (nvidia-smi + Jetson /proc/meminfo), pick largest fitting model from tier list. Scales candidates and batch sizes by available memory. Jetson Orin Nano 8GB → qwen2.5:3b with 2 candidates.
+  - **`/evolve` command**: status, run, history, rollback, review, approve, reject subcommands.
+- 175 new evolution tests (total: 1,400+ passing)
+
+### Changed
+
+- `ToolRegistry` gains `_description_overrides` dict, `update_description()`, `clear_description_override()`, `get_description()` methods
+- `GodspeedSettings` includes `evolution_enabled` and `evolution_model` fields
+- Trace analyzer uses streaming line-by-line reads instead of `readlines()` for low-memory devices
+
 ## [2.1.0] - 2026-04-12
 
 ### Added

--- a/GODSPEED_ARCHITECTURE.md
+++ b/GODSPEED_ARCHITECTURE.md
@@ -1,7 +1,7 @@
-# Godspeed Architecture (v0.6.0)
+# Godspeed Architecture (v2.2.0)
 
 > Security-first coding agent. Hand-rolled ReAct loop. No framework overhead.
-> 53 modules · 6,988 LOC · 626 tests · 90% coverage
+> 1,417+ tests passing
 
 ---
 
@@ -9,14 +9,14 @@
 
 ## Part 1: Core Loop
 
-**Files**: `agent/loop.py` (365 lines), `agent/conversation.py` (121 lines)
+**Files**: `agent/loop.py`, `agent/conversation.py`, `agent/events.py`
 
 ### ReAct Cycle
 
-The agent loop (`async agent_loop()`) follows the pattern proven by mini-swe-agent (74%+ SWE-bench):
+The agent loop (`async agent_loop()`) follows the pattern proven by mini-swe-agent (74%+ SWE-bench), extended with parallel tool execution, speculative dispatch, and cost budget enforcement:
 
 ```
-User input → Conversation → LLM call → Tool calls? → Execute → Loop
+User input → Conversation → LLM call → Tool calls? → Parallel/Serial Split → Execute → Loop
                                       → Text only?  → Return (done)
 ```
 
@@ -24,23 +24,29 @@ User input → Conversation → LLM call → Tool calls? → Execute → Loop
 flowchart TD
     A[User Input] --> B[Add to Conversation]
     B --> C{Near Token Limit?}
-    C -->|Yes| D[Compact Conversation]
-    C -->|No| E[LLM Call]
+    C -->|Yes| D[Compact via Cheapest Model]
+    C -->|No| E{Budget OK?}
     D --> E
-    E --> F{Has Tool Calls?}
-    F -->|No| G[Return Final Text]
-    F -->|Yes| H[Check Permissions]
-    H -->|Denied| I[Record Denial]
-    H -->|Allowed| J[Execute Tool]
-    I --> K{More Tool Calls?}
-    J --> L[Auto-Verify if .py]
-    L --> M[Auto-Stash if 3+ writes]
-    M --> N[Stuck Loop Check]
-    N --> K
-    K -->|Yes| H
-    K -->|No| O{Under Iteration Limit?}
-    O -->|Yes| C
-    O -->|No| P[Return Max Iterations Error]
+    E -->|No| F[Return BudgetExceededError]
+    E -->|Yes| G[LLM Call / Stream]
+    G --> H{Has Tool Calls?}
+    H -->|No| I[Return Final Text]
+    H -->|Yes| J[Speculative Dispatch READ_ONLY]
+    J --> K[Check Permissions]
+    K -->|Denied| L[Record Denial]
+    K -->|Allowed| M{Risk-Based Split}
+    M -->|READ_ONLY| N[Parallel Dispatch]
+    M -->|Write| O[Serial Dispatch]
+    L --> P{More Tool Calls?}
+    N --> Q[Auto-Verify if .py]
+    O --> Q
+    Q --> R[Auto-Stash if 3+ writes]
+    R --> S[Stuck Loop Check]
+    S --> P
+    P -->|Yes| K
+    P -->|No| T{Under Iteration Limit?}
+    T -->|Yes| C
+    T -->|No| U[Return Max Iterations Error]
 ```
 
 ### Constants
@@ -52,7 +58,7 @@ flowchart TD
 | `STUCK_LOOP_THRESHOLD` | 3 | Identical errors before intervention |
 | `AUTO_STASH_THRESHOLD` | 3 | Consecutive writes before git stash |
 
-### Five Callback Types
+### Callback Types
 
 All optional parameters to `agent_loop()`:
 
@@ -63,8 +69,20 @@ All optional parameters to `agent_loop()`:
 | `OnToolResult` | `(str, ToolResult) → None` | After tool execution |
 | `OnPermissionDenied` | `(str, str) → None` | Permission engine blocks a call |
 | `OnChunk` | `(str) → None` | Each streaming text delta |
+| `OnThinking` | `(str) → None` | Extended thinking block from Claude |
 
 **Streaming vs Batch**: When `on_assistant_chunk` is provided, uses `llm_client.stream_chat()` (async generator). Otherwise uses `llm_client.chat()` (batch). The `on_assistant_text` callback is skipped when streaming was used (prevents double-render).
+
+### Speculative Tool Dispatch
+
+During LLM streaming, tool calls are parsed incrementally. When a complete READ_ONLY tool call is detected before generation finishes, it is dispatched immediately as a background `asyncio.Task`. When the full response arrives, cached results are used instead of re-executing. This significantly reduces latency for read-heavy workflows.
+
+### Parallel / Serial Tool Dispatch
+
+When the LLM returns multiple tool calls in a single response:
+- **READ_ONLY** tools (file_read, glob_search, grep_search, repo_map, verify) are dispatched in parallel via `asyncio.gather()`
+- **Write** tools (file_edit, file_write, shell, git) are dispatched sequentially to prevent race conditions
+- Results are ordered: read results first, then write results
 
 ### Pause/Resume
 
@@ -99,7 +117,7 @@ Token counting via `count_message_tokens(messages, model)` from the tokenizer mo
 
 ## Part 2: Security Model
 
-**Files**: `security/permissions.py` (197 lines), `security/dangerous.py` (139 lines), `security/secrets.py` (176 lines)
+**Files**: `security/permissions.py`, `security/dangerous.py`, `security/secrets.py`
 
 ### Permission Evaluation Order
 
@@ -200,7 +218,7 @@ redact_secrets(text) -> str  # replaces with [REDACTED]
 
 ## Part 3: Tool System
 
-**Files**: `tools/base.py` (166 lines), `tools/registry.py` (89 lines)
+**Files**: `tools/base.py`, `tools/registry.py`
 
 ### Tool ABC
 
@@ -264,21 +282,40 @@ class ToolRegistry:
     async dispatch(tool_call, context) -> ToolResult
 ```
 
-### Built-In Tools (9)
+### Built-In Tools (18+)
+
+**Core Tools (always registered):**
 
 | Tool | Risk Level | Purpose |
 |------|-----------|---------|
 | `file_read` | READ_ONLY | Read file content with line numbers |
 | `file_write` | LOW | Create or overwrite file |
 | `file_edit` | LOW | Search/replace in existing file |
-| `shell` | HIGH | Run bash commands (cwd-sandboxed) |
+| `shell` | HIGH | Run bash commands (cwd-sandboxed, supports `background` mode) |
 | `git` | HIGH | Git operations (status, commit, diff, stash, etc.) |
 | `glob_search` | READ_ONLY | Find files by glob pattern |
 | `grep_search` | READ_ONLY | Search file content with regex |
 | `repo_map` | READ_ONLY | Tree-sitter symbol extraction |
-| `verify` | READ_ONLY | Run linter checks (ruff for Python) |
+| `verify` | READ_ONLY | Run linter checks (ruff for Python, with lint-fix retry) |
+| `test_runner` | HIGH | Run pytest/npm test with output capture |
+| `web_search` | READ_ONLY | Search the web via DuckDuckGo |
+| `web_fetch` | READ_ONLY | Fetch URL content as markdown |
+| `notebook_edit` | LOW | Cell-level Jupyter notebook operations |
+| `background_check` | LOW | Poll/read/kill background shell processes |
+| `task` | LOW | Create and manage task lists |
+| `spawn_agent` | HIGH | Delegate work to sub-agents |
 
-Plus `spawn_agent` (HIGH) when sub-agents are enabled, and any MCP tools (HIGH) when MCP servers are configured.
+**Optional Tools (registered when dependencies available):**
+
+| Tool | Risk Level | Extra | Purpose |
+|------|-----------|-------|---------|
+| `image_read` | READ_ONLY | `[image]` | Read PNG/JPG/GIF/WebP as base64 for vision LLMs |
+| `pdf_read` | READ_ONLY | `[pdf]` | Extract text from PDF with page ranges |
+| `github` | HIGH | (requires `gh` CLI) | Create PRs, read issues, comment |
+| `diff_apply` | LOW | — | Apply unified diff patches to files |
+| `code_search` | READ_ONLY | `[search]` | Semantic code search via embeddings |
+
+Plus any MCP tools (HIGH) dynamically registered from configured MCP servers.
 
 ---
 
@@ -286,7 +323,7 @@ Plus `spawn_agent` (HIGH) when sub-agents are enabled, and any MCP tools (HIGH) 
 
 ## Part 4: Intelligence
 
-**Files**: `agent/system_prompt.py` (85 lines), `context/compaction.py` (98 lines), `llm/client.py` (382 lines), `context/checkpoint.py` (80 lines), `context/repo_map.py` (238 lines), `tools/verify.py` (87 lines)
+**Files**: `agent/system_prompt.py`, `context/compaction.py`, `llm/client.py`, `llm/cost.py`, `context/checkpoint.py`, `context/repo_map.py`, `tools/verify.py`
 
 ### System Prompt Assembly
 
@@ -319,8 +356,11 @@ class LLMClient:
     model: str                          # Primary model
     fallback_models: list[str]          # Fallback chain
     router: ModelRouter | None          # Task-type routing
+    thinking_budget: int                # Extended thinking token budget (0 = disabled)
+    max_cost_usd: float                 # Hard cost limit (0.0 = unlimited)
     total_input_tokens: int             # Running total
     total_output_tokens: int
+    total_cost_usd: float               # Running cost estimate
 
     async chat(messages, tools, task_type) -> ChatResponse
     async stream_chat(messages, tools) -> AsyncGenerator[ChatResponse]
@@ -333,6 +373,32 @@ class LLMClient:
 **Fallback Chain**: On failure, retries primary after 1s sleep, then tries each fallback model in order. Skips retries entirely if connection error detected (server unreachable).
 
 **Ollama Upgrade**: Models prefixed `ollama/` are upgraded to `ollama_chat/` for tool-capable chat completions.
+
+**Prompt Caching**: For Anthropic models, system messages are wrapped in content blocks with `cache_control: {"type": "ephemeral"}` to reduce repeated input costs.
+
+### Extended Thinking
+
+For Claude models with `thinking_budget > 0`, passes `thinking={"type": "enabled", "budget_tokens": N}` to LiteLLM. The response includes `thinking` content blocks displayed in a collapsed dim panel before the main response. Toggled via `/think [budget]` command.
+
+### Cost Estimation & Budget Enforcement
+
+`llm/cost.py` provides model pricing and cost tracking:
+
+```python
+estimate_cost(model, input_tokens, output_tokens) -> float  # USD
+format_cost(cost) -> str              # "$1.50" or "free"
+get_cheapest_model(models) -> str     # Lowest $/token from a list
+```
+
+- Ollama models always return `$0.0` (local inference)
+- Provider prefixes (`anthropic/`, `openai/`) are stripped for pricing lookup
+- Unknown models default to free (conservative — avoids false budget blocks)
+
+After each `chat()` call, `LLMClient` updates `total_cost_usd`. If `max_cost_usd > 0` and cost exceeds the limit, raises `BudgetExceededError(spent, limit)`. The agent loop catches this and returns an informative message.
+
+### Cheapest-Model Compaction
+
+When conversation compaction triggers, `_compact_conversation()` selects the cheapest model from `[main_model, *fallback_models]` via `get_cheapest_model()`. If only Ollama models are available (all free), uses the main model. Falls back to main model on error.
 
 ### Checkpoint Save/Restore
 
@@ -369,7 +435,7 @@ class RepoMapper:
 
 ## Part 5: Autonomy
 
-**Files**: `agent/coordinator.py` (140 lines), `tools/spawn_agent.py`, `mcp/client.py` (119 lines), `mcp/tool_adapter.py` (85 lines)
+**Files**: `agent/coordinator.py`, `agent/architect.py`, `tools/spawn_agent.py`, `mcp/client.py`, `mcp/tool_adapter.py`
 
 ### Sub-Agent Architecture
 
@@ -402,6 +468,19 @@ Results returned in order. No cancellation on individual failure — each sub-ag
 
 Registered as a standard tool: `name="spawn_agent"`, `risk_level=HIGH`. The agent calls it like any other tool to delegate work. Arguments: `task` (string description), optionally `parallel_tasks` (list of strings).
 
+### Architect Mode
+
+Two-phase pipeline toggled via `/architect`:
+
+1. **Plan phase** — Calls the architect model (configurable, defaults to main model with planning system prompt) with **read-only tools only**. Produces a detailed implementation plan.
+2. **Execute phase** — Injects the plan as a user message, calls the main model with **full tool access** to implement the plan.
+
+```python
+async architect_loop(task, llm_client, tool_registry, ...) -> str
+```
+
+Controlled by `config.architect_model` (separate model for planning) and the `/architect` toggle command.
+
 ### MCP Client (Model Context Protocol)
 
 ```python
@@ -410,7 +489,7 @@ class MCPServerConfig:
     command: str                     # e.g. "npx", "python"
     args: list[str] | None           # e.g. ["-m", "mcp_server"]
     env: dict[str, str] | None
-    transport: str = "stdio"         # Only stdio supported
+    transport: str = "stdio"         # "stdio" or "sse"
 
 class MCPClient:
     async connect(config) -> list[MCPToolDefinition]
@@ -418,7 +497,7 @@ class MCPClient:
     async disconnect_all()
 ```
 
-**Transport**: Stdio — spawns subprocess, communicates via stdin/stdout JSON-RPC.
+**Transport**: Stdio (spawns subprocess, communicates via stdin/stdout JSON-RPC) or SSE (connects to HTTP server with Server-Sent Events).
 
 **Graceful degradation**: Returns empty tool list if `mcp` package not installed.
 
@@ -451,7 +530,7 @@ Three TUI commands enable mid-session intervention:
 
 ## Part 6: Memory & TUI
 
-**Files**: `memory/user_memory.py` (174 lines), `memory/session.py` (161 lines), `memory/corrections.py` (89 lines), `tui/theme.py` (103 lines), `tui/output.py` (245 lines), `tui/commands.py` (478 lines), `tui/completions.py` (97 lines)
+**Files**: `memory/user_memory.py`, `memory/session.py`, `memory/corrections.py`, `tui/theme.py`, `tui/output.py`, `tui/commands.py`, `tui/completions.py`
 
 ### User Memory (Persistent)
 
@@ -564,7 +643,7 @@ Helpers: `styled(text, style)` → Rich markup, `brand(version)` → branded str
 | `format_stats()` | Token usage table |
 | `format_error()` | Bold red error |
 
-### Slash Commands (16)
+### Slash Commands (25)
 
 | Command | Purpose |
 |---------|---------|
@@ -582,6 +661,15 @@ Helpers: `styled(text, style)` → Rich markup, `brand(version)` → branded str
 | `/pause` | Pause agent at next iteration |
 | `/resume` | Resume paused agent |
 | `/guidance <msg>` | Inject guidance, resume agent |
+| `/tasks` | Show current task list and status |
+| `/reindex` | Rebuild code search index |
+| `/stats` | Show session statistics (tokens, cost, tools) |
+| `/autocommit` | Toggle auto-commit after file writes |
+| `/architect` | Toggle architect mode (plan → execute pipeline) |
+| `/think [budget]` | Toggle extended thinking, set token budget |
+| `/budget [amount]` | Show/set cost budget limit |
+| `/evolve [action]` | Self-evolution management (run/status/review/rollback) |
+| `/export` | Export conversation as markdown |
 | `/quit` | Exit with session stats |
 | `/exit` | Alias for `/quit` |
 
@@ -607,7 +695,7 @@ Key bindings: Enter (submit), Escape+Enter (newline), Ctrl+C (abort input).
 
 ## Audit Trail
 
-**File**: `audit/trail.py`
+**Files**: `audit/trail.py`, `audit/events.py`
 
 Hash-chained audit log for tamper detection:
 
@@ -615,6 +703,78 @@ Hash-chained audit log for tamper detection:
 - Events: `session_start`, `session_end`, `tool_call` (with latency), errors
 - `/audit` command verifies chain integrity
 - Secrets redacted before recording
+- JSONL format consumed by the self-evolution trace analyzer for cross-session learning
+
+---
+
+<!-- PART 7: Self-Evolution -->
+
+## Part 7: Self-Evolution System
+
+**Files**: `evolution/trace_analyzer.py`, `evolution/mutator.py`, `evolution/fitness.py`, `evolution/safety.py`, `evolution/registry.py`, `evolution/applier.py`, `evolution/hardware.py`, `evolution/cross_session.py`, `evolution/skill_gen.py`, `evolution/permissions.py`
+
+Inspired by [NousResearch/hermes-agent-self-evolution](https://github.com/NousResearch/hermes-agent-self-evolution). Runs the entire evolution loop locally via Ollama for **$0**. Optional paid API acceleration.
+
+### Pipeline
+
+```
+Audit Trail (JSONL) → Trace Analyzer → Evolution Engine (GEPA mutations)
+    → Fitness Evaluator (LLM-as-judge) → Safety Gate → Registry → Hot-Swap
+```
+
+### Trace Analyzer
+
+Parses audit trail JSONL into actionable insights:
+- **Tool failure patterns** — grouped by tool + error category, ranked by frequency
+- **Tool latency stats** — p50/p95/p99 per tool
+- **Permission patterns** — tools repeatedly denied → suggest allowlist
+- **Multi-tool sequences** — repeated tool chains → candidates for skill auto-generation
+
+Streaming line-by-line reads (not `readlines()`) for low-memory devices like Jetson Orin.
+
+### Evolution Engine (GEPA Mutations)
+
+Generates improved candidates for tool descriptions, system prompt sections, and compaction prompts using LLM-guided mutations. Produces 1–5 candidates per mutation based on available VRAM.
+
+### Fitness Evaluator
+
+Scores candidates via A/B testing with LLM-as-judge:
+- **Correctness** (weight 0.5) — did the tool/prompt produce correct results?
+- **Procedure following** (weight 0.3) — did it follow the right steps?
+- **Conciseness** (weight 0.2) — was output appropriately sized?
+- Length penalty if mutated text exceeds 2× original
+
+### Safety Gate
+
+All mutations must pass before applying:
+1. 100% test suite pass with mutation in place
+2. Size limit — mutated text ≤ 2× original length
+3. Semantic drift — word overlap stays above threshold
+4. Minimum fitness score ≥ 0.6
+5. Human review required for system prompt core sections and HIGH-risk tool descriptions
+
+### Evolution Registry
+
+Append-only JSONL at `~/.godspeed/evolution/registry.jsonl`. Full mutation history with rollback support.
+
+### Hardware-Aware Model Selection
+
+Auto-detects available VRAM and selects the best Ollama model for evolution:
+
+| VRAM | Model | Candidates | Eval Cases |
+|------|-------|-----------|------------|
+| ≥ 10 GB | `ollama/gemma3:12b` | 5 | 5 |
+| ≥ 6 GB | `ollama/gemma3:4b` | 3 | 3 |
+| ≥ 3 GB | `ollama/qwen2.5:3b` | 2 | 2 |
+| < 3 GB | `ollama/qwen2.5:1.5b` | 1 | 1 |
+
+Detection: `nvidia-smi` for discrete GPUs, `/proc/meminfo` for Jetson (60% shared RAM factor). API models (Claude, GPT) bypass detection entirely.
+
+### Additional Modules
+
+- **Cross-Session Learning** — aggregates insights across sessions, detects regressions, produces model-specific description tuning
+- **Skill Auto-Generation** — detects repeated multi-tool patterns (≥3 occurrences), generates skill markdown with YAML frontmatter
+- **Permission Advisor** — analyzes denial/approval patterns, suggests allowlist optimizations
 
 ---
 
@@ -639,10 +799,24 @@ mcp_servers:
   - name: filesystem
     command: npx
     args: ["-y", "@anthropic/mcp-server-filesystem"]
+    transport: stdio  # or "sse"
 model_routing:
   plan: "claude-sonnet-4-20250514"
   edit: "ollama_chat/qwen3:8b"
   chat: "ollama_chat/gemma3:4b"
+
+# Extended thinking (Claude models)
+thinking_budget: 0            # 0 = disabled, N = token budget
+
+# Cost management
+max_cost_usd: 0.0            # 0.0 = unlimited
+
+# Architect mode
+architect_model: ""           # Separate model for planning phase
+
+# Self-evolution
+evolution_enabled: false
+evolution_model: ""           # Auto-detected from VRAM if empty
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An AI coding agent that treats security as a first-class concern -- not an after
 
 Every open-source coding agent gives an LLM the ability to read files, write code, and run shell commands. None of them ship with a deny-first permission engine, a tamper-evident audit trail, or multi-layer secret protection out of the box. You are expected to bolt security on yourself, or trust the model not to `rm -rf /`.
 
-Godspeed closes that gap. It pairs full coding capability (8 tools, 200+ LLM providers, sub-agents, MCP) with a security model that fails closed by default. Every tool call passes through a 4-tier permission engine. Every action is recorded in a hash-chained audit log you can cryptographically verify. Secrets are caught at four separate layers before they ever reach the model or the log file.
+Godspeed closes that gap. It pairs full coding capability (18+ tools, 200+ LLM providers, sub-agents, MCP) with a security model that fails closed by default. Every tool call passes through a 4-tier permission engine. Every action is recorded in a hash-chained audit log you can cryptographically verify. Secrets are caught at four separate layers before they ever reach the model or the log file.
 
 If you want a coding agent you can actually point at a production codebase, this is it.
 
@@ -39,12 +39,19 @@ If you want a coding agent you can actually point at a production codebase, this
 ### Capability
 
 - **200+ LLM providers** -- Claude, GPT, Gemini, Ollama, and everything else LiteLLM supports. Configure fallback chains so work never stops.
-- **12 built-in tools** -- `file_read`, `file_write`, `file_edit` (fuzzy matching), `shell`, `glob`, `grep`, `git`, `verify` (6 languages), `test_runner` (5 frameworks), `web_search`, `web_fetch`, and `repo_map`. Everything a coding agent needs.
+- **18+ built-in tools** -- `file_read` (images, PDFs, notebooks), `file_write`, `file_edit` (fuzzy matching), `notebook_edit`, `image_read`, `pdf_read`, `shell` (foreground + background), `glob`, `grep`, `git`, `github` (PR/issue workflow via `gh`), `diff_apply` (unified diffs), `verify` (6 languages), `test_runner` (5 frameworks), `web_search`, `web_fetch`, `repo_map`, and `background_check`.
+- **Parallel tool execution** -- when the LLM returns multiple tool calls, they execute concurrently via `asyncio.gather()`. 3-phase dispatch: parse → permission check (sequential) → execute (parallel). READ_ONLY tools always parallel, write tools always serial.
+- **Speculative tool dispatch** -- during streaming, READ_ONLY tool calls are dispatched as background `asyncio.Task`s before the full response completes. The main loop awaits cached results instead of re-dispatching, eliminating dispatch latency for reads.
+- **Extended thinking** -- pass `thinking` parameter to Anthropic/Claude models with configurable token budget. `/think [budget]` slash command. Thinking blocks displayed in collapsed dim panel.
+- **Architect mode** -- `/architect` toggles a two-phase pipeline. Phase 1 uses read-only tools to produce a plan. Phase 2 uses full tools guided by the plan. Configurable architect model.
+- **Cost budget enforcement** -- hard cost limit via `max_cost_usd` config or `/budget` command. Agent stops when exceeded. Ollama always free.
+- **Self-evolution** -- learn from execution traces to improve tool descriptions, system prompt sections, and permission configs. GEPA-style LLM-guided mutations scored by A/B testing with LLM-as-judge. Safety gate prevents regressions (size limits, semantic drift caps, human review). Runs entirely on Ollama for $0 with hardware-aware model selection (RTX 5070 Ti down to Jetson Orin Nano). `/evolve` command.
 - **Sub-agent coordinator** -- spawn isolated sub-agents for parallel tasks, each with their own conversation context. Depth limit 3, reuses the same async agent loop.
-- **MCP client** -- connect to Model Context Protocol servers via stdio transport. Remote tools are auto-adapted to Godspeed's Tool ABC with HIGH risk level.
+- **MCP client** -- connect to Model Context Protocol servers via stdio or SSE transport. Remote tools are auto-adapted to Godspeed's Tool ABC with HIGH risk level.
 - **Model routing** -- route LLM calls by task type (plan/edit/chat) to different models. Use a cheap model for edits and a frontier model for planning.
 - **Human-in-the-loop** -- `/pause` stops the agent at the next iteration, `/guidance <msg>` injects mid-conversation correction and resumes.
-- **Conversation compaction** -- model-aware summarization when approaching the token limit. Small models get aggressive compaction, frontier models get detailed preservation.
+- **Conversation compaction** -- model-aware summarization when approaching the token limit. Small models get aggressive compaction, frontier models get detailed preservation. Uses cheapest model in fallback chain.
+- **Background commands** -- `shell` tool gains `background: true` parameter. `BackgroundRegistry` tracks processes. `background_check` tool for status/output/kill.
 - **Checkpoint save/restore** -- `/checkpoint name` saves conversation state, `/restore name` loads it back. Never lose context again.
 - **Memory** -- SQLite-backed persistent preferences, session event logging, and automatic correction tracking across sessions.
 - **Cross-agent project instructions** -- loads `GODSPEED.md`, `AGENTS.md` (Linux Foundation standard), `CLAUDE.md`, and `.cursorrules`. Zero-friction migration from any agent.
@@ -52,7 +59,7 @@ If you want a coding agent you can actually point at a production codebase, this
 - **Prompt caching** -- system prompt marked with `cache_control` for Anthropic/OpenAI. ~50% cost reduction on repeated prefixes.
 - **Headless/CI mode** -- `godspeed run "task" --headless` for non-interactive execution. Auto-approve levels, JSON output, exit codes for CI/CD integration.
 - **Web tools** -- `web_search` (DuckDuckGo, no API key) and `web_fetch` (HTML-to-text extraction) let the agent look up documentation and error messages.
-- **Multi-language verify** -- auto-verification after edits supports Python (ruff), JS/TS (biome/eslint), Go (go vet), Rust (cargo check), C/C++ (clang-tidy).
+- **Multi-language verify** -- auto-verification after edits supports Python (ruff), JS/TS (biome/eslint), Go (go vet), Rust (cargo check), C/C++ (clang-tidy). Lint-fix retry loop up to 3 rounds.
 - **Test runner** -- auto-detect pytest, jest, vitest, go test, cargo test. Run targeted or full test suites. Agent-accessible for edit-test-fix loops.
 - **Conversation export** -- `/export` saves the full session as formatted markdown for sharing or review.
 - **Rich TUI** -- syntax highlighting, unified diff rendering, streaming output, and slash commands via Rich and prompt-toolkit.
@@ -64,8 +71,11 @@ flowchart LR
     User([User]) --> TUI["TUI\n(Rich + prompt-toolkit)"]
     TUI --> Loop["Agent Loop\n(loop.py)"]
     Loop --> LLM["LLM\n(LiteLLM + ModelRouter)"]
+    LLM -->|streaming| Spec["Speculative\nDispatch"]
+    Spec -->|READ_ONLY| Tools
     LLM -->|tool calls| Perm["Permission\nEngine"]
-    Perm -->|allowed| Tools["Tools\n(8 built-in + MCP)"]
+    Perm -->|allowed| Dispatch["Parallel/Serial\nDispatch"]
+    Dispatch --> Tools["Tools\n(18+ built-in + MCP)"]
     Perm -->|denied| Deny[Deny + Log]
     Tools --> Audit["Audit Trail\n(SHA-256 JSONL)"]
     Deny --> Audit
@@ -73,28 +83,33 @@ flowchart LR
     Loop -->|sub-agents| Loop
     Loop -->|response| TUI
     Loop --> Memory["Memory\n(SQLite)"]
+    Audit -->|traces| Evo["Self-Evolution\n(Ollama, $0)"]
+    Evo -->|improved descriptions| Tools
 
     style Perm fill:#e74c3c,color:#fff
     style Audit fill:#2ecc71,color:#fff
     style Memory fill:#3498db,color:#fff
+    style Spec fill:#9b59b6,color:#fff
+    style Evo fill:#e67e22,color:#fff
 ```
 
 **How it works:**
 
-The agent loop is hand-rolled (no framework) following the same pattern proven by top-performing coding agents. The LLM decides when to stop. On each turn, the LLM either responds with text (done) or requests tool calls. Every tool call passes through the **permission engine** before execution: deny rules are evaluated first and always win, then dangerous command detection (72+ regex patterns) blocks destructive operations, then session grants and allow rules, and finally the tool's risk level determines the default. If anything is ambiguous, it fails closed. After execution, the tool call, its result, and the permission decision are recorded in the **audit trail** -- a hash-chained JSONL file where each record includes the SHA-256 hash of the previous record. Secrets are redacted at four layers: file access deny rules, context cleaning before the LLM sees content, output filtering on LLM responses, and audit log redaction. The loop also includes **stuck-loop detection** (3 identical errors triggers a replan), **auto-verification** (linter check after file edits in 6 languages), **auto-stash** (git stash after 3+ consecutive writes), and **pause/resume** for human-in-the-loop intervention.
+The agent loop is hand-rolled (no framework) following the same pattern proven by top-performing coding agents. The LLM decides when to stop. On each turn, the LLM either responds with text (done) or requests tool calls. During streaming, **speculative dispatch** starts READ_ONLY tool calls as background `asyncio.Task`s before the full response completes — the main loop awaits cached results instead of re-dispatching. Every tool call passes through the **permission engine** before execution: deny rules are evaluated first and always win, then dangerous command detection (72+ regex patterns) blocks destructive operations, then session grants and allow rules, and finally the tool's risk level determines the default. If anything is ambiguous, it fails closed. Permitted calls are split by risk level: **READ_ONLY tools run in parallel** via `asyncio.gather()`, **write tools run sequentially**. After execution, the tool call, its result, and the permission decision are recorded in the **audit trail** -- a hash-chained JSONL file where each record includes the SHA-256 hash of the previous record. Secrets are redacted at four layers: file access deny rules, context cleaning before the LLM sees content, output filtering on LLM responses, and audit log redaction. The loop also includes **stuck-loop detection** (3 identical errors triggers a replan), **auto-verification** (linter check after file edits in 6 languages with retry), **auto-stash** (git stash after 3+ consecutive writes), **cost budget enforcement**, and **pause/resume** for human-in-the-loop intervention. The **self-evolution system** mines audit trails for failure patterns and uses LLM-guided mutations to improve tool descriptions and prompts over time.
 
 **Key modules:**
 
 | Module | Path | Purpose |
 |--------|------|---------|
-| Agent loop | `src/godspeed/agent/` | Conversation management, LLM interaction, tool dispatch, sub-agent coordinator |
+| Agent loop | `src/godspeed/agent/` | Conversation management, LLM interaction, parallel + speculative dispatch, sub-agent coordinator |
 | Security | `src/godspeed/security/` | Permission engine, dangerous command detection, secret scanning |
 | Audit | `src/godspeed/audit/` | Hash-chained event logging, redaction, verification, compression |
-| Tools | `src/godspeed/tools/` | 12 built-in tools with JSON schemas |
-| LLM | `src/godspeed/llm/` | LiteLLM client wrapper, model routing, token counting |
+| Tools | `src/godspeed/tools/` | 18+ built-in tools with JSON schemas |
+| LLM | `src/godspeed/llm/` | LiteLLM client wrapper, model routing, token counting, cost tracking |
 | Context | `src/godspeed/context/` | Project instructions, compaction, checkpoints, repo map |
-| MCP | `src/godspeed/mcp/` | Model Context Protocol client and tool adapter |
+| MCP | `src/godspeed/mcp/` | Model Context Protocol client (stdio + SSE) and tool adapter |
 | Memory | `src/godspeed/memory/` | SQLite-backed preferences, session events, correction tracking |
+| Evolution | `src/godspeed/evolution/` | Trace analysis, GEPA mutations, LLM-as-judge fitness, safety gate, registry |
 | TUI | `src/godspeed/tui/` | Terminal UI, rich output, permission prompts, slash commands |
 
 ## Getting Started
@@ -164,6 +179,11 @@ The agent will read your code, answer questions, write files, and run commands -
 | `/extend [N]` | Set max iterations per turn (default: 50) |
 | `/context` | Show context window usage (tokens, percentage) |
 | `/plan` | Toggle plan mode (read-only, explore and plan only) |
+| `/architect` | Toggle architect mode (plan with read-only tools, then execute) |
+| `/think [budget]` | Toggle extended thinking for Claude models |
+| `/budget [amount]` | Show or set cost budget for the session |
+| `/autocommit` | Toggle auto-commit after successful edits |
+| `/evolve [cmd]` | Self-evolution: status, run, history, rollback, review |
 | `/checkpoint [name]` | Save conversation checkpoint, or list if no name |
 | `/restore <name>` | Restore a saved checkpoint |
 | `/pause` | Pause the agent loop at next iteration |
@@ -236,6 +256,12 @@ Permission rules use glob-style matching against `ToolName(argument)` strings. D
 | Deny-first permission engine | **Yes** (4-tier, 72+ dangerous patterns) | Proprietary | No | No | No |
 | Hash-chained audit trail | **Yes** (SHA-256 JSONL, verifiable) | No | No | No | No |
 | Secret protection | **4 layers** (deny, context clean, output filter, audit redact) | Limited | No | No | No |
+| Parallel tool execution | **Yes** (READ_ONLY parallel, write serial) | Yes | No | No | No |
+| Speculative tool dispatch | **Yes** (READ_ONLY pre-dispatched during streaming) | No | No | No | No |
+| Extended thinking | **Yes** (configurable budget, Claude models) | Yes | No | No | No |
+| Self-evolution | **Yes** (trace analysis → GEPA mutations → LLM judge → safety gate) | No | No | No | No |
+| Cost budgets | **Yes** (hard limit, `/budget` command) | No | No | No | No |
+| Architect mode | **Yes** (plan-then-execute, two-model) | No | No | Yes | No |
 | Multi-language verify | **6 languages** (Python, JS/TS, Go, Rust, C/C++) | Python | No | Python | LSP |
 | Test runner (auto-detect) | **5 frameworks** (pytest, jest, vitest, go, cargo) | Yes | No | Yes | No |
 | Web search & fetch | **Yes** (DuckDuckGo, no API key) | Yes | No | No | No |
@@ -244,12 +270,12 @@ Permission rules use glob-style matching against `ToolName(argument)` strings. D
 | Cross-agent config | **Yes** (GODSPEED.md, AGENTS.md, CLAUDE.md, .cursorrules) | CLAUDE.md only | .cursorrules only | No | AGENTS.md |
 | Prompt caching | **Yes** (Anthropic/OpenAI) | Yes | No | No | No |
 | Sub-agents | **Yes** (isolated, parallel, depth 3) | Yes | No | No | No |
-| MCP support | **Yes** (stdio transport) | Yes | Yes | No | No |
+| MCP support | **Yes** (stdio + SSE transport) | Yes | Yes | No | No |
 | Free by default | **Yes** (Ollama, zero API cost) | No (paid API) | No (subscription) | Yes | Yes |
 | 200+ LLM providers | **Yes** (LiteLLM) | Claude only | OpenAI/Claude | ~75 | 75+ |
 | Open source | **MIT** | No | No | Apache 2.0 | MIT |
 
-Godspeed is the only open-source coding agent that ships with production security primitives, multi-language verification, and cost tracking out of the box.
+Godspeed is the only open-source coding agent that ships with production security primitives, speculative tool dispatch, self-evolution, and multi-language verification out of the box.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed"
-version = "2.1.0"
+version = "2.2.0"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "godspeed"
-version = "1.0.0"
-description = "Security-first open-source coding agent with 4-tier permissions, hash-chained audit trails, and 200+ LLM provider support"
+version = "2.1.0"
+description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "1.0.0"
+__version__ = "2.1.0"

--- a/src/godspeed/agent/architect.py
+++ b/src/godspeed/agent/architect.py
@@ -1,0 +1,143 @@
+"""Architect mode — two-phase plan-then-execute pipeline."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from godspeed.agent.conversation import Conversation
+from godspeed.agent.loop import agent_loop
+from godspeed.llm.client import LLMClient
+from godspeed.tools.base import RiskLevel, ToolContext
+from godspeed.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+ARCHITECT_SYSTEM_PROMPT = (
+    "You are a code architect. Analyze the request and produce a detailed, "
+    "step-by-step implementation plan. Use read-only tools (file_read, glob_search, "
+    "grep_search, repo_map) to explore the codebase. "
+    "Do NOT write any code or modify any files. "
+    "Output a structured plan with numbered steps."
+)
+
+
+async def architect_loop(
+    user_input: str,
+    conversation: Conversation,
+    llm_client: LLMClient,
+    tool_registry: ToolRegistry,
+    tool_context: ToolContext,
+    architect_model: str = "",
+    on_phase_change: Any = None,  # Callable[[str, str], None] — (phase, model)
+    **kwargs: Any,
+) -> str:
+    """Run architect mode: plan phase -> execute phase.
+
+    Phase 1 (Plan): Calls architect_model (or main model) with read-only tools
+    and a planning system prompt. Produces a plan.
+
+    Phase 2 (Execute): Injects the plan as context, calls main model with full
+    tools to implement.
+    """
+    # Phase 1: Plan
+    plan_model = architect_model or llm_client.model
+    if on_phase_change:
+        on_phase_change("plan", plan_model)
+
+    # Create a filtered registry with only READ_ONLY tools
+    read_only_registry = _filter_read_only(tool_registry)
+
+    # Create a separate conversation for planning
+    plan_conversation = Conversation(
+        system_prompt=ARCHITECT_SYSTEM_PROMPT,
+        model=plan_model,
+        max_tokens=conversation.max_tokens,
+    )
+
+    # Temporarily switch model for planning if different
+    original_model = llm_client.model
+    if plan_model != original_model:
+        llm_client.model = plan_model
+
+    # Run planning phase
+    plan = await agent_loop(
+        user_input=user_input,
+        conversation=plan_conversation,
+        llm_client=llm_client,
+        tool_registry=read_only_registry,
+        tool_context=tool_context,
+        parallel_tool_calls=True,
+        **{
+            k: v
+            for k, v in kwargs.items()
+            if k
+            in {
+                "on_assistant_text",
+                "on_tool_call",
+                "on_tool_result",
+                "on_assistant_chunk",
+                "on_thinking",
+                "max_iterations",
+            }
+        },
+    )
+
+    # Restore original model
+    if plan_model != original_model:
+        llm_client.model = original_model
+
+    if not plan or plan.startswith("Error:"):
+        return plan or "Error: Architect planning phase produced no output."
+
+    # Phase 2: Execute
+    if on_phase_change:
+        on_phase_change("execute", llm_client.model)
+
+    # Inject plan as context for the execution phase
+    plan_context = (
+        f"An architect has analyzed the request and produced this implementation plan:\n\n"
+        f"---\n{plan}\n---\n\n"
+        f"Original request: {user_input}\n\n"
+        f"Execute this plan. Follow the steps precisely. You have full tool access."
+    )
+
+    result = await agent_loop(
+        user_input=plan_context,
+        conversation=conversation,
+        llm_client=llm_client,
+        tool_registry=tool_registry,
+        tool_context=tool_context,
+        parallel_tool_calls=True,
+        **{
+            k: v
+            for k, v in kwargs.items()
+            if k
+            in {
+                "on_assistant_text",
+                "on_tool_call",
+                "on_tool_result",
+                "on_assistant_chunk",
+                "on_thinking",
+                "max_iterations",
+                "on_permission_denied",
+                "hook_executor",
+                "auto_fix_retries",
+                "auto_commit",
+                "auto_commit_threshold",
+                "on_parallel_start",
+                "on_parallel_complete",
+            }
+        },
+    )
+
+    return result
+
+
+def _filter_read_only(registry: ToolRegistry) -> ToolRegistry:
+    """Create a new registry containing only READ_ONLY tools."""
+    filtered = ToolRegistry()
+    for tool in registry.list_tools():
+        if tool.risk_level == RiskLevel.READ_ONLY:
+            filtered.register(tool)
+    return filtered

--- a/src/godspeed/agent/auto_commit.py
+++ b/src/godspeed/agent/auto_commit.py
@@ -1,0 +1,75 @@
+"""Auto-commit workflow — generates commit messages and commits via GitPython."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import git
+
+from godspeed.llm.client import LLMClient
+from godspeed.tools.base import ToolResult
+
+logger = logging.getLogger(__name__)
+
+COMMIT_SYSTEM_PROMPT = (
+    "You are a git commit message generator. Write a conventional commit message "
+    "for these changes. Format: type(scope): description. One line, under 72 chars. "
+    "Return ONLY the commit message."
+)
+
+FALLBACK_MESSAGE = "chore: auto-commit from godspeed"
+
+
+async def generate_commit_message(changes: list[str], llm_client: LLMClient) -> str:
+    """Generate a conventional commit message from a list of change descriptions.
+
+    Makes a cheap LLM call to produce a one-line commit message. Falls back to a
+    generic message on any failure.
+
+    Args:
+        changes: List of change descriptions (e.g. "edited src/main.py").
+        llm_client: LLM client for the generation call.
+
+    Returns:
+        A conventional commit message string.
+    """
+    try:
+        messages = [
+            {"role": "system", "content": COMMIT_SYSTEM_PROMPT},
+            {"role": "user", "content": "\n".join(changes)},
+        ]
+        response = await llm_client.chat(messages=messages)
+        message = response.content.strip()
+        if message:
+            return message
+        logger.warning("LLM returned empty commit message, using fallback")
+        return FALLBACK_MESSAGE
+    except Exception as exc:
+        logger.warning("Failed to generate commit message error=%s, using fallback", exc)
+        return FALLBACK_MESSAGE
+
+
+async def auto_commit(repo_path: Path, message: str) -> ToolResult:
+    """Stage tracked changes and commit with attribution.
+
+    Uses GitPython to stage modified tracked files and create a commit with
+    Godspeed co-author attribution.
+
+    Args:
+        repo_path: Path to (or inside) the git repository.
+        message: Commit message to use.
+
+    Returns:
+        ToolResult with success or failure info.
+    """
+    try:
+        repo = git.Repo(repo_path, search_parent_directories=True)
+        repo.git.add("-u")
+        commit = repo.index.commit(f"{message}\n\nCo-Authored-By: Godspeed <noreply@godspeed.dev>")
+        sha = commit.hexsha[:8]
+        logger.info("Auto-committed sha=%s message=%s", sha, message)
+        return ToolResult.success(f"Auto-committed: {sha} {message}")
+    except Exception as exc:
+        logger.warning("Auto-commit failed error=%s", exc)
+        return ToolResult.failure(str(exc))

--- a/src/godspeed/agent/conversation.py
+++ b/src/godspeed/agent/conversation.py
@@ -45,8 +45,13 @@ class Conversation:
         """Check if we're approaching the context limit."""
         return self.token_count >= int(self.max_tokens * self.compaction_threshold)
 
-    def add_user_message(self, content: str) -> None:
-        """Add a user message."""
+    def add_user_message(self, content: str | list[dict[str, Any]]) -> None:
+        """Add a user message.
+
+        Args:
+            content: Either a plain text string or a list of content blocks
+                (e.g. text + image blocks in OpenAI multimodal format).
+        """
         self._messages.append({"role": "user", "content": content})
 
     def add_assistant_message(
@@ -119,3 +124,51 @@ class Conversation:
     def clear(self) -> None:
         """Clear all messages (keeps system prompt)."""
         self._messages.clear()
+
+
+def build_image_content_block(image_url: str) -> dict[str, Any]:
+    """Create an image content block for multimodal messages.
+
+    Args:
+        image_url: HTTP(S) URL or base64 data URI (data:image/...;base64,...).
+
+    Returns:
+        OpenAI-format image content block.
+
+    Raises:
+        ValueError: If the URL format is invalid.
+    """
+    if not image_url:
+        msg = "image_url must not be empty"
+        raise ValueError(msg)
+    if not (
+        image_url.startswith("http://")
+        or image_url.startswith("https://")
+        or image_url.startswith("data:image/")
+    ):
+        msg = (
+            f"Invalid image URL format: must be http(s):// or data:image/ URI, got {image_url[:50]}"
+        )
+        raise ValueError(msg)
+    return {"type": "image_url", "image_url": {"url": image_url}}
+
+
+def build_multimodal_message(
+    text: str,
+    images: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Build a list of content blocks combining text and images.
+
+    Args:
+        text: The text portion of the message.
+        images: Optional list of image URLs or base64 data URIs.
+
+    Returns:
+        List of content blocks suitable for Conversation.add_user_message().
+    """
+    blocks: list[dict[str, Any]] = []
+    if text:
+        blocks.append({"type": "text", "text": text})
+    for url in images or []:
+        blocks.append(build_image_content_block(url))
+    return blocks

--- a/src/godspeed/agent/events.py
+++ b/src/godspeed/agent/events.py
@@ -1,0 +1,111 @@
+"""Typed event protocol for the agent loop.
+
+Events replace callbacks for composable consumption. The callback-based
+agent_loop() remains for backward compat — it wraps agent_loop_events().
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ThinkingEvent:
+    """Extended thinking content from the LLM."""
+
+    text: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TextChunkEvent:
+    """Streaming text chunk from the LLM."""
+
+    text: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AssistantTextEvent:
+    """Complete assistant text response (model decided to stop)."""
+
+    text: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ToolCallEvent:
+    """A tool is about to be executed."""
+
+    tool_name: str
+    arguments: dict[str, Any]
+    call_id: str = ""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ToolResultEvent:
+    """Result from a tool execution."""
+
+    tool_name: str
+    output: str
+    is_error: bool = False
+    call_id: str = ""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PermissionDeniedEvent:
+    """A tool call was denied by the permission engine."""
+
+    tool_name: str
+    reason: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ParallelBatchStartEvent:
+    """Multiple tools starting in parallel."""
+
+    tools: list[tuple[str, dict[str, Any]]]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ParallelBatchCompleteEvent:
+    """Parallel tool batch completed."""
+
+    results: list[tuple[str, str, bool]]  # (tool_name, output, is_error)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BudgetExceededEvent:
+    """Cost budget was exceeded."""
+
+    spent: float
+    limit: float
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ErrorEvent:
+    """An error occurred in the agent loop."""
+
+    message: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PhaseChangeEvent:
+    """Architect mode phase change."""
+
+    phase: str  # "plan" or "execute"
+    model: str
+
+
+# Union type for all events
+AgentEvent = (
+    ThinkingEvent
+    | TextChunkEvent
+    | AssistantTextEvent
+    | ToolCallEvent
+    | ToolResultEvent
+    | PermissionDeniedEvent
+    | ParallelBatchStartEvent
+    | ParallelBatchCompleteEvent
+    | BudgetExceededEvent
+    | ErrorEvent
+    | PhaseChangeEvent
+)

--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -46,6 +46,9 @@ OnToolCall = Callable[[str, dict[str, Any]], None]
 OnToolResult = Callable[[str, ToolResult], None]
 OnPermissionDenied = Callable[[str, str], None]
 OnChunk = Callable[[str], None]
+OnParallelStart = Callable[[list[tuple[str, dict[str, Any]]]], None]
+OnParallelComplete = Callable[[list[tuple[str, str, bool]]], None]
+OnThinking = Callable[[str], None]
 
 
 async def agent_loop(
@@ -62,6 +65,14 @@ async def agent_loop(
     max_iterations: int | None = None,
     pause_event: asyncio.Event | None = None,
     hook_executor: Any | None = None,
+    parallel_tool_calls: bool = True,
+    skip_user_message: bool = False,
+    auto_fix_retries: int = 3,
+    auto_commit: bool = False,
+    auto_commit_threshold: int = 5,
+    on_parallel_start: OnParallelStart | None = None,
+    on_parallel_complete: OnParallelComplete | None = None,
+    on_thinking: OnThinking | None = None,
 ) -> str:
     """Run the agent loop until the model stops calling tools.
 
@@ -87,19 +98,25 @@ async def agent_loop(
         max_iterations: Override the default iteration limit (MAX_ITERATIONS).
         pause_event: Optional asyncio.Event for pause/resume. When cleared,
             the loop waits at the top of each iteration until set again.
+        parallel_tool_calls: Execute multiple tool calls concurrently when True
+            (default). Falls back to sequential when False or for single calls.
 
     Returns:
         The final assistant text response.
     """
     iteration_limit = max_iterations if max_iterations is not None else MAX_ITERATIONS
-    conversation.add_user_message(user_input)
+    if not skip_user_message and user_input:
+        conversation.add_user_message(user_input)
     tool_schemas = tool_registry.get_schemas()
 
     retries = 0
     final_text = ""
     recent_error_hashes: list[str] = []
     consecutive_writes = 0
+    consecutive_successful_edits = 0
+    recent_change_descriptions: list[str] = []
     auto_stashed = False
+    speculative_cache: dict[str, asyncio.Task[ToolResult]] = {}
 
     for iteration in range(iteration_limit):
         # Pause/resume: if pause_event exists and is cleared, wait for it
@@ -122,6 +139,9 @@ async def agent_loop(
                     conversation.messages,
                     tool_schemas if tool_schemas else None,
                     on_assistant_chunk,
+                    tool_registry=tool_registry,
+                    tool_context=tool_context,
+                    speculative_cache=speculative_cache,
                 )
             else:
                 response = await llm_client.chat(
@@ -129,8 +149,22 @@ async def agent_loop(
                     tools=tool_schemas if tool_schemas else None,
                 )
         except Exception as exc:
+            # Import here to avoid circular import at module level
+            from godspeed.llm.client import BudgetExceededError
+
+            if isinstance(exc, BudgetExceededError):
+                msg = (
+                    f"Budget exceeded (${exc.spent:.4f} / ${exc.limit:.2f} limit). "
+                    "Use /budget to increase the limit."
+                )
+                logger.warning("Budget exceeded spent=%.4f limit=%.2f", exc.spent, exc.limit)
+                return msg
             logger.error("LLM call failed error=%s", exc, exc_info=True)
             return f"Error: LLM call failed — {exc}"
+
+        # Display thinking blocks (extended thinking for Anthropic models)
+        if response.thinking and on_thinking:
+            on_thinking(response.thinking)
 
         # Handle text response (model decided to stop)
         if not response.has_tool_calls:
@@ -151,8 +185,15 @@ async def agent_loop(
         if response.content and on_assistant_text:
             on_assistant_text(response.content)
 
+        # --- Phase 1: Parse and pre-flight all tool calls ---
+        parsed_calls: list[tuple[dict[str, Any], ToolCall | None]] = []
         for raw_tc in response.tool_calls:
-            tool_call = _parse_tool_call(raw_tc)
+            parsed_calls.append((raw_tc, _parse_tool_call(raw_tc)))
+
+        # --- Phase 2: Permission checks + pre-tool hooks (sequential) ---
+        # These are fast and order-sensitive, so always sequential.
+        permitted: list[ToolCall] = []
+        for raw_tc, tool_call in parsed_calls:
             if tool_call is None:
                 retries += 1
                 if retries > MAX_RETRIES:
@@ -200,125 +241,442 @@ async def agent_loop(
                     )
                     continue
 
-            # Execute tool with latency tracking
+            permitted.append(tool_call)
+
+        if not permitted:
+            # All calls were malformed, denied, or blocked — continue to next LLM turn
+            continue
+
+        # --- Phase 3: Execute tools (parallel or sequential) ---
+        # Risk-based split: READ_ONLY tools run in parallel, write tools run serially
+        use_parallel = parallel_tool_calls and len(permitted) > 1
+
+        if use_parallel:
+            # Partition into read-only (parallel-safe) and write (serial) groups
+            from godspeed.tools.base import RiskLevel
+
+            read_only_calls: list[ToolCall] = []
+            write_calls: list[ToolCall] = []
+            for tc in permitted:
+                tool = tool_registry.get(tc.tool_name)
+                if tool is not None and tool.risk_level == RiskLevel.READ_ONLY:
+                    read_only_calls.append(tc)
+                else:
+                    write_calls.append(tc)
+
+            # Dispatch read-only tools in parallel
+            all_calls = read_only_calls + write_calls
+            # Notify TUI of parallel dispatch start
+            if on_parallel_start:
+                on_parallel_start([(tc.tool_name, tc.arguments) for tc in all_calls])
+
             t0 = time.monotonic()
-            result = await tool_registry.dispatch(tool_call, tool_context)
-            latency_ms = (time.monotonic() - t0) * 1000
+            parallel_results: list[ToolResult] = []
+            if read_only_calls:
+                # Check speculative cache for pre-dispatched READ_ONLY tools
+                coros = []
+                for tc in read_only_calls:
+                    cached_task = speculative_cache.pop(tc.call_id, None)
+                    if cached_task is not None:
+                        logger.debug("Speculative hit tool=%s call_id=%s", tc.tool_name, tc.call_id)
+                        coros.append(cached_task)
+                    else:
+                        coros.append(tool_registry.dispatch(tc, tool_context))
+                parallel_results = list(await asyncio.gather(*coros))
 
-            # Post-tool hook
-            if hook_executor is not None:
-                await asyncio.get_event_loop().run_in_executor(
-                    None, hook_executor.run_post_tool, tool_call.tool_name
-                )
+            # Dispatch write tools sequentially
+            serial_results: list[ToolResult] = []
+            for tc in write_calls:
+                result = await tool_registry.dispatch(tc, tool_context)
+                serial_results.append(result)
 
-            if on_tool_result:
-                on_tool_result(tool_call.tool_name, result)
-
-            # Record audit event with latency
-            if tool_context.audit is not None:
-                tool_context.audit.record(
-                    event_type="tool_call",
-                    detail={
-                        "tool": tool_call.tool_name,
-                        "arguments": tool_call.arguments,
-                        "output_length": len(result.output),
-                        "is_error": result.is_error,
-                        "latency_ms": round(latency_ms, 1),
-                    },
-                    outcome="error" if result.is_error else "success",
-                )
-
-            # Feed result back to conversation
-            result_content = result.error if result.is_error else result.output
-            conversation.add_tool_result(
-                tool_call_id=tool_call.call_id,
-                content=result_content or "",
+            # Combine results in the same order as all_calls
+            results = parallel_results + serial_results
+            permitted = all_calls  # Reorder to match results
+            batch_latency_ms = (time.monotonic() - t0) * 1000
+            logger.info(
+                "Parallel dispatch completed tools=%d latency_ms=%.1f",
+                len(permitted),
+                batch_latency_ms,
             )
 
-            # Auto-verify after successful file edits/writes
-            if (
-                not result.is_error
-                and tool_call.tool_name in ("file_edit", "file_write")
-                and tool_registry.has_tool("verify")
-            ):
-                file_path = tool_call.arguments.get("file_path", "")
-                if file_path and file_path.endswith(VERIFIABLE_EXTENSIONS):
-                    verify_call = ToolCall(
-                        tool_name="verify",
-                        arguments={"file_path": file_path},
-                        call_id=f"{tool_call.call_id}_verify",
-                    )
-                    verify_result = await tool_registry.dispatch(verify_call, tool_context)
-                    conversation.add_tool_result(
-                        tool_call_id=verify_call.call_id,
-                        content=verify_result.output or "",
-                    )
-                    logger.debug(
-                        "Auto-verify file=%s passed=%s",
-                        file_path,
-                        "passed" in verify_result.output.lower(),
+            # Process results in original order
+            for tool_call, result in zip(permitted, results, strict=True):
+                # Post-tool hook
+                if hook_executor is not None:
+                    await asyncio.get_event_loop().run_in_executor(
+                        None, hook_executor.run_post_tool, tool_call.tool_name
                     )
 
-            # Auto-stash: track consecutive write operations
-            if not result.is_error and tool_call.tool_name in ("file_edit", "file_write"):
-                consecutive_writes += 1
-                if (
-                    consecutive_writes >= AUTO_STASH_THRESHOLD
-                    and not auto_stashed
-                    and tool_registry.has_tool("git")
-                ):
-                    stash_call = ToolCall(
-                        tool_name="git",
-                        arguments={"action": "stash"},
-                        call_id=f"{tool_call.call_id}_autostash",
+                if on_tool_result:
+                    on_tool_result(tool_call.tool_name, result)
+
+                # Audit — use batch latency split evenly as approximation
+                if tool_context.audit is not None:
+                    tool_context.audit.record(
+                        event_type="tool_call",
+                        detail={
+                            "tool": tool_call.tool_name,
+                            "arguments": tool_call.arguments,
+                            "output_length": len(result.output),
+                            "is_error": result.is_error,
+                            "latency_ms": round(batch_latency_ms / len(permitted), 1),
+                            "parallel": True,
+                        },
+                        outcome="error" if result.is_error else "success",
                     )
-                    stash_result = await tool_registry.dispatch(stash_call, tool_context)
-                    if (
-                        not stash_result.is_error
-                        and "nothing to stash" not in (stash_result.output or "").lower()
-                    ):
-                        auto_stashed = True
-                        logger.info(
-                            "Auto-stash triggered after %d consecutive writes",
-                            consecutive_writes,
+
+                # Feed result to conversation
+                result_content = result.error if result.is_error else result.output
+                conversation.add_tool_result(
+                    tool_call_id=tool_call.call_id,
+                    content=result_content or "",
+                )
+
+            # Notify TUI of parallel dispatch completion
+            if on_parallel_complete:
+                on_parallel_complete(
+                    [
+                        (
+                            tc.tool_name,
+                            str(r.error) if r.is_error else str(r.output),
+                            r.is_error,
+                        )
+                        for tc, r in zip(permitted, results, strict=True)
+                    ]
+                )
+
+            # Auto-verify: run sequentially after parallel batch
+            for tool_call, result in zip(permitted, results, strict=True):
+                if (
+                    not result.is_error
+                    and tool_call.tool_name in ("file_edit", "file_write")
+                    and tool_registry.has_tool("verify")
+                ):
+                    file_path = tool_call.arguments.get("file_path", "")
+                    if file_path and file_path.endswith(VERIFIABLE_EXTENSIONS):
+                        verify_result = await _auto_verify_file(
+                            file_path,
+                            tool_call.call_id,
+                            tool_registry,
+                            tool_context,
+                            auto_fix_retries,
                         )
                         conversation.add_tool_result(
-                            tool_call_id=stash_call.call_id,
-                            content=(
-                                f"[Auto-stash] Saved working state after "
-                                f"{consecutive_writes} consecutive file edits. "
-                                f"Use git stash_pop to restore if needed."
-                            ),
+                            tool_call_id=f"{tool_call.call_id}_verify",
+                            content=verify_result.output or "",
                         )
+                        logger.debug(
+                            "Auto-verify file=%s passed=%s",
+                            file_path,
+                            "passed" in verify_result.output.lower(),
+                        )
+
+            # Auto-stash: count writes in batch
+            batch_writes = sum(
+                1
+                for tc, r in zip(permitted, results, strict=True)
+                if not r.is_error and tc.tool_name in ("file_edit", "file_write")
+            )
+            batch_has_non_write = any(
+                tc.tool_name not in ("file_edit", "file_write") for tc in permitted
+            )
+            if batch_has_non_write:
+                consecutive_writes = batch_writes
             else:
-                consecutive_writes = 0
+                consecutive_writes += batch_writes
 
-            # Stuck-loop detection: track repeated errors
-            if result.is_error:
-                error_hash = hashlib.sha256((result_content or "").encode()).hexdigest()
-                recent_error_hashes.append(error_hash)
-                if len(recent_error_hashes) > STUCK_LOOP_THRESHOLD:
-                    recent_error_hashes.pop(0)
-
+            if (
+                consecutive_writes >= AUTO_STASH_THRESHOLD
+                and not auto_stashed
+                and tool_registry.has_tool("git")
+            ):
+                stash_call = ToolCall(
+                    tool_name="git",
+                    arguments={"action": "stash"},
+                    call_id=f"{permitted[-1].call_id}_autostash",
+                )
+                stash_result = await tool_registry.dispatch(stash_call, tool_context)
                 if (
-                    len(recent_error_hashes) == STUCK_LOOP_THRESHOLD
-                    and len(set(recent_error_hashes)) == 1
+                    not stash_result.is_error
+                    and "nothing to stash" not in (stash_result.output or "").lower()
                 ):
-                    logger.warning(
-                        "Stuck loop detected: %d identical errors hash=%s",
-                        STUCK_LOOP_THRESHOLD,
-                        error_hash[:12],
+                    auto_stashed = True
+                    logger.info(
+                        "Auto-stash triggered after %d consecutive writes",
+                        consecutive_writes,
                     )
-                    conversation.add_user_message(
-                        "You have failed 3 times with the same error. "
-                        "Stop, explain what is wrong, and try a completely "
-                        "different approach."
+                    conversation.add_tool_result(
+                        tool_call_id=stash_call.call_id,
+                        content=(
+                            f"[Auto-stash] Saved working state after "
+                            f"{consecutive_writes} consecutive file edits. "
+                            f"Use git stash_pop to restore if needed."
+                        ),
                     )
+
+            # Auto-commit tracking for parallel batch
+            for tc, r in zip(permitted, results, strict=True):
+                if not r.is_error and tc.tool_name in ("file_edit", "file_write"):
+                    consecutive_successful_edits += 1
+                    desc = f"{tc.tool_name} {tc.arguments.get('file_path', '?')}"
+                    recent_change_descriptions.append(desc)
+
+            if auto_commit and consecutive_successful_edits >= auto_commit_threshold:
+                committed = await _try_auto_commit(
+                    list(recent_change_descriptions),
+                    tool_context,
+                    llm_client,
+                    conversation,
+                    permitted[-1].call_id,
+                )
+                if committed:
+                    consecutive_successful_edits = 0
+                    recent_change_descriptions.clear()
+
+            # Stuck-loop: check across batch results
+            for _tool_call, result in zip(permitted, results, strict=True):
+                result_content = result.error if result.is_error else result.output
+                if result.is_error:
+                    error_hash = hashlib.sha256((result_content or "").encode()).hexdigest()
+                    recent_error_hashes.append(error_hash)
+                    if len(recent_error_hashes) > STUCK_LOOP_THRESHOLD:
+                        recent_error_hashes.pop(0)
+                else:
                     recent_error_hashes.clear()
-            else:
+
+            if (
+                len(recent_error_hashes) == STUCK_LOOP_THRESHOLD
+                and len(set(recent_error_hashes)) == 1
+            ):
+                logger.warning(
+                    "Stuck loop detected: %d identical errors",
+                    STUCK_LOOP_THRESHOLD,
+                )
+                conversation.add_user_message(
+                    "You have failed 3 times with the same error. "
+                    "Stop, explain what is wrong, and try a completely "
+                    "different approach."
+                )
                 recent_error_hashes.clear()
 
+        else:
+            # Sequential dispatch (single call or parallel disabled)
+            for tool_call in permitted:
+                # Execute tool with latency tracking (check speculative cache first)
+                t0 = time.monotonic()
+                cached_task = speculative_cache.pop(tool_call.call_id, None)
+                if cached_task is not None:
+                    logger.debug(
+                        "Speculative hit (sequential) tool=%s call_id=%s",
+                        tool_call.tool_name,
+                        tool_call.call_id,
+                    )
+                    result = await cached_task
+                else:
+                    result = await tool_registry.dispatch(tool_call, tool_context)
+                latency_ms = (time.monotonic() - t0) * 1000
+
+                # Post-tool hook
+                if hook_executor is not None:
+                    await asyncio.get_event_loop().run_in_executor(
+                        None, hook_executor.run_post_tool, tool_call.tool_name
+                    )
+
+                if on_tool_result:
+                    on_tool_result(tool_call.tool_name, result)
+
+                # Record audit event with latency
+                if tool_context.audit is not None:
+                    tool_context.audit.record(
+                        event_type="tool_call",
+                        detail={
+                            "tool": tool_call.tool_name,
+                            "arguments": tool_call.arguments,
+                            "output_length": len(result.output),
+                            "is_error": result.is_error,
+                            "latency_ms": round(latency_ms, 1),
+                        },
+                        outcome="error" if result.is_error else "success",
+                    )
+
+                # Feed result back to conversation
+                result_content = result.error if result.is_error else result.output
+                conversation.add_tool_result(
+                    tool_call_id=tool_call.call_id,
+                    content=result_content or "",
+                )
+
+                # Auto-verify after successful file edits/writes
+                if (
+                    not result.is_error
+                    and tool_call.tool_name in ("file_edit", "file_write")
+                    and tool_registry.has_tool("verify")
+                ):
+                    file_path = tool_call.arguments.get("file_path", "")
+                    if file_path and file_path.endswith(VERIFIABLE_EXTENSIONS):
+                        verify_result = await _auto_verify_file(
+                            file_path,
+                            tool_call.call_id,
+                            tool_registry,
+                            tool_context,
+                            auto_fix_retries,
+                        )
+                        conversation.add_tool_result(
+                            tool_call_id=f"{tool_call.call_id}_verify",
+                            content=verify_result.output or "",
+                        )
+                        logger.debug(
+                            "Auto-verify file=%s passed=%s",
+                            file_path,
+                            "passed" in verify_result.output.lower(),
+                        )
+
+                # Auto-stash: track consecutive write operations
+                if not result.is_error and tool_call.tool_name in (
+                    "file_edit",
+                    "file_write",
+                ):
+                    consecutive_writes += 1
+                    if (
+                        consecutive_writes >= AUTO_STASH_THRESHOLD
+                        and not auto_stashed
+                        and tool_registry.has_tool("git")
+                    ):
+                        stash_call = ToolCall(
+                            tool_name="git",
+                            arguments={"action": "stash"},
+                            call_id=f"{tool_call.call_id}_autostash",
+                        )
+                        stash_result = await tool_registry.dispatch(stash_call, tool_context)
+                        if (
+                            not stash_result.is_error
+                            and "nothing to stash" not in (stash_result.output or "").lower()
+                        ):
+                            auto_stashed = True
+                            logger.info(
+                                "Auto-stash triggered after %d consecutive writes",
+                                consecutive_writes,
+                            )
+                            conversation.add_tool_result(
+                                tool_call_id=stash_call.call_id,
+                                content=(
+                                    f"[Auto-stash] Saved working state after "
+                                    f"{consecutive_writes} consecutive file edits. "
+                                    f"Use git stash_pop to restore if needed."
+                                ),
+                            )
+                    # Auto-commit tracking
+                    consecutive_successful_edits += 1
+                    desc = f"{tool_call.tool_name} {tool_call.arguments.get('file_path', '?')}"
+                    recent_change_descriptions.append(desc)
+
+                    if auto_commit and consecutive_successful_edits >= auto_commit_threshold:
+                        committed = await _try_auto_commit(
+                            list(recent_change_descriptions),
+                            tool_context,
+                            llm_client,
+                            conversation,
+                            tool_call.call_id,
+                        )
+                        if committed:
+                            consecutive_successful_edits = 0
+                            recent_change_descriptions.clear()
+                else:
+                    consecutive_writes = 0
+                    consecutive_successful_edits = 0
+                    recent_change_descriptions = []
+
+                # Stuck-loop detection: track repeated errors
+                if result.is_error:
+                    error_hash = hashlib.sha256((result_content or "").encode()).hexdigest()
+                    recent_error_hashes.append(error_hash)
+                    if len(recent_error_hashes) > STUCK_LOOP_THRESHOLD:
+                        recent_error_hashes.pop(0)
+
+                    if (
+                        len(recent_error_hashes) == STUCK_LOOP_THRESHOLD
+                        and len(set(recent_error_hashes)) == 1
+                    ):
+                        logger.warning(
+                            "Stuck loop detected: %d identical errors hash=%s",
+                            STUCK_LOOP_THRESHOLD,
+                            error_hash[:12],
+                        )
+                        conversation.add_user_message(
+                            "You have failed 3 times with the same error. "
+                            "Stop, explain what is wrong, and try a completely "
+                            "different approach."
+                        )
+                        recent_error_hashes.clear()
+                else:
+                    recent_error_hashes.clear()
+
     return "Error: Reached maximum iterations. The task may be too complex for a single turn."
+
+
+async def _auto_verify_file(
+    file_path: str,
+    parent_call_id: str,
+    tool_registry: ToolRegistry,
+    tool_context: ToolContext,
+    auto_fix_retries: int,
+) -> ToolResult:
+    """Run auto-verify on a file, using the retry loop when retries > 0.
+
+    Falls back to plain verify dispatch when retries are disabled (0).
+    """
+    from pathlib import Path
+
+    from godspeed.tools.verify import _EXTENSION_MAP, _verify_with_retry
+
+    resolved = Path(file_path) if Path(file_path).is_absolute() else (tool_context.cwd / file_path)
+    suffix = resolved.suffix.lower()
+    lang = _EXTENSION_MAP.get(suffix)
+
+    if auto_fix_retries > 0 and lang is not None:
+        # Use the retry loop (runs synchronously in the subprocess calls)
+        return _verify_with_retry(
+            resolved=resolved,
+            display_path=file_path,
+            lang=lang,
+            cwd=tool_context.cwd,
+            max_retries=auto_fix_retries,
+        )
+
+    # Fallback: plain verify dispatch (one-shot)
+    verify_call = ToolCall(
+        tool_name="verify",
+        arguments={"file_path": file_path},
+        call_id=f"{parent_call_id}_verify",
+    )
+    return await tool_registry.dispatch(verify_call, tool_context)
+
+
+async def _try_auto_commit(
+    change_descriptions: list[str],
+    tool_context: ToolContext,
+    llm_client: LLMClient,
+    conversation: Conversation,
+    parent_call_id: str,
+) -> bool:
+    """Attempt an auto-commit with LLM-generated message. Returns True on success."""
+    from godspeed.agent.auto_commit import auto_commit, generate_commit_message
+
+    try:
+        message = await generate_commit_message(change_descriptions, llm_client)
+        result = await auto_commit(tool_context.cwd, message)
+        if not result.is_error:
+            logger.info("Auto-commit succeeded message=%s", message)
+            conversation.add_tool_result(
+                tool_call_id=f"{parent_call_id}_autocommit",
+                content=f"[Auto-commit] {result.output}",
+            )
+            return True
+        logger.warning("Auto-commit failed: %s", result.error)
+    except Exception as exc:
+        logger.warning("Auto-commit error: %s", exc)
+    return False
 
 
 def _parse_tool_call(raw: dict[str, Any]) -> ToolCall | None:
@@ -350,14 +708,22 @@ async def _compact_conversation(conversation: Conversation, llm_client: LLMClien
     """Compact conversation by summarizing history via a separate LLM call.
 
     Uses model-aware compaction prompts — small models get aggressive summarization,
-    frontier models get detailed preservation.
+    frontier models get detailed preservation. Picks the cheapest available model
+    from the fallback chain to minimize compaction cost.
     """
     from godspeed.context.compaction import get_compaction_prompt
+    from godspeed.llm.cost import get_cheapest_model
 
     model_name = getattr(llm_client, "model", "")
     logger.info("Compacting conversation tokens=%d model=%s", conversation.token_count, model_name)
 
-    prompt = get_compaction_prompt(model_name) if model_name else get_compaction_prompt("")
+    # Use cheapest model for compaction
+    candidates = [model_name, *getattr(llm_client, "fallback_models", [])]
+    cheapest = get_cheapest_model(candidates)
+    if cheapest and cheapest != model_name:
+        logger.info("Compaction using cheaper model=%s (instead of %s)", cheapest, model_name)
+
+    prompt = get_compaction_prompt(cheapest or model_name)
     context = conversation.get_compaction_context()
     summary_messages = [
         {"role": "system", "content": prompt},
@@ -365,7 +731,10 @@ async def _compact_conversation(conversation: Conversation, llm_client: LLMClien
     ]
 
     try:
-        response = await llm_client.chat(messages=summary_messages)
+        response = await llm_client.chat(
+            messages=summary_messages,
+            task_type="compaction",
+        )
         conversation.compact(response.content)
     except Exception as exc:
         logger.error("Compaction failed error=%s", exc, exc_info=True)
@@ -377,8 +746,16 @@ async def _streaming_call(
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None,
     on_chunk: Callable[[str], None],
+    tool_registry: ToolRegistry | None = None,
+    tool_context: ToolContext | None = None,
+    speculative_cache: dict[str, asyncio.Task[ToolResult]] | None = None,
 ) -> ChatResponse:
     """Make a streaming LLM call, invoking on_chunk for each text delta.
+
+    When tool_registry and tool_context are provided, speculatively dispatches
+    READ_ONLY tool calls as soon as the final response arrives — before the
+    main loop processes them. Results are stored in speculative_cache so the
+    main loop can await them instead of re-dispatching.
 
     Returns the final complete ChatResponse for conversation history.
     """
@@ -396,4 +773,48 @@ async def _streaming_call(
         # Stream ended without a finish_reason — shouldn't happen but be safe
         return ChatResponse(content="", tool_calls=[], finish_reason="stop", usage={})
 
+    # Speculative execution: start READ_ONLY tools immediately
+    if (
+        final_response.has_tool_calls
+        and tool_registry is not None
+        and tool_context is not None
+        and speculative_cache is not None
+    ):
+        _speculative_dispatch(
+            final_response.tool_calls,
+            tool_registry,
+            tool_context,
+            speculative_cache,
+        )
+
     return final_response
+
+
+def _speculative_dispatch(
+    raw_tool_calls: list[dict[str, Any]],
+    tool_registry: ToolRegistry,
+    tool_context: ToolContext,
+    cache: dict[str, asyncio.Task[ToolResult]],
+) -> None:
+    """Start READ_ONLY tool calls speculatively as background tasks.
+
+    Parses each tool call and checks risk level. If READ_ONLY, dispatches
+    immediately and stores the asyncio.Task in cache keyed by call_id.
+    The main loop checks the cache before dispatching to avoid double work.
+    """
+    from godspeed.tools.base import RiskLevel
+
+    for raw_tc in raw_tool_calls:
+        parsed = _parse_tool_call(raw_tc)
+        if parsed is None:
+            continue
+
+        tool = tool_registry.get(parsed.tool_name)
+        if tool is None or tool.risk_level != RiskLevel.READ_ONLY:
+            continue
+
+        call_id = parsed.call_id
+        if call_id and call_id not in cache:
+            logger.debug("Speculative dispatch tool=%s call_id=%s", parsed.tool_name, call_id)
+            task = asyncio.create_task(tool_registry.dispatch(parsed, tool_context))
+            cache[call_id] = task

--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -281,7 +281,7 @@ async def agent_loop(
                         logger.debug("Speculative hit tool=%s call_id=%s", tc.tool_name, tc.call_id)
                         coros.append(cached_task)
                     else:
-                        coros.append(tool_registry.dispatch(tc, tool_context))
+                        coros.append(asyncio.create_task(tool_registry.dispatch(tc, tool_context)))
                 parallel_results = list(await asyncio.gather(*coros))
 
             # Dispatch write tools sequentially

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -131,9 +131,11 @@ def _build_tool_registry() -> tuple:
     registry = ToolRegistry()
     risk_levels: dict[str, RiskLevel] = {}
 
+    from godspeed.tools.background import BackgroundCheckTool
     from godspeed.tools.git import GitTool
     from godspeed.tools.glob_search import GlobSearchTool
     from godspeed.tools.grep_search import GrepSearchTool
+    from godspeed.tools.notebook import NotebookEditTool
     from godspeed.tools.repo_map import RepoMapTool
     from godspeed.tools.shell import ShellTool
     from godspeed.tools.test_runner import TestRunnerTool
@@ -141,7 +143,7 @@ def _build_tool_registry() -> tuple:
     from godspeed.tools.web_fetch import WebFetchTool
     from godspeed.tools.web_search import WebSearchTool
 
-    tools = [
+    tools: list = [
         FileReadTool(),
         FileWriteTool(),
         FileEditTool(),
@@ -154,7 +156,38 @@ def _build_tool_registry() -> tuple:
         TestRunnerTool(),
         WebSearchTool(),
         WebFetchTool(),
+        NotebookEditTool(),
+        BackgroundCheckTool(),
     ]
+
+    # Optional tools — register if their dependencies are available
+    try:
+        from godspeed.tools.image_read import ImageReadTool
+
+        tools.append(ImageReadTool())
+    except ImportError:
+        pass
+
+    try:
+        from godspeed.tools.pdf_read import PdfReadTool
+
+        tools.append(PdfReadTool())
+    except ImportError:
+        pass
+
+    try:
+        from godspeed.tools.github import GithubTool
+
+        tools.append(GithubTool())
+    except ImportError:
+        pass
+
+    try:
+        from godspeed.tools.diff_apply import DiffApplyTool
+
+        tools.append(DiffApplyTool())
+    except ImportError:
+        pass
 
     for tool in tools:
         registry.register(tool)
@@ -260,6 +293,8 @@ async def _run_app(
         model=effective_model,
         fallback_models=settings.fallback_models,
         router=router,
+        thinking_budget=settings.thinking_budget,
+        max_cost_usd=settings.max_cost_usd,
     )
 
     # Conversation
@@ -283,6 +318,9 @@ async def _run_app(
                     command=server_cfg.get("command", ""),
                     args=server_cfg.get("args", []),
                     env=server_cfg.get("env", {}),
+                    transport=server_cfg.get("transport", "stdio"),
+                    url=server_cfg.get("url"),
+                    headers=server_cfg.get("headers"),
                 )
                 try:
                     definitions = await mcp_client.connect(config)
@@ -656,6 +694,8 @@ async def _headless_run(
         model=effective_model,
         fallback_models=settings.fallback_models,
         router=router,
+        thinking_budget=settings.thinking_budget,
+        max_cost_usd=settings.max_cost_usd,
     )
 
     conversation = Conversation(

--- a/src/godspeed/config.py
+++ b/src/godspeed/config.py
@@ -156,11 +156,43 @@ class GodspeedSettings(BaseSettings):
     # Model routing — map task types to specific models
     routing: dict[str, str] = Field(default_factory=dict)
 
-    # MCP servers
-    mcp_servers: list[dict[str, Any]] = Field(default_factory=list)
+    # MCP servers — each entry is a dict with keys:
+    #   name:      str   — unique server identifier (required)
+    #   transport: str   — "stdio" (default) or "sse"
+    #   command:   str   — executable for stdio transport
+    #   args:      list  — CLI args for stdio transport
+    #   env:       dict  — extra env vars for stdio subprocess
+    #   url:       str   — base URL for sse transport (e.g. "http://localhost:3001")
+    #   headers:   dict  — HTTP headers for sse transport (e.g. Authorization)
+    mcp_servers: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "MCP server configurations. Each entry supports 'stdio' transport "
+            "(command, args, env) or 'sse' transport (url, headers). "
+            "Defaults to stdio when transport is omitted."
+        ),
+    )
 
     # Hooks — shell commands at lifecycle events
     hooks: list[dict[str, Any]] = Field(default_factory=list)
+
+    # Agent behavior
+    parallel_tool_calls: bool = True
+    auto_fix_retries: int = 3  # lint-fix retry rounds (0 = one-shot, no auto-fix)
+    auto_commit: bool = False
+    auto_commit_threshold: int = 5
+
+    # Thinking — extended thinking for Anthropic/Claude models
+    thinking_budget: int = 0  # 0 = disabled; >0 = budget_tokens for thinking blocks
+
+    # Cost budget — hard limit on session spend (0 = unlimited)
+    max_cost_usd: float = 0.0
+
+    # Architect mode — two-model pipeline (plan then execute)
+    architect_model: str = ""  # model for planning phase; empty = use main model
+
+    # Sandboxing
+    sandbox: str = "none"  # "none" | "docker"
 
     # Memory
     memory_enabled: bool = True

--- a/src/godspeed/config.py
+++ b/src/godspeed/config.py
@@ -194,6 +194,10 @@ class GodspeedSettings(BaseSettings):
     # Sandboxing
     sandbox: str = "none"  # "none" | "docker"
 
+    # Self-evolution — learn from execution traces to improve prompts/tools
+    evolution_enabled: bool = False  # enable with /evolve or config
+    evolution_model: str = ""  # model for mutations/judging; empty = auto-detect
+
     # Memory
     memory_enabled: bool = True
 

--- a/src/godspeed/evolution/__init__.py
+++ b/src/godspeed/evolution/__init__.py
@@ -1,0 +1,3 @@
+"""Godspeed self-evolution system — learn from execution traces to improve prompts and tools."""
+
+from __future__ import annotations

--- a/src/godspeed/evolution/applier.py
+++ b/src/godspeed/evolution/applier.py
@@ -1,0 +1,141 @@
+"""Evolution applier — runtime hot-swap of evolved artifacts.
+
+Applies mutations to tool descriptions, system prompt sections, and skills
+at runtime. Supports rollback on regression. Loads applied overrides on startup.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from godspeed.evolution.registry import EvolutionRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class EvolutionApplier:
+    """Apply evolved artifacts at runtime without restart.
+
+    Manages the lifecycle of applied mutations:
+    - Apply: update tool descriptions or save prompt overrides
+    - Rollback: restore originals
+    - Load: restore applied state on startup
+    """
+
+    def __init__(self, registry: EvolutionRegistry) -> None:
+        self._registry = registry
+        self._description_overrides: dict[str, str] = {}  # tool_name -> description
+        self._prompt_overrides: dict[str, str] = {}  # section_name -> text
+
+    @property
+    def description_overrides(self) -> dict[str, str]:
+        """Currently active tool description overrides."""
+        return dict(self._description_overrides)
+
+    @property
+    def prompt_overrides(self) -> dict[str, str]:
+        """Currently active prompt section overrides."""
+        return dict(self._prompt_overrides)
+
+    def load_applied(self) -> int:
+        """Load all previously applied mutations from disk.
+
+        Called on startup to restore evolution state.
+
+        Returns:
+            Number of overrides loaded.
+        """
+        count = 0
+        for applied_data in self._registry.list_applied():
+            artifact_type = applied_data.get("artifact_type", "")
+            artifact_id = applied_data.get("artifact_id", "")
+            mutated_text = applied_data.get("mutated_text", "")
+
+            if not artifact_id or not mutated_text:
+                continue
+
+            if artifact_type == "tool_description":
+                self._description_overrides[artifact_id] = mutated_text
+                count += 1
+            elif artifact_type == "prompt_section":
+                self._prompt_overrides[artifact_id] = mutated_text
+                count += 1
+            elif artifact_type == "skill":
+                # Skills are written as files — they persist on disk
+                count += 1
+
+        if count > 0:
+            logger.info("Loaded %d evolution overrides", count)
+        return count
+
+    def apply_tool_description(
+        self, record_id: str, tool_name: str, mutated_text: str, original_text: str
+    ) -> None:
+        """Apply a tool description mutation.
+
+        Updates the in-memory override and persists to registry.
+        """
+        self._registry.save_original(tool_name, original_text)
+        self._registry.mark_applied(record_id, mutated_text)
+        self._description_overrides[tool_name] = mutated_text
+        logger.info("Applied tool description evolution tool=%s record=%s", tool_name, record_id)
+
+    def apply_prompt_section(
+        self, record_id: str, section_name: str, mutated_text: str, original_text: str
+    ) -> None:
+        """Apply a prompt section mutation."""
+        self._registry.save_original(section_name, original_text)
+        self._registry.mark_applied(record_id, mutated_text)
+        self._prompt_overrides[section_name] = mutated_text
+        logger.info(
+            "Applied prompt section evolution section=%s record=%s", section_name, record_id
+        )
+
+    def apply_skill(
+        self, record_id: str, skill_name: str, skill_content: str, skills_dir: Path
+    ) -> None:
+        """Apply a skill mutation by writing a skill file."""
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        skill_path = skills_dir / f"{skill_name}.md"
+        skill_path.write_text(skill_content, encoding="utf-8")
+        self._registry.mark_applied(record_id, skill_content)
+        logger.info("Applied skill evolution skill=%s path=%s", skill_name, skill_path)
+
+    def rollback(self, record_id: str) -> bool:
+        """Rollback a specific mutation.
+
+        Returns:
+            True if rollback succeeded.
+        """
+        record = self._registry.get_record(record_id)
+        if record is None:
+            logger.warning("Cannot rollback — record not found id=%s", record_id)
+            return False
+
+        if not record.applied_at:
+            logger.warning("Cannot rollback — record was never applied id=%s", record_id)
+            return False
+
+        if (
+            record.artifact_type == "tool_description"
+            and record.artifact_id in self._description_overrides
+        ):
+            del self._description_overrides[record.artifact_id]
+        elif (
+            record.artifact_type == "prompt_section"
+            and record.artifact_id in self._prompt_overrides
+        ):
+            del self._prompt_overrides[record.artifact_id]
+
+        self._registry.mark_reverted(record_id)
+        logger.info("Rolled back evolution record=%s artifact=%s", record_id, record.artifact_id)
+        return True
+
+    def get_tool_description(self, tool_name: str, default: str) -> str:
+        """Get the effective tool description (override or default)."""
+        return self._description_overrides.get(tool_name, default)
+
+    def get_prompt_section(self, section_name: str, default: str) -> str:
+        """Get the effective prompt section (override or default)."""
+        return self._prompt_overrides.get(section_name, default)

--- a/src/godspeed/evolution/cross_session.py
+++ b/src/godspeed/evolution/cross_session.py
@@ -1,0 +1,254 @@
+"""Cross-session learning — aggregate insights and detect regressions.
+
+Analyzes patterns across multiple sessions, provides model-specific tuning
+recommendations, and detects regressions after mutations are applied.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections import Counter
+
+from godspeed.evolution.trace_analyzer import (
+    SessionTrace,
+    TraceAnalyzer,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AggregateReport:
+    """Combined insights from multiple sessions."""
+
+    total_sessions: int
+    total_tool_calls: int
+    total_errors: int
+    error_rate: float
+    tool_error_rates: tuple[tuple[str, float, int], ...]  # (tool_name, error_rate, count)
+    model_distribution: tuple[tuple[str, int], ...]  # (model_name, session_count)
+    avg_session_latency_ms: float
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ModelReport:
+    """Model-specific analysis."""
+
+    model: str
+    sessions: int
+    tool_error_rates: tuple[tuple[str, float, int], ...]
+    avg_latency_ms: float
+    most_failed_tool: str
+    most_failed_rate: float
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ImpactReport:
+    """Before/after comparison for an evolution change."""
+
+    artifact_id: str
+    before_error_rate: float
+    after_error_rate: float
+    delta: float  # negative = improvement
+    before_sessions: int
+    after_sessions: int
+    improved: bool
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RegressionAlert:
+    """Alert for a detected regression after mutation."""
+
+    artifact_id: str
+    record_id: str
+    before_error_rate: float
+    after_error_rate: float
+    delta: float
+    recommendation: str  # "rollback" | "monitor" | "investigate"
+
+
+# ---------------------------------------------------------------------------
+# Cross-Session Analyzer
+# ---------------------------------------------------------------------------
+
+
+class CrossSessionAnalyzer:
+    """Aggregate insights across sessions and detect regressions."""
+
+    def __init__(self) -> None:
+        self._analyzer = TraceAnalyzer()
+
+    def aggregate_sessions(self, sessions: list[SessionTrace]) -> AggregateReport:
+        """Combine insights from multiple sessions."""
+        total_calls = 0
+        total_errors = 0
+        tool_calls: Counter[str] = Counter()
+        tool_errors: Counter[str] = Counter()
+        model_counts: Counter[str] = Counter()
+        total_latency = 0.0
+
+        for session in sessions:
+            model_counts[session.model or "unknown"] += 1
+            total_latency += session.total_latency_ms
+            for tc in session.tool_calls:
+                total_calls += 1
+                tool_calls[tc.tool_name] += 1
+                if tc.is_error:
+                    total_errors += 1
+                    tool_errors[tc.tool_name] += 1
+
+        error_rate = total_errors / total_calls if total_calls > 0 else 0.0
+
+        tool_error_rates: list[tuple[str, float, int]] = []
+        for tool_name, count in tool_calls.most_common():
+            errs = tool_errors.get(tool_name, 0)
+            rate = errs / count if count > 0 else 0.0
+            tool_error_rates.append((tool_name, rate, count))
+
+        # Sort by error rate descending
+        tool_error_rates.sort(key=lambda x: x[1], reverse=True)
+
+        avg_latency = total_latency / len(sessions) if sessions else 0.0
+
+        return AggregateReport(
+            total_sessions=len(sessions),
+            total_tool_calls=total_calls,
+            total_errors=total_errors,
+            error_rate=error_rate,
+            tool_error_rates=tuple(tool_error_rates),
+            model_distribution=tuple(model_counts.most_common()),
+            avg_session_latency_ms=avg_latency,
+        )
+
+    def model_specific_analysis(self, sessions: list[SessionTrace], model: str) -> ModelReport:
+        """Analyze sessions for a specific model."""
+        model_sessions = [s for s in sessions if s.model == model]
+
+        tool_calls: Counter[str] = Counter()
+        tool_errors: Counter[str] = Counter()
+        total_latency = 0.0
+
+        for session in model_sessions:
+            total_latency += session.total_latency_ms
+            for tc in session.tool_calls:
+                tool_calls[tc.tool_name] += 1
+                if tc.is_error:
+                    tool_errors[tc.tool_name] += 1
+
+        tool_error_rates: list[tuple[str, float, int]] = []
+        for tool_name, count in tool_calls.most_common():
+            errs = tool_errors.get(tool_name, 0)
+            rate = errs / count if count > 0 else 0.0
+            tool_error_rates.append((tool_name, rate, count))
+
+        tool_error_rates.sort(key=lambda x: x[1], reverse=True)
+
+        most_failed = tool_error_rates[0] if tool_error_rates else ("none", 0.0, 0)
+        avg_latency = total_latency / len(model_sessions) if model_sessions else 0.0
+
+        return ModelReport(
+            model=model,
+            sessions=len(model_sessions),
+            tool_error_rates=tuple(tool_error_rates),
+            avg_latency_ms=avg_latency,
+            most_failed_tool=most_failed[0],
+            most_failed_rate=most_failed[1],
+        )
+
+    def track_evolution_impact(
+        self,
+        before_sessions: list[SessionTrace],
+        after_sessions: list[SessionTrace],
+        artifact_id: str,
+    ) -> ImpactReport:
+        """Compare error rates before and after a mutation was applied."""
+        before_errors, before_total = self._count_tool_errors(before_sessions, artifact_id)
+        after_errors, after_total = self._count_tool_errors(after_sessions, artifact_id)
+
+        before_rate = before_errors / before_total if before_total > 0 else 0.0
+        after_rate = after_errors / after_total if after_total > 0 else 0.0
+        delta = after_rate - before_rate
+
+        return ImpactReport(
+            artifact_id=artifact_id,
+            before_error_rate=before_rate,
+            after_error_rate=after_rate,
+            delta=delta,
+            before_sessions=len(before_sessions),
+            after_sessions=len(after_sessions),
+            improved=delta < 0,
+        )
+
+    def detect_regression(
+        self,
+        before_sessions: list[SessionTrace],
+        after_sessions: list[SessionTrace],
+        threshold: float = 0.1,
+    ) -> list[RegressionAlert]:
+        """Detect tools that regressed after mutations were applied."""
+        before_rates = self._tool_error_rates(before_sessions)
+        after_rates = self._tool_error_rates(after_sessions)
+
+        alerts: list[RegressionAlert] = []
+        for tool_name, after_rate in after_rates.items():
+            before_rate = before_rates.get(tool_name, 0.0)
+            delta = after_rate - before_rate
+
+            if delta > threshold:
+                if delta > 0.3:
+                    recommendation = "rollback"
+                elif delta > 0.15:
+                    recommendation = "investigate"
+                else:
+                    recommendation = "monitor"
+
+                alerts.append(
+                    RegressionAlert(
+                        artifact_id=tool_name,
+                        record_id="",  # Filled by caller if known
+                        before_error_rate=before_rate,
+                        after_error_rate=after_rate,
+                        delta=delta,
+                        recommendation=recommendation,
+                    )
+                )
+
+        alerts.sort(key=lambda a: a.delta, reverse=True)
+        return alerts
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _count_tool_errors(sessions: list[SessionTrace], tool_name: str) -> tuple[int, int]:
+        """Count errors and total calls for a specific tool."""
+        errors = 0
+        total = 0
+        for session in sessions:
+            for tc in session.tool_calls:
+                if tc.tool_name == tool_name:
+                    total += 1
+                    if tc.is_error:
+                        errors += 1
+        return errors, total
+
+    @staticmethod
+    def _tool_error_rates(sessions: list[SessionTrace]) -> dict[str, float]:
+        """Compute error rates per tool across sessions."""
+        calls: Counter[str] = Counter()
+        errors: Counter[str] = Counter()
+
+        for session in sessions:
+            for tc in session.tool_calls:
+                calls[tc.tool_name] += 1
+                if tc.is_error:
+                    errors[tc.tool_name] += 1
+
+        return {tool: errors.get(tool, 0) / count for tool, count in calls.items() if count > 0}

--- a/src/godspeed/evolution/fitness.py
+++ b/src/godspeed/evolution/fitness.py
@@ -1,0 +1,268 @@
+"""Fitness evaluator — A/B testing with LLM-as-judge scoring.
+
+Scores mutation candidates on correctness, procedure following, and conciseness
+using a configurable LLM judge (default: Ollama for $0 cost).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+
+from godspeed.evolution.mutator import MutationCandidate
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class JudgeVerdict:
+    """Raw verdict from the LLM judge comparing two outputs."""
+
+    a_correctness: float
+    a_procedure: float
+    a_conciseness: float
+    b_correctness: float
+    b_procedure: float
+    b_conciseness: float
+    winner: str  # "a" | "b" | "tie"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FitnessScore:
+    """Multi-dimensional fitness score for a mutation candidate."""
+
+    correctness: float  # 0-1
+    procedure_following: float  # 0-1
+    conciseness: float  # 0-1
+    overall: float  # weighted composite
+    length_penalty: float  # 0-1 penalty for size growth
+    confidence: float  # 0-1 based on number of test cases evaluated
+
+
+# Weights for the composite score
+CORRECTNESS_WEIGHT = 0.5
+PROCEDURE_WEIGHT = 0.3
+CONCISENESS_WEIGHT = 0.2
+
+# Maximum allowed growth ratio before length penalty kicks in
+MAX_LENGTH_RATIO = 2.0
+
+JUDGE_PROMPT = """\
+Compare two versions of a coding agent artifact for the same purpose.
+
+Purpose: {purpose}
+
+Version A (original):
+{original}
+
+Version B (mutated):
+{mutated}
+
+Score each version on these criteria (0-10 scale):
+1. Correctness: Is it factually correct, complete, and free of errors?
+2. Procedure: Does it guide the agent through the right steps in the right order?
+3. Conciseness: Is it appropriately sized — not too verbose, not missing info?
+
+Return ONLY a JSON object with these exact keys:
+{{"a_correctness": N, "a_procedure": N, "a_conciseness": N, \
+"b_correctness": N, "b_procedure": N, "b_conciseness": N, \
+"winner": "a"|"b"|"tie"}}"""
+
+
+# ---------------------------------------------------------------------------
+# Fitness Evaluator
+# ---------------------------------------------------------------------------
+
+
+class FitnessEvaluator:
+    """Score mutation candidates using LLM-as-judge."""
+
+    def __init__(self, judge_model: str = "") -> None:
+        from godspeed.evolution.hardware import select_evolution_model
+
+        self._judge_model = select_evolution_model(judge_model)
+
+    @property
+    def judge_model(self) -> str:
+        return self._judge_model
+
+    async def evaluate(
+        self,
+        candidate: MutationCandidate,
+        test_cases: list[str] | None = None,
+    ) -> FitnessScore:
+        """Evaluate a mutation candidate's fitness.
+
+        Args:
+            candidate: The mutation to evaluate.
+            test_cases: Optional list of task descriptions to test against.
+                If None, uses the candidate's own context for evaluation.
+
+        Returns:
+            FitnessScore with multi-dimensional scores.
+        """
+        cases = test_cases or [f"Evaluate {candidate.artifact_type} for {candidate.artifact_id}"]
+        verdicts: list[JudgeVerdict] = []
+
+        for case in cases:
+            try:
+                verdict = await self._judge(
+                    purpose=case,
+                    original=candidate.original,
+                    mutated=candidate.mutated,
+                )
+                if verdict is not None:
+                    verdicts.append(verdict)
+            except Exception:
+                logger.warning(
+                    "Judge call failed case=%s artifact=%s",
+                    case[:50],
+                    candidate.artifact_id,
+                    exc_info=True,
+                )
+
+        if not verdicts:
+            return FitnessScore(
+                correctness=0.0,
+                procedure_following=0.0,
+                conciseness=0.0,
+                overall=0.0,
+                length_penalty=0.0,
+                confidence=0.0,
+            )
+
+        return self._aggregate_verdicts(verdicts, candidate, len(cases))
+
+    async def _judge(
+        self,
+        purpose: str,
+        original: str,
+        mutated: str,
+    ) -> JudgeVerdict | None:
+        """Call the LLM judge to compare original vs mutated."""
+        prompt = JUDGE_PROMPT.format(
+            purpose=purpose,
+            original=original,
+            mutated=mutated,
+        )
+
+        try:
+            response_text = await self._call_llm(prompt)
+            return self._parse_verdict(response_text)
+        except Exception:
+            logger.debug("Failed to parse judge response", exc_info=True)
+            return None
+
+    async def _call_llm(self, prompt: str) -> str:
+        """Call the configured judge LLM."""
+        from godspeed.llm.client import LLMClient
+
+        client = LLMClient(model=self._judge_model)
+        messages = [{"role": "user", "content": prompt}]
+        response = await client.chat(messages)
+        return response.content
+
+    @staticmethod
+    def _parse_verdict(text: str) -> JudgeVerdict | None:
+        """Parse LLM response into a JudgeVerdict."""
+        # Try to find JSON in the response
+        text = text.strip()
+
+        # Handle responses wrapped in markdown code blocks
+        if "```" in text:
+            parts = text.split("```")
+            for part in parts:
+                part = part.strip()
+                if part.startswith("json"):
+                    part = part[4:].strip()
+                if part.startswith("{"):
+                    text = part
+                    break
+
+        # Find the JSON object
+        start = text.find("{")
+        end = text.rfind("}") + 1
+        if start == -1 or end == 0:
+            return None
+
+        try:
+            data = json.loads(text[start:end])
+        except json.JSONDecodeError:
+            return None
+
+        required_keys = {
+            "a_correctness",
+            "a_procedure",
+            "a_conciseness",
+            "b_correctness",
+            "b_procedure",
+            "b_conciseness",
+            "winner",
+        }
+        if not required_keys.issubset(data.keys()):
+            return None
+
+        def _clamp(val: float) -> float:
+            return max(0.0, min(10.0, float(val)))
+
+        winner = str(data["winner"]).lower()
+        if winner not in ("a", "b", "tie"):
+            winner = "tie"
+
+        return JudgeVerdict(
+            a_correctness=_clamp(data["a_correctness"]),
+            a_procedure=_clamp(data["a_procedure"]),
+            a_conciseness=_clamp(data["a_conciseness"]),
+            b_correctness=_clamp(data["b_correctness"]),
+            b_procedure=_clamp(data["b_procedure"]),
+            b_conciseness=_clamp(data["b_conciseness"]),
+            winner=winner,
+        )
+
+    @staticmethod
+    def _aggregate_verdicts(
+        verdicts: list[JudgeVerdict],
+        candidate: MutationCandidate,
+        total_cases: int,
+    ) -> FitnessScore:
+        """Aggregate multiple verdicts into a single FitnessScore."""
+        n = len(verdicts)
+
+        # Average the B scores (mutated version) normalized to 0-1
+        avg_correctness = sum(v.b_correctness for v in verdicts) / (n * 10)
+        avg_procedure = sum(v.b_procedure for v in verdicts) / (n * 10)
+        avg_conciseness = sum(v.b_conciseness for v in verdicts) / (n * 10)
+
+        # Length penalty
+        orig_len = len(candidate.original)
+        mut_len = len(candidate.mutated)
+        length_ratio = mut_len / orig_len if orig_len > 0 else 1.0
+        length_penalty = max(0.0, (length_ratio - MAX_LENGTH_RATIO) / MAX_LENGTH_RATIO)
+        length_penalty = min(1.0, length_penalty)
+
+        # Weighted composite
+        overall = (
+            CORRECTNESS_WEIGHT * avg_correctness
+            + PROCEDURE_WEIGHT * avg_procedure
+            + CONCISENESS_WEIGHT * avg_conciseness
+            - length_penalty * 0.2  # Penalty reduces overall by up to 0.2
+        )
+        overall = max(0.0, min(1.0, overall))
+
+        # Confidence based on how many test cases were successfully evaluated
+        confidence = n / total_cases if total_cases > 0 else 0.0
+
+        return FitnessScore(
+            correctness=round(avg_correctness, 4),
+            procedure_following=round(avg_procedure, 4),
+            conciseness=round(avg_conciseness, 4),
+            overall=round(overall, 4),
+            length_penalty=round(length_penalty, 4),
+            confidence=round(confidence, 4),
+        )

--- a/src/godspeed/evolution/hardware.py
+++ b/src/godspeed/evolution/hardware.py
@@ -1,0 +1,205 @@
+"""Hardware-aware model selection for evolution — auto-detect VRAM, pick largest fitting model.
+
+Handles everything from RTX 5070 Ti (16GB dedicated) to Jetson Orin Nano (8GB shared RAM).
+Falls back gracefully when VRAM detection fails or Ollama is unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# VRAM tiers → model selection
+# ---------------------------------------------------------------------------
+
+# Ordered largest-first. Each entry: (min_vram_mb, model, description)
+# VRAM thresholds account for ~1GB overhead from Ollama + OS.
+MODEL_TIERS: list[tuple[int, str, str]] = [
+    (10_000, "ollama/gemma3:12b", "12B — needs ~10GB free VRAM"),
+    (6_000, "ollama/gemma3:4b", "4B — needs ~6GB free VRAM"),
+    (3_000, "ollama/qwen2.5:3b", "3B — needs ~3GB free VRAM"),
+    (1_500, "ollama/qwen2.5:1.5b", "1.5B — needs ~1.5GB free VRAM"),
+]
+
+# Absolute fallback if nothing fits or detection fails
+FALLBACK_MODEL = "ollama/qwen2.5:1.5b"
+
+# num_candidates scaling by available VRAM
+CANDIDATES_BY_VRAM: list[tuple[int, int]] = [
+    (10_000, 5),  # 10GB+ → up to 5 candidates
+    (6_000, 3),  # 6GB+ → up to 3 candidates
+    (3_000, 2),  # 3GB+ → 2 candidates
+    (0, 1),  # anything less → 1 candidate
+]
+
+# Max concurrent A/B test cases for fitness evaluation
+MAX_EVAL_CASES_BY_VRAM: list[tuple[int, int]] = [
+    (10_000, 5),
+    (6_000, 3),
+    (3_000, 2),
+    (0, 1),
+]
+
+
+# ---------------------------------------------------------------------------
+# VRAM detection
+# ---------------------------------------------------------------------------
+
+
+def detect_vram_mb() -> int | None:
+    """Detect available GPU VRAM in MB. Returns None if detection fails.
+
+    Tries nvidia-smi first (discrete NVIDIA GPUs), then tegrastats-style
+    detection (Jetson), then returns None.
+    """
+    vram = _detect_nvidia_smi()
+    if vram is not None:
+        return vram
+
+    vram = _detect_jetson()
+    if vram is not None:
+        return vram
+
+    return None
+
+
+def _detect_nvidia_smi() -> int | None:
+    """Query nvidia-smi for free VRAM in MB."""
+    if not shutil.which("nvidia-smi"):
+        return None
+
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.free",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+
+        # Take the first GPU's free memory
+        for line in result.stdout.strip().splitlines():
+            line = line.strip()
+            if line:
+                return int(float(line))
+    except (subprocess.TimeoutExpired, ValueError, OSError) as exc:
+        logger.debug("nvidia-smi detection failed: %s", exc)
+
+    return None
+
+
+def _detect_jetson() -> int | None:
+    """Detect available memory on Jetson (shared RAM architecture).
+
+    On Jetson, GPU and CPU share the same RAM pool. We read /proc/meminfo
+    for available memory and apply a conservative factor since GPU workloads
+    compete with the OS and CPU processes.
+    """
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    # Value is in kB
+                    kb = int(line.split()[1])
+                    # Jetson shares RAM — use 60% of available as VRAM budget
+                    return int((kb / 1024) * 0.6)
+    except (OSError, ValueError, IndexError):
+        pass
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Model selection
+# ---------------------------------------------------------------------------
+
+
+def select_evolution_model(configured_model: str = "") -> str:
+    """Select the best evolution model based on config and available hardware.
+
+    Priority:
+    1. Explicit user configuration (non-empty configured_model)
+    2. Auto-detect VRAM and pick largest fitting model
+    3. Fallback to smallest model (qwen2.5:1.5b)
+
+    Args:
+        configured_model: User-configured model string (from evolution_model config).
+
+    Returns:
+        LiteLLM-compatible model string.
+    """
+    if configured_model:
+        logger.debug("Using configured evolution model=%s", configured_model)
+        return configured_model
+
+    vram = detect_vram_mb()
+    if vram is None:
+        logger.info("Could not detect VRAM — defaulting to %s", FALLBACK_MODEL)
+        return FALLBACK_MODEL
+
+    logger.info("Detected %d MB available VRAM for evolution", vram)
+
+    for min_vram, model, desc in MODEL_TIERS:
+        if vram >= min_vram:
+            logger.info("Selected evolution model=%s (%s)", model, desc)
+            return model
+
+    logger.info("Low VRAM (%d MB) — using fallback %s", vram, FALLBACK_MODEL)
+    return FALLBACK_MODEL
+
+
+def recommended_num_candidates(configured_model: str = "") -> int:
+    """Return recommended number of mutation candidates based on available VRAM.
+
+    Fewer candidates = less VRAM pressure and faster evolution cycles.
+    """
+    if configured_model and not configured_model.startswith("ollama/"):
+        # API models have no local VRAM constraint
+        return 5
+
+    vram = detect_vram_mb()
+    if vram is None:
+        return 2  # Conservative default
+
+    for min_vram, candidates in CANDIDATES_BY_VRAM:
+        if vram >= min_vram:
+            return candidates
+
+    return 1
+
+
+def recommended_max_eval_cases(configured_model: str = "") -> int:
+    """Return recommended max A/B test cases for fitness evaluation."""
+    if configured_model and not configured_model.startswith("ollama/"):
+        return 5
+
+    vram = detect_vram_mb()
+    if vram is None:
+        return 2
+
+    for min_vram, cases in MAX_EVAL_CASES_BY_VRAM:
+        if vram >= min_vram:
+            return cases
+
+    return 1
+
+
+def is_low_memory() -> bool:
+    """Check if running in a low-memory environment (< 6GB VRAM).
+
+    Low-memory mode: fewer candidates, smaller batch sizes, streaming traces.
+    """
+    vram = detect_vram_mb()
+    if vram is None:
+        return True  # Assume constrained if we can't detect
+    return vram < 6_000

--- a/src/godspeed/evolution/mutator.py
+++ b/src/godspeed/evolution/mutator.py
@@ -1,0 +1,408 @@
+"""Evolution engine — GEPA-style LLM-guided mutations.
+
+Generates improved candidates for tool descriptions, system prompt sections,
+and compaction prompts using failure analysis from the trace analyzer.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+
+from godspeed.evolution.trace_analyzer import (
+    EvolutionReport,
+    ToolCall,
+    ToolFailurePattern,
+    ToolSequence,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MutationCandidate:
+    """A proposed improvement to an agent artifact."""
+
+    artifact_type: str  # "tool_description", "prompt_section", "compaction_prompt", "skill"
+    artifact_id: str  # tool name, section name, etc.
+    original: str
+    mutated: str
+    mutation_rationale: str
+    model_used: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SkillCandidate:
+    """A proposed auto-generated skill from repeated tool patterns."""
+
+    name: str
+    description: str
+    trigger: str
+    content: str
+    source_sequence: ToolSequence
+
+
+# ---------------------------------------------------------------------------
+# Mutation prompts
+# ---------------------------------------------------------------------------
+
+TOOL_DESCRIPTION_MUTATION_PROMPT = """\
+You are improving a coding agent's tool description. The description tells the LLM \
+when and how to use this tool.
+
+Tool name: {tool_name}
+Current description:
+{current_description}
+
+Problems identified from usage data:
+{failure_summary}
+
+Generate an improved description that:
+1. Addresses the specific failures listed above
+2. Maintains the same core functionality
+3. Is clear and unambiguous for an LLM to follow
+4. Includes a brief example if the current version caused confusion
+
+Return ONLY the improved description text. No explanation, no preamble."""
+
+PROMPT_SECTION_MUTATION_PROMPT = """\
+You are improving a section of a coding agent's system prompt.
+
+Section name: {section_name}
+Current text:
+{current_text}
+
+Usage analysis summary:
+- Sessions analyzed: {sessions_analyzed}
+- Overall error rate: {error_rate:.1%}
+- Top failing tools: {top_failures}
+
+Generate an improved version that reduces errors and improves clarity.
+Return ONLY the improved text. No explanation, no preamble."""
+
+COMPACTION_MUTATION_PROMPT = """\
+You are improving a coding agent's conversation compaction prompt. This prompt \
+is used to summarize long conversations so they fit in the context window.
+
+Current compaction prompt:
+{current_prompt}
+
+Quality feedback (0-1 scores from recent compactions):
+{quality_scores}
+
+Generate an improved compaction prompt that produces higher-quality summaries.
+Return ONLY the improved prompt text. No explanation, no preamble."""
+
+TOOL_EXAMPLES_PROMPT = """\
+Based on these successful tool calls, generate 2-3 concise usage examples \
+for the tool '{tool_name}'.
+
+Successful calls:
+{examples}
+
+Format each example as:
+- Example: <one-line description>
+  Arguments: <JSON arguments>
+
+Return ONLY the examples. No explanation."""
+
+SKILL_GENERATION_PROMPT = """\
+The following tool sequence is used frequently ({frequency} times across sessions):
+Tools: {tool_chain}
+
+Example successful executions:
+{example_traces}
+
+Generate a reusable skill definition in this format:
+---
+name: <kebab-case-name>
+description: <one line>
+trigger: <trigger word>
+---
+
+<Step-by-step instructions using the tools above>
+
+Return ONLY the skill definition. No explanation."""
+
+
+# ---------------------------------------------------------------------------
+# Evolution Engine
+# ---------------------------------------------------------------------------
+
+
+class EvolutionEngine:
+    """Generate improved candidates using LLM-guided mutations.
+
+    Uses any LiteLLM-compatible model. Default: auto-detected based on
+    available VRAM (from RTX 5070 Ti 16GB down to Jetson Orin Nano 8GB shared).
+    """
+
+    def __init__(self, model: str = "") -> None:
+        from godspeed.evolution.hardware import select_evolution_model
+
+        self._model = select_evolution_model(model)
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def mutate_tool_description(
+        self,
+        tool_name: str,
+        current_desc: str,
+        failure_patterns: list[ToolFailurePattern],
+        num_candidates: int = 3,
+    ) -> list[MutationCandidate]:
+        """Generate improved tool descriptions based on failure analysis.
+
+        Args:
+            tool_name: Name of the tool to improve.
+            current_desc: Current tool description.
+            failure_patterns: Failures specific to this tool.
+            num_candidates: Number of candidates to generate.
+
+        Returns:
+            List of MutationCandidate objects.
+        """
+        if not failure_patterns:
+            logger.debug("No failures for tool=%s — skipping mutation", tool_name)
+            return []
+
+        failure_summary = self._format_failures(failure_patterns)
+        prompt = TOOL_DESCRIPTION_MUTATION_PROMPT.format(
+            tool_name=tool_name,
+            current_description=current_desc,
+            failure_summary=failure_summary,
+        )
+
+        candidates: list[MutationCandidate] = []
+        for i in range(num_candidates):
+            try:
+                mutated = await self._call_llm(prompt)
+                if mutated and mutated.strip() != current_desc.strip():
+                    candidates.append(
+                        MutationCandidate(
+                            artifact_type="tool_description",
+                            artifact_id=tool_name,
+                            original=current_desc,
+                            mutated=mutated.strip(),
+                            mutation_rationale=(
+                                f"Address {len(failure_patterns)} failure"
+                                f" pattern(s): {failure_summary[:200]}"
+                            ),
+                            model_used=self._model,
+                        )
+                    )
+            except Exception:
+                logger.warning(
+                    "Mutation generation failed tool=%s attempt=%d",
+                    tool_name,
+                    i,
+                    exc_info=True,
+                )
+
+        return candidates
+
+    async def mutate_prompt_section(
+        self,
+        section_name: str,
+        current_text: str,
+        report: EvolutionReport,
+        num_candidates: int = 3,
+    ) -> list[MutationCandidate]:
+        """Generate improved system prompt sections based on usage report."""
+        top_failures = ", ".join(
+            f"{f.tool_name} ({f.error_category}: {f.frequency}x)" for f in report.tool_failures[:5]
+        )
+
+        prompt = PROMPT_SECTION_MUTATION_PROMPT.format(
+            section_name=section_name,
+            current_text=current_text,
+            sessions_analyzed=report.sessions_analyzed,
+            error_rate=report.error_rate,
+            top_failures=top_failures or "none",
+        )
+
+        candidates: list[MutationCandidate] = []
+        for i in range(num_candidates):
+            try:
+                mutated = await self._call_llm(prompt)
+                if mutated and mutated.strip() != current_text.strip():
+                    candidates.append(
+                        MutationCandidate(
+                            artifact_type="prompt_section",
+                            artifact_id=section_name,
+                            original=current_text,
+                            mutated=mutated.strip(),
+                            mutation_rationale=(
+                                f"Reduce error rate from {report.error_rate:.1%}"
+                                f" across {report.sessions_analyzed} sessions"
+                            ),
+                            model_used=self._model,
+                        )
+                    )
+            except Exception:
+                logger.warning(
+                    "Prompt mutation failed section=%s attempt=%d",
+                    section_name,
+                    i,
+                    exc_info=True,
+                )
+
+        return candidates
+
+    async def mutate_compaction_prompt(
+        self,
+        current_prompt: str,
+        quality_scores: list[float],
+        num_candidates: int = 3,
+    ) -> list[MutationCandidate]:
+        """Generate improved compaction prompts based on quality feedback."""
+        scores_str = ", ".join(f"{s:.2f}" for s in quality_scores[-10:])
+        avg = sum(quality_scores) / len(quality_scores) if quality_scores else 0.0
+
+        prompt = COMPACTION_MUTATION_PROMPT.format(
+            current_prompt=current_prompt,
+            quality_scores=f"Recent scores: [{scores_str}], average: {avg:.2f}",
+        )
+
+        candidates: list[MutationCandidate] = []
+        for i in range(num_candidates):
+            try:
+                mutated = await self._call_llm(prompt)
+                if mutated and mutated.strip() != current_prompt.strip():
+                    candidates.append(
+                        MutationCandidate(
+                            artifact_type="compaction_prompt",
+                            artifact_id="compaction",
+                            original=current_prompt,
+                            mutated=mutated.strip(),
+                            mutation_rationale=f"Improve compaction quality from avg {avg:.2f}",
+                            model_used=self._model,
+                        )
+                    )
+            except Exception:
+                logger.warning("Compaction mutation failed attempt=%d", i, exc_info=True)
+
+        return candidates
+
+    async def generate_tool_examples(
+        self,
+        tool_name: str,
+        successful_traces: list[ToolCall],
+        max_examples: int = 5,
+    ) -> list[str]:
+        """Create usage examples from successful tool call traces."""
+        if not successful_traces:
+            return []
+
+        examples_text = "\n".join(
+            f"- {tc.tool_name}({tc.arguments}) → {tc.output_length} chars, {tc.latency_ms:.0f}ms"
+            for tc in successful_traces[:max_examples]
+        )
+
+        prompt = TOOL_EXAMPLES_PROMPT.format(
+            tool_name=tool_name,
+            examples=examples_text,
+        )
+
+        try:
+            result = await self._call_llm(prompt)
+            if result:
+                return [line.strip() for line in result.strip().split("\n") if line.strip()]
+        except Exception:
+            logger.warning("Example generation failed tool=%s", tool_name, exc_info=True)
+
+        return []
+
+    async def suggest_new_skill(
+        self,
+        sequence: ToolSequence,
+        example_traces: list[list[ToolCall]],
+    ) -> SkillCandidate | None:
+        """Auto-generate a skill from a repeated tool sequence."""
+        traces_text = ""
+        for i, trace in enumerate(example_traces[:3]):
+            traces_text += f"\nExecution {i + 1}:\n"
+            for tc in trace:
+                status = "error" if tc.is_error else "ok"
+                traces_text += f"  {tc.tool_name}({tc.arguments}) → {status}\n"
+
+        prompt = SKILL_GENERATION_PROMPT.format(
+            frequency=sequence.frequency,
+            tool_chain=" → ".join(sequence.tools),
+            example_traces=traces_text,
+        )
+
+        try:
+            result = await self._call_llm(prompt)
+            if result:
+                return self._parse_skill_candidate(result, sequence)
+        except Exception:
+            logger.warning("Skill generation failed sequence=%s", sequence.tools, exc_info=True)
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _call_llm(self, prompt: str) -> str:
+        """Call the configured LLM with a simple prompt. Returns response text."""
+        from godspeed.llm.client import LLMClient
+
+        client = LLMClient(model=self._model)
+        messages = [{"role": "user", "content": prompt}]
+        response = await client.chat(messages)
+        return response.content
+
+    @staticmethod
+    def _format_failures(patterns: list[ToolFailurePattern]) -> str:
+        """Format failure patterns into a readable summary."""
+        lines: list[str] = []
+        for p in patterns:
+            lines.append(f"- {p.error_category} ({p.frequency}x): {p.suggested_fix}")
+            if p.example_args:
+                lines.append(f"  Example args: {p.example_args[0]}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _parse_skill_candidate(raw_text: str, sequence: ToolSequence) -> SkillCandidate | None:
+        """Parse LLM output into a SkillCandidate."""
+        import yaml
+
+        # Find YAML frontmatter
+        parts = raw_text.split("---")
+        if len(parts) < 3:
+            logger.debug("Skill output missing frontmatter delimiters")
+            return None
+
+        try:
+            metadata = yaml.safe_load(parts[1])
+        except yaml.YAMLError:
+            logger.debug("Invalid YAML in skill frontmatter")
+            return None
+
+        if not isinstance(metadata, dict):
+            return None
+
+        name = metadata.get("name", "")
+        description = metadata.get("description", "")
+        trigger = metadata.get("trigger", "")
+        content = "---".join(parts[2:]).strip()
+
+        if not all([name, description, trigger, content]):
+            return None
+
+        return SkillCandidate(
+            name=name,
+            description=description,
+            trigger=trigger,
+            content=content,
+            source_sequence=sequence,
+        )

--- a/src/godspeed/evolution/permissions.py
+++ b/src/godspeed/evolution/permissions.py
@@ -1,0 +1,119 @@
+"""Permission pattern learning — analyze denials/grants to suggest optimizations.
+
+Mines audit trails for permission patterns and recommends allowlist changes.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections import Counter
+
+from godspeed.evolution.trace_analyzer import SessionTrace
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PermissionSuggestion:
+    """A suggested permission configuration change."""
+
+    tool_name: str
+    action: str  # "add_to_allowlist" | "pre_approve" | "review_needed"
+    denial_count: int
+    grant_count: int
+    rationale: str
+
+
+# ---------------------------------------------------------------------------
+# Permission Advisor
+# ---------------------------------------------------------------------------
+
+
+class PermissionAdvisor:
+    """Analyze permission patterns to suggest allowlist optimizations."""
+
+    def __init__(
+        self,
+        denial_threshold: int = 5,
+        grant_threshold: int = 5,
+    ) -> None:
+        self._denial_threshold = denial_threshold
+        self._grant_threshold = grant_threshold
+
+    def analyze_denials(self, sessions: list[SessionTrace]) -> list[PermissionSuggestion]:
+        """Find tools denied >threshold times — suggest adding to allowlist."""
+        denials: Counter[str] = Counter()
+        denial_reasons: dict[str, list[str]] = {}
+
+        for session in sessions:
+            for tool_name, reason in session.permission_denials:
+                denials[tool_name] += 1
+                if tool_name not in denial_reasons:
+                    denial_reasons[tool_name] = []
+                if len(denial_reasons[tool_name]) < 3:
+                    denial_reasons[tool_name].append(reason)
+
+        suggestions: list[PermissionSuggestion] = []
+        for tool_name, count in denials.most_common():
+            if count >= self._denial_threshold:
+                reasons = denial_reasons.get(tool_name, [])
+                rationale = (
+                    f"Denied {count} times across sessions. "
+                    f"Reasons: {', '.join(sorted(set(reasons))[:3])}"
+                )
+                suggestions.append(
+                    PermissionSuggestion(
+                        tool_name=tool_name,
+                        action="add_to_allowlist",
+                        denial_count=count,
+                        grant_count=0,
+                        rationale=rationale,
+                    )
+                )
+
+        return suggestions
+
+    def analyze_approvals(self, sessions: list[SessionTrace]) -> list[PermissionSuggestion]:
+        """Find tools always approved — suggest pre-approving."""
+        grants: Counter[str] = Counter()
+        denials: Counter[str] = Counter()
+
+        for session in sessions:
+            for tool_name in session.permission_grants:
+                grants[tool_name] += 1
+            for tool_name, _ in session.permission_denials:
+                denials[tool_name] += 1
+
+        suggestions: list[PermissionSuggestion] = []
+        for tool_name, count in grants.most_common():
+            if count >= self._grant_threshold and denials.get(tool_name, 0) == 0:
+                suggestions.append(
+                    PermissionSuggestion(
+                        tool_name=tool_name,
+                        action="pre_approve",
+                        denial_count=0,
+                        grant_count=count,
+                        rationale=f"Approved {count} times, never denied. Safe to pre-approve.",
+                    )
+                )
+
+        return suggestions
+
+    def generate_permission_config(self, suggestions: list[PermissionSuggestion]) -> dict:
+        """Produce a config snippet for godspeed.yaml."""
+        allow: list[str] = []
+        for s in suggestions:
+            if s.action in ("add_to_allowlist", "pre_approve"):
+                allow.append(s.tool_name)
+
+        return {"permissions": {"allow": sorted(set(allow))}}
+
+    def get_all_suggestions(self, sessions: list[SessionTrace]) -> list[PermissionSuggestion]:
+        """Get combined denial + approval suggestions."""
+        return self.analyze_denials(sessions) + self.analyze_approvals(sessions)

--- a/src/godspeed/evolution/registry.py
+++ b/src/godspeed/evolution/registry.py
@@ -1,0 +1,295 @@
+"""Evolution registry — versioned history of all evolved artifacts.
+
+Append-only JSONL storage tracking every mutation attempt, its fitness score,
+safety verdict, and whether it was applied/reverted.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from godspeed.evolution.fitness import FitnessScore
+from godspeed.evolution.mutator import MutationCandidate
+from godspeed.evolution.safety import SafetyVerdict
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(slots=True)
+class EvolutionRecord:
+    """A single entry in the evolution registry."""
+
+    record_id: str
+    artifact_type: str
+    artifact_id: str
+    original_hash: str
+    mutated_hash: str
+    fitness_overall: float
+    fitness_confidence: float
+    safety_passed: bool
+    requires_review: bool
+    model_used: str
+    created_at: str  # ISO 8601
+    applied_at: str  # ISO 8601 or "" if not applied
+    reverted_at: str  # ISO 8601 or "" if not reverted
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> EvolutionRecord:
+        valid = {f.name for f in dataclasses.fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in valid})
+
+
+# ---------------------------------------------------------------------------
+# Evolution Registry
+# ---------------------------------------------------------------------------
+
+
+class EvolutionRegistry:
+    """Append-only JSONL registry tracking all evolution history.
+
+    Storage layout:
+        base_dir/
+        ├── registry.jsonl       # append-only history
+        ├── candidates/          # pending candidates
+        │   └── {id}.json
+        ├── applied/             # currently active mutations
+        │   └── {artifact_id}.json
+        └── originals/           # backups before mutation
+            └── {artifact_id}.json
+    """
+
+    def __init__(self, base_dir: Path) -> None:
+        self._base_dir = base_dir
+        self._registry_path = base_dir / "registry.jsonl"
+        self._candidates_dir = base_dir / "candidates"
+        self._applied_dir = base_dir / "applied"
+        self._originals_dir = base_dir / "originals"
+
+        # Ensure directories exist
+        for d in (self._candidates_dir, self._applied_dir, self._originals_dir):
+            d.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def base_dir(self) -> Path:
+        return self._base_dir
+
+    def register(
+        self,
+        candidate: MutationCandidate,
+        score: FitnessScore,
+        verdict: SafetyVerdict,
+    ) -> str:
+        """Record a mutation attempt in the registry.
+
+        Returns:
+            The record ID.
+        """
+        record_id = str(uuid4())[:12]
+
+        record = EvolutionRecord(
+            record_id=record_id,
+            artifact_type=candidate.artifact_type,
+            artifact_id=candidate.artifact_id,
+            original_hash=self._hash_text(candidate.original),
+            mutated_hash=self._hash_text(candidate.mutated),
+            fitness_overall=score.overall,
+            fitness_confidence=score.confidence,
+            safety_passed=verdict.passed,
+            requires_review=verdict.requires_human_review,
+            model_used=candidate.model_used,
+            created_at=datetime.now(tz=UTC).isoformat(),
+            applied_at="",
+            reverted_at="",
+        )
+
+        # Append to registry
+        self._append_record(record)
+
+        # Save candidate details for review
+        candidate_data = {
+            "record_id": record_id,
+            "artifact_type": candidate.artifact_type,
+            "artifact_id": candidate.artifact_id,
+            "original": candidate.original,
+            "mutated": candidate.mutated,
+            "mutation_rationale": candidate.mutation_rationale,
+            "fitness": dataclasses.asdict(score),
+            "safety": {
+                "passed": verdict.passed,
+                "checks": [
+                    {"name": name, "passed": ok, "reason": reason}
+                    for name, ok, reason in verdict.checks
+                ],
+                "requires_human_review": verdict.requires_human_review,
+            },
+        }
+        candidate_path = self._candidates_dir / f"{record_id}.json"
+        candidate_path.write_text(json.dumps(candidate_data, indent=2), encoding="utf-8")
+
+        logger.info(
+            "Registered evolution record=%s artifact=%s fitness=%.3f safety=%s",
+            record_id,
+            candidate.artifact_id,
+            score.overall,
+            verdict.passed,
+        )
+        return record_id
+
+    def mark_applied(self, record_id: str, mutated_text: str) -> None:
+        """Mark a record as applied and save the active mutation."""
+        records = self._load_records()
+        for rec in records:
+            if rec.record_id == record_id:
+                rec.applied_at = datetime.now(tz=UTC).isoformat()
+                # Save to applied/
+                applied_path = self._applied_dir / f"{rec.artifact_id}.json"
+                applied_data = {
+                    "record_id": record_id,
+                    "artifact_id": rec.artifact_id,
+                    "artifact_type": rec.artifact_type,
+                    "mutated_text": mutated_text,
+                    "applied_at": rec.applied_at,
+                }
+                applied_path.write_text(json.dumps(applied_data, indent=2), encoding="utf-8")
+                break
+
+        self._rewrite_registry(records)
+
+    def mark_reverted(self, record_id: str) -> None:
+        """Mark a record as reverted and remove from applied/."""
+        records = self._load_records()
+        for rec in records:
+            if rec.record_id == record_id:
+                rec.reverted_at = datetime.now(tz=UTC).isoformat()
+                # Remove from applied/
+                applied_path = self._applied_dir / f"{rec.artifact_id}.json"
+                if applied_path.exists():
+                    applied_path.unlink()
+                break
+
+        self._rewrite_registry(records)
+
+    def save_original(self, artifact_id: str, original_text: str) -> None:
+        """Backup original text before applying a mutation."""
+        path = self._originals_dir / f"{artifact_id}.json"
+        if not path.exists():  # Only save the first original
+            path.write_text(
+                json.dumps({"artifact_id": artifact_id, "text": original_text}, indent=2),
+                encoding="utf-8",
+            )
+
+    def get_original(self, artifact_id: str) -> str | None:
+        """Retrieve the backed-up original text for an artifact."""
+        path = self._originals_dir / f"{artifact_id}.json"
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data.get("text")
+
+    def get_applied(self, artifact_id: str) -> dict | None:
+        """Get the currently applied mutation for an artifact."""
+        path = self._applied_dir / f"{artifact_id}.json"
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def list_applied(self) -> list[dict]:
+        """List all currently applied mutations."""
+        results = []
+        for path in self._applied_dir.glob("*.json"):
+            results.append(json.loads(path.read_text(encoding="utf-8")))
+        return results
+
+    def get_history(self, artifact_id: str) -> list[EvolutionRecord]:
+        """Get full mutation history for an artifact."""
+        records = self._load_records()
+        return [r for r in records if r.artifact_id == artifact_id]
+
+    def get_record(self, record_id: str) -> EvolutionRecord | None:
+        """Get a specific record by ID."""
+        records = self._load_records()
+        for r in records:
+            if r.record_id == record_id:
+                return r
+        return None
+
+    def get_candidate(self, record_id: str) -> dict | None:
+        """Get full candidate details by record ID."""
+        path = self._candidates_dir / f"{record_id}.json"
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def leaderboard(self, top_n: int = 10) -> list[EvolutionRecord]:
+        """Get top improvements by fitness score."""
+        records = self._load_records()
+        # Only applied, non-reverted records
+        active = [r for r in records if r.applied_at and not r.reverted_at]
+        active.sort(key=lambda r: r.fitness_overall, reverse=True)
+        return active[:top_n]
+
+    def stats(self) -> dict:
+        """Get summary statistics."""
+        records = self._load_records()
+        return {
+            "total_mutations": len(records),
+            "applied": sum(1 for r in records if r.applied_at),
+            "reverted": sum(1 for r in records if r.reverted_at),
+            "active": sum(1 for r in records if r.applied_at and not r.reverted_at),
+            "safety_passed": sum(1 for r in records if r.safety_passed),
+            "safety_failed": sum(1 for r in records if not r.safety_passed),
+            "avg_fitness": (
+                sum(r.fitness_overall for r in records) / len(records) if records else 0.0
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _append_record(self, record: EvolutionRecord) -> None:
+        """Append a record to the JSONL registry."""
+        line = json.dumps(record.to_dict()) + "\n"
+        with open(self._registry_path, "a", encoding="utf-8") as f:
+            f.write(line)
+
+    def _load_records(self) -> list[EvolutionRecord]:
+        """Load all records from the JSONL registry."""
+        if not self._registry_path.exists():
+            return []
+
+        records: list[EvolutionRecord] = []
+        for line in self._registry_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                records.append(EvolutionRecord.from_dict(data))
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.debug("Skipping malformed registry record: %s", exc)
+        return records
+
+    def _rewrite_registry(self, records: list[EvolutionRecord]) -> None:
+        """Rewrite the entire registry (used for updates like mark_applied)."""
+        lines = [json.dumps(r.to_dict()) + "\n" for r in records]
+        self._registry_path.write_text("".join(lines), encoding="utf-8")
+
+    @staticmethod
+    def _hash_text(text: str) -> str:
+        """SHA-256 hash of text content."""
+        return hashlib.sha256(text.encode()).hexdigest()[:16]

--- a/src/godspeed/evolution/safety.py
+++ b/src/godspeed/evolution/safety.py
@@ -1,0 +1,147 @@
+"""Safety gate — prevent regressions from evolved artifacts.
+
+All mutations must pass safety checks before being applied:
+- Test suite still passes (100%)
+- Size limits respected (no >2x growth)
+- Semantic drift within bounds
+- Fitness above threshold
+- High-impact changes flagged for human review
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+
+from godspeed.evolution.fitness import FitnessScore
+from godspeed.evolution.mutator import MutationCandidate
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SafetyVerdict:
+    """Result of running all safety checks on a mutation candidate."""
+
+    passed: bool
+    checks: tuple[tuple[str, bool, str], ...]  # (check_name, passed, reason)
+    requires_human_review: bool
+
+
+# Artifacts that always need human review
+HIGH_IMPACT_ARTIFACT_TYPES = frozenset({"prompt_section"})
+HIGH_IMPACT_ARTIFACT_IDS = frozenset({"core", "security", "permissions"})
+
+
+# ---------------------------------------------------------------------------
+# Safety Gate
+# ---------------------------------------------------------------------------
+
+
+class SafetyGate:
+    """Run safety checks on mutation candidates before applying them."""
+
+    def __init__(
+        self,
+        max_growth: float = 2.0,
+        min_similarity: float = 0.3,
+        min_fitness: float = 0.6,
+    ) -> None:
+        self._max_growth = max_growth
+        self._min_similarity = min_similarity
+        self._min_fitness = min_fitness
+
+    def gate(
+        self,
+        candidate: MutationCandidate,
+        score: FitnessScore,
+    ) -> SafetyVerdict:
+        """Run all safety checks and return a verdict.
+
+        Does NOT run the test suite (that's an async operation handled
+        separately). This gate covers the fast, synchronous checks.
+        """
+        checks: list[tuple[str, bool, str]] = []
+
+        # Check 1: Size limit
+        size_ok, size_msg = self.check_size_limit(candidate)
+        checks.append(("size_limit", size_ok, size_msg))
+
+        # Check 2: Semantic drift
+        drift_ok, drift_msg = self.check_semantic_drift(candidate)
+        checks.append(("semantic_drift", drift_ok, drift_msg))
+
+        # Check 3: Fitness threshold
+        fitness_ok, fitness_msg = self.check_fitness_threshold(score)
+        checks.append(("fitness_threshold", fitness_ok, fitness_msg))
+
+        # Check 4: Confidence threshold
+        conf_ok = score.confidence >= 0.5
+        conf_msg = f"confidence={score.confidence:.2f} (min=0.50)"
+        checks.append(("confidence", conf_ok, conf_msg))
+
+        all_passed = all(ok for _, ok, _ in checks)
+        needs_review = self.requires_human_review(candidate)
+
+        return SafetyVerdict(
+            passed=all_passed,
+            checks=tuple(checks),
+            requires_human_review=needs_review,
+        )
+
+    def check_size_limit(self, candidate: MutationCandidate) -> tuple[bool, str]:
+        """Check that mutated text is not excessively larger than original."""
+        orig_len = len(candidate.original)
+        mut_len = len(candidate.mutated)
+
+        if orig_len == 0:
+            return True, "original is empty — no size check"
+
+        ratio = mut_len / orig_len
+        passed = ratio <= self._max_growth
+        msg = f"size ratio={ratio:.2f} (max={self._max_growth:.1f})"
+        return passed, msg
+
+    def check_semantic_drift(self, candidate: MutationCandidate) -> tuple[bool, str]:
+        """Check that mutated text hasn't drifted too far from original.
+
+        Uses word-overlap Jaccard similarity (no embeddings needed).
+        """
+        orig_words = self._tokenize(candidate.original)
+        mut_words = self._tokenize(candidate.mutated)
+
+        if not orig_words and not mut_words:
+            return True, "both empty"
+        if not orig_words or not mut_words:
+            return False, "one side is empty"
+
+        intersection = orig_words & mut_words
+        union = orig_words | mut_words
+        similarity = len(intersection) / len(union) if union else 0.0
+
+        passed = similarity >= self._min_similarity
+        msg = f"similarity={similarity:.3f} (min={self._min_similarity:.2f})"
+        return passed, msg
+
+    def check_fitness_threshold(self, score: FitnessScore) -> tuple[bool, str]:
+        """Check that fitness score meets minimum threshold."""
+        passed = score.overall >= self._min_fitness
+        msg = f"overall={score.overall:.3f} (min={self._min_fitness:.2f})"
+        return passed, msg
+
+    def requires_human_review(self, candidate: MutationCandidate) -> bool:
+        """Determine if this mutation needs human approval."""
+        if candidate.artifact_type in HIGH_IMPACT_ARTIFACT_TYPES:
+            return True
+        return candidate.artifact_id in HIGH_IMPACT_ARTIFACT_IDS
+
+    @staticmethod
+    def _tokenize(text: str) -> set[str]:
+        """Simple word tokenization for similarity comparison."""
+        return set(re.findall(r"\w+", text.lower()))

--- a/src/godspeed/evolution/skill_gen.py
+++ b/src/godspeed/evolution/skill_gen.py
@@ -1,0 +1,152 @@
+"""Skill auto-generation — detect repeated tool patterns and create skills.
+
+Analyzes multi-tool sequences from trace data and generates reusable
+skill markdown files with YAML frontmatter.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+
+import yaml
+
+from godspeed.evolution.trace_analyzer import SessionTrace, ToolSequence, TraceAnalyzer
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GeneratedSkill:
+    """A skill auto-generated from repeated tool patterns."""
+
+    name: str
+    description: str
+    trigger: str
+    content: str  # Full markdown with frontmatter
+    source_tools: tuple[str, ...]
+    frequency: int
+
+
+# ---------------------------------------------------------------------------
+# Skill Generator
+# ---------------------------------------------------------------------------
+
+
+class SkillGenerator:
+    """Detect repeated tool patterns and generate reusable skills."""
+
+    def __init__(self) -> None:
+        self._analyzer = TraceAnalyzer()
+
+    def detect_patterns(
+        self,
+        sessions: list[SessionTrace],
+        min_frequency: int = 3,
+    ) -> list[ToolSequence]:
+        """Find tool chains that repeat ≥min_frequency times."""
+        return self._analyzer.analyze_multi_tool_sequences(sessions, min_frequency)
+
+    def generate_skill_markdown(
+        self,
+        sequence: ToolSequence,
+        description: str | None = None,
+    ) -> str:
+        """Produce a skill file with YAML frontmatter from a tool sequence.
+
+        Args:
+            sequence: The detected tool pattern.
+            description: Override description. Auto-generated if None.
+
+        Returns:
+            Complete skill markdown with frontmatter.
+        """
+        name = self._make_name(sequence.tools)
+        trigger = name  # Use name as trigger
+        desc = description or self._make_description(sequence.tools)
+
+        frontmatter = {
+            "name": name,
+            "description": desc,
+            "trigger": trigger,
+        }
+
+        steps = []
+        for i, tool in enumerate(sequence.tools, 1):
+            steps.append(f"{i}. Use `{tool}` tool")
+
+        body = "\n".join(steps)
+        header = yaml.dump(frontmatter, default_flow_style=False).strip()
+        skill_text = f"---\n{header}\n---\n\n{body}\n"
+        return skill_text
+
+    def generate(
+        self,
+        sequence: ToolSequence,
+        description: str | None = None,
+    ) -> GeneratedSkill:
+        """Generate a full GeneratedSkill from a sequence."""
+        name = self._make_name(sequence.tools)
+        desc = description or self._make_description(sequence.tools)
+        content = self.generate_skill_markdown(sequence, description)
+
+        return GeneratedSkill(
+            name=name,
+            description=desc,
+            trigger=name,
+            content=content,
+            source_tools=sequence.tools,
+            frequency=sequence.frequency,
+        )
+
+    def validate_skill(self, skill_text: str) -> bool:
+        """Validate that a skill has proper YAML frontmatter and required fields."""
+        parts = skill_text.split("---")
+        if len(parts) < 3:
+            return False
+
+        try:
+            metadata = yaml.safe_load(parts[1])
+        except yaml.YAMLError:
+            return False
+
+        if not isinstance(metadata, dict):
+            return False
+
+        required = {"name", "description", "trigger"}
+        if not required.issubset(metadata.keys()):
+            return False
+
+        # Check body has content
+        body = "---".join(parts[2:]).strip()
+        return len(body) > 0
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_name(tools: tuple[str, ...]) -> str:
+        """Generate a kebab-case name from tool names."""
+        # Deduplicate consecutive tools
+        deduped: list[str] = []
+        for t in tools:
+            if not deduped or deduped[-1] != t:
+                deduped.append(t)
+
+        name = "-and-".join(t.replace("_", "-") for t in deduped)
+        # Sanitize
+        name = re.sub(r"[^a-z0-9-]", "", name.lower())
+        return name[:50]  # Cap length
+
+    @staticmethod
+    def _make_description(tools: tuple[str, ...]) -> str:
+        """Generate a description from tool names."""
+        tool_names = " then ".join(t.replace("_", " ") for t in dict.fromkeys(tools))
+        return f"Auto-generated: {tool_names}"

--- a/src/godspeed/evolution/trace_analyzer.py
+++ b/src/godspeed/evolution/trace_analyzer.py
@@ -1,0 +1,455 @@
+"""Trace analyzer — extract actionable insights from audit trail JSONL.
+
+Parses session audit logs into structured traces and analyzes them for:
+- Tool failure patterns (grouped by tool + error category)
+- Tool latency statistics (p50/p95/p99)
+- Permission patterns (repeatedly denied/approved tools)
+- Multi-tool sequences (candidates for skill auto-generation)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import gzip
+import json
+import logging
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from godspeed.audit.events import AuditEventType, AuditRecord
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ToolCall:
+    """A single tool call extracted from audit records."""
+
+    tool_name: str
+    arguments: dict[str, Any]
+    output_length: int
+    is_error: bool
+    latency_ms: float
+    outcome: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SessionTrace:
+    """Structured trace for one agent session."""
+
+    session_id: str
+    tool_calls: tuple[ToolCall, ...]
+    errors: tuple[ToolCall, ...]
+    permission_denials: tuple[tuple[str, str], ...]  # (tool_name, reason)
+    permission_grants: tuple[str, ...]  # tool_name
+    total_latency_ms: float
+    model: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ToolFailurePattern:
+    """A recurring tool failure pattern across sessions."""
+
+    tool_name: str
+    error_category: str  # "invalid_args", "permission_denied", "timeout", "execution_error"
+    frequency: int
+    example_args: tuple[dict[str, Any], ...]
+    suggested_fix: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class LatencyStats:
+    """Latency statistics for a single tool."""
+
+    tool_name: str
+    count: int
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    mean_ms: float
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PermissionInsight:
+    """Insight about a tool's permission patterns."""
+
+    tool_name: str
+    denial_count: int
+    grant_count: int
+    suggestion: str  # "add_to_allowlist" | "pre_approve" | "review_needed"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ToolSequence:
+    """A repeated multi-tool pattern detected across sessions."""
+
+    tools: tuple[str, ...]
+    frequency: int
+    avg_success_rate: float
+    candidate_skill_name: str
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class EvolutionReport:
+    """Aggregated analysis report for the mutation engine."""
+
+    sessions_analyzed: int
+    tool_failures: tuple[ToolFailurePattern, ...]
+    latency_stats: tuple[LatencyStats, ...]
+    permission_insights: tuple[PermissionInsight, ...]
+    tool_sequences: tuple[ToolSequence, ...]
+    most_used_tools: tuple[tuple[str, int], ...]
+    error_rate: float  # overall error rate across all tool calls
+
+
+# ---------------------------------------------------------------------------
+# Trace Analyzer
+# ---------------------------------------------------------------------------
+
+
+class TraceAnalyzer:
+    """Parse audit trail JSONL into actionable insights."""
+
+    def load_sessions(self, audit_dir: Path, last_n: int = 0) -> list[SessionTrace]:
+        """Load session traces from audit JSONL files.
+
+        Args:
+            audit_dir: Directory containing .audit.jsonl and .audit.jsonl.gz files.
+            last_n: If > 0, only return the most recent N sessions (by file mtime).
+
+        Returns:
+            List of SessionTrace objects, one per session file.
+        """
+        if not audit_dir.is_dir():
+            logger.warning("Audit directory does not exist path=%s", audit_dir)
+            return []
+
+        # Collect all audit files
+        files: list[Path] = []
+        for pattern in ("*.audit.jsonl", "*.audit.jsonl.gz"):
+            files.extend(audit_dir.glob(pattern))
+
+        if not files:
+            return []
+
+        # Sort by modification time (newest first) for last_n filtering
+        files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        if last_n > 0:
+            files = files[:last_n]
+
+        sessions: list[SessionTrace] = []
+        for path in files:
+            trace = self._parse_session(path)
+            if trace is not None:
+                sessions.append(trace)
+
+        return sessions
+
+    def analyze_tool_failures(self, sessions: list[SessionTrace]) -> list[ToolFailurePattern]:
+        """Group errors by tool_name + error category, rank by frequency."""
+        # Key: (tool_name, error_category) -> list of example args
+        failures: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+
+        for session in sessions:
+            for tc in session.errors:
+                category = self._classify_error(tc)
+                failures[(tc.tool_name, category)].append(tc.arguments)
+
+        patterns: list[ToolFailurePattern] = []
+        for (tool_name, category), args_list in failures.items():
+            examples = tuple(args_list[:5])  # Keep at most 5 examples
+            suggested_fix = self._suggest_fix(tool_name, category, examples)
+            patterns.append(
+                ToolFailurePattern(
+                    tool_name=tool_name,
+                    error_category=category,
+                    frequency=len(args_list),
+                    example_args=examples,
+                    suggested_fix=suggested_fix,
+                )
+            )
+
+        # Sort by frequency descending
+        patterns.sort(key=lambda p: p.frequency, reverse=True)
+        return patterns
+
+    def analyze_tool_latency(self, sessions: list[SessionTrace]) -> list[LatencyStats]:
+        """Compute p50/p95/p99 latency per tool across all sessions."""
+        latencies: dict[str, list[float]] = defaultdict(list)
+
+        for session in sessions:
+            for tc in session.tool_calls:
+                if tc.latency_ms > 0:
+                    latencies[tc.tool_name].append(tc.latency_ms)
+
+        stats: list[LatencyStats] = []
+        for tool_name, values in latencies.items():
+            if not values:
+                continue
+            sorted_vals = sorted(values)
+            n = len(sorted_vals)
+            stats.append(
+                LatencyStats(
+                    tool_name=tool_name,
+                    count=n,
+                    p50_ms=self._percentile(sorted_vals, 50),
+                    p95_ms=self._percentile(sorted_vals, 95),
+                    p99_ms=self._percentile(sorted_vals, 99),
+                    mean_ms=statistics.mean(sorted_vals),
+                )
+            )
+
+        stats.sort(key=lambda s: s.p95_ms, reverse=True)
+        return stats
+
+    def analyze_permission_patterns(self, sessions: list[SessionTrace]) -> list[PermissionInsight]:
+        """Identify tools that are repeatedly denied or always approved."""
+        denials: Counter[str] = Counter()
+        grants: Counter[str] = Counter()
+
+        for session in sessions:
+            for tool_name, _reason in session.permission_denials:
+                denials[tool_name] += 1
+            for tool_name in session.permission_grants:
+                grants[tool_name] += 1
+
+        all_tools = set(denials.keys()) | set(grants.keys())
+        insights: list[PermissionInsight] = []
+
+        for tool_name in all_tools:
+            d = denials.get(tool_name, 0)
+            g = grants.get(tool_name, 0)
+
+            if d >= 5 and g == 0:
+                suggestion = "review_needed"
+            elif d >= 5:
+                suggestion = "add_to_allowlist"
+            elif g >= 5 and d == 0:
+                suggestion = "pre_approve"
+            else:
+                continue  # Not enough signal
+
+            insights.append(
+                PermissionInsight(
+                    tool_name=tool_name,
+                    denial_count=d,
+                    grant_count=g,
+                    suggestion=suggestion,
+                )
+            )
+
+        insights.sort(key=lambda i: i.denial_count + i.grant_count, reverse=True)
+        return insights
+
+    def analyze_multi_tool_sequences(
+        self, sessions: list[SessionTrace], min_frequency: int = 3
+    ) -> list[ToolSequence]:
+        """Detect repeated tool chains across sessions."""
+        # Extract tool name sequences per session (sliding windows of 2-4)
+        sequence_counts: Counter[tuple[str, ...]] = Counter()
+        sequence_successes: dict[tuple[str, ...], list[bool]] = defaultdict(list)
+
+        for session in sessions:
+            names = [tc.tool_name for tc in session.tool_calls]
+            errors = {i for i, tc in enumerate(session.tool_calls) if tc.is_error}
+
+            for window_size in (2, 3, 4):
+                for i in range(len(names) - window_size + 1):
+                    seq = tuple(names[i : i + window_size])
+                    sequence_counts[seq] += 1
+                    all_ok = all(j not in errors for j in range(i, i + window_size))
+                    sequence_successes[seq].append(all_ok)
+
+        results: list[ToolSequence] = []
+        for seq, count in sequence_counts.items():
+            if count < min_frequency:
+                continue
+            successes = sequence_successes[seq]
+            avg_success = sum(successes) / len(successes) if successes else 0.0
+            skill_name = "_and_".join(dict.fromkeys(seq))  # Deduplicate consecutive
+            results.append(
+                ToolSequence(
+                    tools=seq,
+                    frequency=count,
+                    avg_success_rate=avg_success,
+                    candidate_skill_name=skill_name,
+                )
+            )
+
+        results.sort(key=lambda r: r.frequency, reverse=True)
+        return results
+
+    def generate_report(self, sessions: list[SessionTrace]) -> EvolutionReport:
+        """Generate a full analysis report from session traces."""
+        # Tool usage counts
+        tool_counts: Counter[str] = Counter()
+        total_calls = 0
+        total_errors = 0
+
+        for session in sessions:
+            for tc in session.tool_calls:
+                tool_counts[tc.tool_name] += 1
+                total_calls += 1
+                if tc.is_error:
+                    total_errors += 1
+
+        error_rate = total_errors / total_calls if total_calls > 0 else 0.0
+
+        return EvolutionReport(
+            sessions_analyzed=len(sessions),
+            tool_failures=tuple(self.analyze_tool_failures(sessions)),
+            latency_stats=tuple(self.analyze_tool_latency(sessions)),
+            permission_insights=tuple(self.analyze_permission_patterns(sessions)),
+            tool_sequences=tuple(self.analyze_multi_tool_sequences(sessions)),
+            most_used_tools=tuple(tool_counts.most_common(10)),
+            error_rate=error_rate,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _parse_session(self, path: Path) -> SessionTrace | None:
+        """Parse a single audit JSONL file into a SessionTrace.
+
+        Reads line-by-line (streaming) to avoid loading entire files into memory.
+        This matters on constrained devices (Jetson Orin Nano, 8GB shared RAM).
+        """
+        records: list[AuditRecord] = []
+        try:
+            if str(path).endswith(".gz"):
+                ctx = gzip.open(path, "rt", encoding="utf-8")  # noqa: SIM115
+            else:
+                ctx = open(path, encoding="utf-8")  # noqa: SIM115
+            with ctx as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                        records.append(AuditRecord.model_validate(data))
+                    except (json.JSONDecodeError, Exception) as exc:
+                        logger.debug(
+                            "Skipping malformed audit record path=%s error=%s",
+                            path,
+                            exc,
+                        )
+                        continue
+        except (OSError, gzip.BadGzipFile) as exc:
+            logger.warning("Failed to read audit file path=%s error=%s", path, exc)
+            return None
+
+        if not records:
+            return None
+
+        session_id = records[0].session_id
+        model = ""
+
+        tool_calls: list[ToolCall] = []
+        permission_denials: list[tuple[str, str]] = []
+        permission_grants: list[str] = []
+        total_latency = 0.0
+
+        # Build tool call / response pairs
+        pending_calls: dict[str, AuditRecord] = {}  # tool_name+seq -> call record
+
+        for rec in records:
+            if rec.action_type == AuditEventType.TOOL_CALL:
+                tool_name = rec.action_detail.get("tool_name", "unknown")
+                pending_calls[f"{tool_name}_{rec.sequence}"] = rec
+
+            elif rec.action_type == AuditEventType.TOOL_RESPONSE:
+                tool_name = rec.action_detail.get("tool_name", "unknown")
+                is_error = rec.outcome in ("error", "timeout")
+                latency_ms = rec.action_detail.get("latency_ms", 0.0)
+                output_length = rec.action_detail.get("output_length", 0)
+                arguments = rec.action_detail.get("arguments", {})
+
+                # Try to find the matching call for arguments
+                for key, call_rec in list(pending_calls.items()):
+                    if key.startswith(f"{tool_name}_"):
+                        arguments = call_rec.action_detail.get("arguments", arguments)
+                        del pending_calls[key]
+                        break
+
+                tc = ToolCall(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    output_length=output_length,
+                    is_error=is_error,
+                    latency_ms=latency_ms,
+                    outcome=rec.outcome,
+                )
+                tool_calls.append(tc)
+                total_latency += latency_ms
+
+            elif rec.action_type == AuditEventType.PERMISSION_CHECK:
+                tool_name = rec.action_detail.get("tool_name", "unknown")
+                if rec.outcome == "denied":
+                    reason = rec.action_detail.get("reason", "unknown")
+                    permission_denials.append((tool_name, reason))
+
+            elif rec.action_type == AuditEventType.PERMISSION_GRANT:
+                tool_name = rec.action_detail.get("tool_name", "unknown")
+                permission_grants.append(tool_name)
+
+            elif rec.action_type == AuditEventType.LLM_REQUEST:
+                model = rec.action_detail.get("model", model)
+
+        errors = tuple(tc for tc in tool_calls if tc.is_error)
+
+        return SessionTrace(
+            session_id=session_id,
+            tool_calls=tuple(tool_calls),
+            errors=errors,
+            permission_denials=tuple(permission_denials),
+            permission_grants=tuple(permission_grants),
+            total_latency_ms=total_latency,
+            model=model,
+        )
+
+    @staticmethod
+    def _classify_error(tc: ToolCall) -> str:
+        """Classify a tool call error into a category."""
+        if tc.outcome == "timeout":
+            return "timeout"
+        if tc.outcome == "denied":
+            return "permission_denied"
+        # Check arguments for common patterns
+        args_str = str(tc.arguments).lower()
+        if "not found" in args_str or "no such file" in args_str:
+            return "invalid_args"
+        return "execution_error"
+
+    @staticmethod
+    def _suggest_fix(tool_name: str, category: str, examples: tuple[dict[str, Any], ...]) -> str:
+        """Generate a human-readable fix suggestion for a failure pattern."""
+        suggestions = {
+            "invalid_args": (
+                f"Tool '{tool_name}' description may be unclear about valid argument values"
+            ),
+            "permission_denied": (f"Tool '{tool_name}' needs permission configuration review"),
+            "timeout": (f"Tool '{tool_name}' may need a higher timeout or background execution"),
+            "execution_error": (f"Tool '{tool_name}' description may need better examples"),
+        }
+        return suggestions.get(category, f"Review tool '{tool_name}' for recurring errors")
+
+    @staticmethod
+    def _percentile(sorted_values: list[float], pct: int) -> float:
+        """Compute the p-th percentile of a sorted list."""
+        if not sorted_values:
+            return 0.0
+        n = len(sorted_values)
+        idx = (pct / 100) * (n - 1)
+        lower = int(idx)
+        upper = min(lower + 1, n - 1)
+        frac = idx - lower
+        return sorted_values[lower] * (1 - frac) + sorted_values[upper] * frac

--- a/src/godspeed/llm/client.py
+++ b/src/godspeed/llm/client.py
@@ -26,6 +26,15 @@ def _get_litellm():
     return _litellm
 
 
+class BudgetExceededError(RuntimeError):
+    """Raised when session cost exceeds the configured budget."""
+
+    def __init__(self, spent: float, limit: float) -> None:
+        self.spent = spent
+        self.limit = limit
+        super().__init__(f"Budget exceeded: ${spent:.4f} / ${limit:.2f} limit")
+
+
 @dataclass
 class ChatResponse:
     """Parsed response from an LLM call."""
@@ -34,6 +43,7 @@ class ChatResponse:
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     finish_reason: str | None = ""
     usage: dict[str, int] = field(default_factory=dict)
+    thinking: str = ""  # Extended thinking content (Anthropic models)
 
     @property
     def has_tool_calls(self) -> bool:
@@ -88,13 +98,18 @@ class LLMClient:
         fallback_models: list[str] | None = None,
         timeout: int = 120,
         router: ModelRouter | None = None,
+        thinking_budget: int = 0,
+        max_cost_usd: float = 0.0,
     ) -> None:
         self.model = model
         self.fallback_models = fallback_models or []
         self.timeout = timeout
         self.router = router or ModelRouter()
+        self.thinking_budget = thinking_budget
+        self.max_cost_usd = max_cost_usd
         self.total_input_tokens = 0
         self.total_output_tokens = 0
+        self.total_cost_usd: float = 0.0
 
     # Ollama models known to support native tool calling
     _TOOLS_CAPABLE_OLLAMA = (
@@ -257,6 +272,16 @@ class LLMClient:
                 cached.append(msg)
         return cached
 
+    def _is_anthropic_model(self, model: str | None = None) -> bool:
+        """Check if the model is an Anthropic/Claude model."""
+        name = (model or self.model).lower()
+        return any(prefix in name for prefix in ("claude", "anthropic"))
+
+    def _check_budget(self) -> None:
+        """Raise BudgetExceededError if session cost exceeds the limit."""
+        if self.max_cost_usd > 0 and self.total_cost_usd > self.max_cost_usd:
+            raise BudgetExceededError(self.total_cost_usd, self.max_cost_usd)
+
     async def _call(
         self,
         model: str,
@@ -264,6 +289,8 @@ class LLMClient:
         tools: list[dict[str, Any]] | None,
     ) -> ChatResponse:
         """Make a single LLM API call."""
+        from godspeed.llm.cost import estimate_cost
+
         # Apply prompt caching for supported providers
         cached_messages = self._apply_prompt_caching(model, messages)
 
@@ -282,11 +309,35 @@ class LLMClient:
                     model,
                 )
 
+        # Extended thinking for Anthropic models
+        if self.thinking_budget > 0 and self._is_anthropic_model(model):
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": self.thinking_budget}
+
         response = await _get_litellm().acompletion(**kwargs)
 
         # Parse response
         choice = response.choices[0]
         message = choice.message
+
+        # Extract thinking content from Anthropic responses
+        thinking_text = ""
+        if hasattr(message, "thinking") and message.thinking:
+            thinking_text = message.thinking
+        # Also check content blocks for thinking type
+        if not thinking_text and hasattr(message, "content") and isinstance(message.content, list):
+            for block in message.content:
+                if isinstance(block, dict) and block.get("type") == "thinking":
+                    thinking_text = block.get("thinking", "")
+                    break
+
+        # Extract text content (may be in content blocks)
+        content_text = ""
+        if isinstance(message.content, str):
+            content_text = message.content
+        elif isinstance(message.content, list):
+            for block in message.content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    content_text += block.get("text", "")
 
         # Extract tool calls
         tool_calls = []
@@ -302,18 +353,29 @@ class LLMClient:
                     }
                 )
 
-        # Track usage
+        # Track usage and cost
+        input_tokens = 0
+        output_tokens = 0
         if response.usage:
-            self.total_input_tokens += response.usage.prompt_tokens or 0
-            self.total_output_tokens += response.usage.completion_tokens or 0
+            input_tokens = response.usage.prompt_tokens or 0
+            output_tokens = response.usage.completion_tokens or 0
+            self.total_input_tokens += input_tokens
+            self.total_output_tokens += output_tokens
+
+        call_cost = estimate_cost(model, input_tokens, output_tokens)
+        self.total_cost_usd += call_cost
+
+        # Check budget after tracking
+        self._check_budget()
 
         return ChatResponse(
-            content=message.content or "",
+            content=content_text or "",
             tool_calls=tool_calls,
             finish_reason=choice.finish_reason or "",
+            thinking=thinking_text,
             usage={
-                "input_tokens": response.usage.prompt_tokens or 0,
-                "output_tokens": response.usage.completion_tokens or 0,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
             }
             if response.usage
             else {},

--- a/src/godspeed/llm/cost.py
+++ b/src/godspeed/llm/cost.py
@@ -77,6 +77,38 @@ def estimate_cost(
     return input_cost + output_cost
 
 
+def get_cheapest_model(models: list[str]) -> str:
+    """Return the model with the lowest per-token cost from a list.
+
+    Used for compaction: pick the cheapest model to summarize history.
+    Returns the first model if all are free (Ollama) or unknown.
+    """
+    if not models:
+        return ""
+
+    best_model = models[0]
+    best_cost = float("inf")
+
+    for model_name in models:
+        model_lower = model_name.lower()
+        # Free models get cost 0
+        if any(model_lower.startswith(prefix) for prefix in _FREE_PREFIXES):
+            return model_name  # Can't beat free
+
+        name = model_lower.split("/")[-1] if "/" in model_lower else model_lower
+        total_cost = 0.0
+        for prefix, (inp, out) in _MODEL_PRICING.items():
+            if name.startswith(prefix):
+                total_cost = inp + out
+                break
+
+        if total_cost < best_cost:
+            best_cost = total_cost
+            best_model = model_name
+
+    return best_model
+
+
 def format_cost(cost: float) -> str:
     """Format a cost value for display.
 

--- a/src/godspeed/llm/token_counter.py
+++ b/src/godspeed/llm/token_counter.py
@@ -32,6 +32,10 @@ _MODEL_ENCODINGS: dict[str, str] = {
 }
 _DEFAULT_ENCODING = "cl100k_base"
 
+# Approximate token cost for an image content block. OpenAI's high-detail mode
+# uses ~765 tokens per image. This is a safe upper estimate for context budgeting.
+IMAGE_BLOCK_TOKEN_ESTIMATE = 765
+
 
 def get_encoding(model: str) -> tiktoken.Encoding:
     """Get the tiktoken encoding for a model. Falls back to cl100k_base."""
@@ -77,6 +81,10 @@ def count_message_tokens(messages: list[dict[str, Any]], model: str = "gpt-4") -
                 # Tool calls or content blocks
                 for item in value:
                     if isinstance(item, dict):
+                        # Image content blocks get a flat token estimate
+                        if item.get("type") == "image_url":
+                            tokens += IMAGE_BLOCK_TOKEN_ESTIMATE
+                            continue
                         for v in item.values():
                             if isinstance(v, str):
                                 tokens += len(enc.encode(v))

--- a/src/godspeed/mcp/client.py
+++ b/src/godspeed/mcp/client.py
@@ -9,21 +9,45 @@ logger = logging.getLogger(__name__)
 
 
 class MCPServerConfig:
-    """Configuration for an MCP server connection."""
+    """Configuration for an MCP server connection.
+
+    Supports two transport modes:
+
+    **stdio** (default) — launches a local subprocess and communicates over
+    stdin/stdout.  Requires ``command`` and optionally ``args``/``env``.
+
+    **sse** — connects to a remote MCP server over HTTP (JSON-RPC).
+    Requires ``url`` and optionally ``headers`` for auth tokens.
+
+    Attributes:
+        name: Human-readable server identifier used in tool prefixes.
+        command: Executable path for stdio transport (ignored for sse).
+        args: CLI arguments passed to *command* (stdio only).
+        env: Extra environment variables for the subprocess (stdio only).
+        transport: ``"stdio"`` (default) or ``"sse"``.
+        url: Base URL of the remote MCP server (sse only, e.g.
+            ``"http://localhost:3001"``).
+        headers: HTTP headers sent with every request (sse only).  Useful
+            for Bearer tokens: ``{"Authorization": "Bearer <tok>"}``.
+    """
 
     def __init__(
         self,
         name: str,
-        command: str,
+        command: str = "",
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
         transport: str = "stdio",
+        url: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self.name = name
         self.command = command
         self.args = args or []
         self.env = env or {}
         self.transport = transport
+        self.url = url
+        self.headers = headers
 
 
 class MCPToolDefinition:
@@ -45,16 +69,20 @@ class MCPToolDefinition:
 class MCPClient:
     """Client for discovering and calling tools on MCP servers.
 
-    Wraps the mcp library for stdio transport. Gracefully handles
-    the case where the mcp package is not installed.
+    Wraps the mcp library for stdio transport and MCPSSEClient for
+    SSE/HTTP transport. Gracefully handles the case where dependencies
+    are not installed.
     """
 
     def __init__(self) -> None:
         self._connections: dict[str, Any] = {}
-        self._available = self._check_available()
+        self._sse_clients: dict[str, Any] = {}
+        self._stdio_available = self._check_stdio_available()
+        self._sse_available = self._check_sse_available()
 
     @staticmethod
-    def _check_available() -> bool:
+    def _check_stdio_available() -> bool:
+        """Check whether the ``mcp`` package is installed (required for stdio)."""
         try:
             import mcp  # noqa: F401
 
@@ -62,16 +90,82 @@ class MCPClient:
         except ImportError:
             return False
 
+    @staticmethod
+    def _check_sse_available() -> bool:
+        """Check whether ``httpx`` is installed (required for SSE transport)."""
+        try:
+            import httpx  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    @property
+    def stdio_available(self) -> bool:
+        """True when the ``mcp`` SDK is installed (needed for stdio transport)."""
+        return self._stdio_available
+
     @property
     def available(self) -> bool:
-        return self._available
+        """True when at least one transport backend can be used.
+
+        SSE transport only requires ``httpx`` (always bundled).  stdio
+        transport requires the ``mcp`` package.
+        """
+        return self._stdio_available or self._sse_available
 
     async def connect(self, config: MCPServerConfig) -> list[MCPToolDefinition]:
         """Connect to an MCP server and discover its tools.
 
         Returns a list of tool definitions provided by the server.
+        Supports both stdio and SSE transports based on config.transport.
         """
-        if not self._available:
+        if config.transport == "sse":
+            return await self._connect_sse(config)
+        return await self._connect_stdio(config)
+
+    async def _connect_sse(self, config: MCPServerConfig) -> list[MCPToolDefinition]:
+        """Connect to a remote MCP server via SSE/HTTP transport."""
+        if not self._sse_available:
+            logger.warning("httpx not installed — skipping SSE server %s", config.name)
+            return []
+
+        if config.url is None:
+            logger.error("MCP SSE config missing url server=%s", config.name)
+            return []
+
+        try:
+            from godspeed.mcp.sse_transport import MCPSSEClient
+
+            client = MCPSSEClient(base_url=config.url, headers=config.headers)
+            await client.connect()
+            self._sse_clients[config.name] = client
+
+            raw_tools = await client.list_tools()
+            definitions: list[MCPToolDefinition] = []
+            for tool in raw_tools:
+                defn = MCPToolDefinition(
+                    name=f"mcp_{config.name}_{tool.get('name', 'unknown')}",
+                    description=tool.get("description", f"MCP tool: {tool.get('name')}"),
+                    input_schema=tool.get("inputSchema", {}),
+                    server_name=config.name,
+                )
+                definitions.append(defn)
+
+            logger.info(
+                "MCP SSE connected server=%s tools=%d",
+                config.name,
+                len(definitions),
+            )
+            return definitions
+
+        except Exception as exc:
+            logger.error("MCP SSE connection failed server=%s error=%s", config.name, exc)
+            return []
+
+    async def _connect_stdio(self, config: MCPServerConfig) -> list[MCPToolDefinition]:
+        """Connect to a local MCP server via stdio transport."""
+        if not self._stdio_available:
             logger.warning("MCP package not installed — skipping server %s", config.name)
             return []
 
@@ -133,6 +227,12 @@ class MCPClient:
         Returns:
             The tool result as a string.
         """
+        # Check SSE clients first
+        sse_client = self._sse_clients.get(server_name)
+        if sse_client is not None:
+            return await sse_client.call_tool(tool_name, arguments)
+
+        # Fall back to stdio session
         session = self._connections.get(server_name)
         if session is None:
             return f"Error: MCP server '{server_name}' is not connected"
@@ -158,4 +258,10 @@ class MCPClient:
 
     async def disconnect_all(self) -> None:
         """Close all MCP server connections."""
+        for sse_client in self._sse_clients.values():
+            try:
+                await sse_client.disconnect()
+            except Exception as exc:
+                logger.error("MCP SSE disconnect error: %s", exc)
+        self._sse_clients.clear()
         self._connections.clear()

--- a/src/godspeed/mcp/sse_transport.py
+++ b/src/godspeed/mcp/sse_transport.py
@@ -1,0 +1,154 @@
+"""MCP SSE/HTTP transport — connect to remote MCP servers over HTTP."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Safety limits
+_TIMEOUT_SECONDS = 30.0
+_MAX_RESPONSE_BYTES = 1_048_576  # 1 MB
+
+
+class MCPSSEClient:
+    """MCP client for SSE/HTTP transport (remote MCP servers).
+
+    Uses JSON-RPC over HTTP — POST requests to well-known endpoints.
+    Does NOT depend on httpx-sse; responses are plain JSON.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._headers = headers or {}
+        self._client: httpx.AsyncClient | None = None
+
+    async def connect(self) -> None:
+        """Initialize connection to SSE MCP server."""
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            headers=self._headers,
+            timeout=httpx.Timeout(_TIMEOUT_SECONDS),
+        )
+        try:
+            resp = await self._client.post("/initialize", json={})
+            resp.raise_for_status()
+            logger.info("MCP SSE connected url=%s", self._base_url)
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "MCP SSE initialize returned non-2xx url=%s status=%d",
+                self._base_url,
+                exc.response.status_code,
+            )
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            logger.error("MCP SSE connect failed url=%s error=%s", self._base_url, exc)
+            raise
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Discover available tools from the server.
+
+        Returns:
+            List of tool definition dicts with keys: name, description, inputSchema.
+        """
+        if self._client is None:
+            logger.error("MCP SSE client not connected — call connect() first")
+            return []
+
+        try:
+            resp = await self._client.post("/tools/list", json={})
+            resp.raise_for_status()
+            self._validate_response_size(resp)
+            data = resp.json()
+            tools: list[dict[str, Any]] = data.get("tools", [])
+            return tools
+        except httpx.TimeoutException:
+            logger.error("MCP SSE list_tools timed out url=%s", self._base_url)
+            return []
+        except (httpx.ConnectError, httpx.HTTPStatusError) as exc:
+            logger.error("MCP SSE list_tools failed url=%s error=%s", self._base_url, exc)
+            return []
+        except ValueError:
+            logger.error("MCP SSE list_tools returned invalid JSON url=%s", self._base_url)
+            return []
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        """Call a tool on the remote server.
+
+        Args:
+            tool_name: Name of the tool to call.
+            arguments: Tool arguments dict.
+
+        Returns:
+            The tool result as a string.
+        """
+        if self._client is None:
+            return "Error: MCP SSE client not connected"
+
+        try:
+            resp = await self._client.post(
+                "/tools/call",
+                json={"name": tool_name, "arguments": arguments},
+            )
+            resp.raise_for_status()
+            self._validate_response_size(resp)
+            data = resp.json()
+
+            # Extract text from content array (MCP standard format)
+            content = data.get("content", [])
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict) and "text" in item:
+                    parts.append(item["text"])
+            return "\n".join(parts) if parts else str(data)
+        except httpx.TimeoutException:
+            logger.error(
+                "MCP SSE call_tool timed out url=%s tool=%s",
+                self._base_url,
+                tool_name,
+            )
+            return f"Error: MCP SSE call timed out for tool '{tool_name}'"
+        except (httpx.ConnectError, httpx.HTTPStatusError) as exc:
+            logger.error(
+                "MCP SSE call_tool failed url=%s tool=%s error=%s",
+                self._base_url,
+                tool_name,
+                exc,
+            )
+            return f"Error: MCP SSE call failed for tool '{tool_name}' — {exc}"
+        except ValueError:
+            logger.error(
+                "MCP SSE call_tool returned invalid JSON url=%s tool=%s",
+                self._base_url,
+                tool_name,
+            )
+            return f"Error: MCP SSE returned invalid JSON for tool '{tool_name}'"
+
+    async def disconnect(self) -> None:
+        """Close the HTTP client."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+            logger.info("MCP SSE disconnected url=%s", self._base_url)
+
+    @staticmethod
+    def _validate_response_size(resp: httpx.Response) -> None:
+        """Reject responses exceeding the safety limit."""
+        content_length = resp.headers.get("content-length")
+        if content_length is not None and int(content_length) > _MAX_RESPONSE_BYTES:
+            msg = (
+                f"MCP SSE response too large: {content_length} bytes (limit {_MAX_RESPONSE_BYTES})"
+            )
+            raise ValueError(msg)
+        if len(resp.content) > _MAX_RESPONSE_BYTES:
+            msg = (
+                f"MCP SSE response too large: {len(resp.content)} bytes "
+                f"(limit {_MAX_RESPONSE_BYTES})"
+            )
+            raise ValueError(msg)

--- a/src/godspeed/tools/background.py
+++ b/src/godspeed/tools/background.py
@@ -1,0 +1,213 @@
+"""Background command execution — run long-running processes with status polling."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+logger = logging.getLogger(__name__)
+
+MAX_CONCURRENT = 10
+
+
+@dataclass
+class BackgroundProcess:
+    """Tracked background subprocess."""
+
+    id: int
+    command: str
+    process: asyncio.subprocess.Process
+    started_at: float
+    stdout_chunks: list[str] = field(default_factory=list)
+    stderr_chunks: list[str] = field(default_factory=list)
+    _collection_task: asyncio.Task[None] | None = field(default=None, repr=False)
+
+    @property
+    def is_running(self) -> bool:
+        return self.process.returncode is None
+
+    @property
+    def returncode(self) -> int | None:
+        return self.process.returncode
+
+    @property
+    def elapsed_secs(self) -> float:
+        return time.monotonic() - self.started_at
+
+    @property
+    def stdout(self) -> str:
+        return "".join(self.stdout_chunks)
+
+    @property
+    def stderr(self) -> str:
+        return "".join(self.stderr_chunks)
+
+
+class BackgroundRegistry:
+    """Singleton registry tracking running background processes."""
+
+    _instance: BackgroundRegistry | None = None
+
+    def __init__(self) -> None:
+        self._processes: dict[int, BackgroundProcess] = {}
+        self._next_id = 1
+
+    @classmethod
+    def get(cls) -> BackgroundRegistry:
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset the singleton (for testing)."""
+        cls._instance = None
+
+    def add(self, proc: BackgroundProcess) -> None:
+        self._processes[proc.id] = proc
+
+    def get_process(self, pid: int) -> BackgroundProcess | None:
+        return self._processes.get(pid)
+
+    def list_all(self) -> list[BackgroundProcess]:
+        return list(self._processes.values())
+
+    @property
+    def count(self) -> int:
+        return len(self._processes)
+
+    def next_id(self) -> int:
+        pid = self._next_id
+        self._next_id += 1
+        return pid
+
+    @property
+    def active_count(self) -> int:
+        return sum(1 for p in self._processes.values() if p.is_running)
+
+
+async def _collect_output(proc: BackgroundProcess) -> None:
+    """Collect stdout/stderr from a background process."""
+
+    async def _read_stream(stream: asyncio.StreamReader | None, chunks: list[str]) -> None:
+        if stream is None:
+            return
+        while True:
+            line = await stream.readline()
+            if not line:
+                break
+            chunks.append(line.decode("utf-8", errors="replace"))
+
+    await asyncio.gather(
+        _read_stream(proc.process.stdout, proc.stdout_chunks),
+        _read_stream(proc.process.stderr, proc.stderr_chunks),
+    )
+    await proc.process.wait()
+
+
+class BackgroundCheckTool(Tool):
+    """Check status, get output, or kill background processes."""
+
+    @property
+    def name(self) -> str:
+        return "background_check"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Check on background processes. Actions: 'status' (show all), "
+            "'output' (get stdout/stderr for a process), 'kill' (terminate a process)."
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.LOW
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["status", "output", "kill"],
+                    "description": "The action to perform",
+                },
+                "id": {
+                    "type": "integer",
+                    "description": "Process ID (required for 'output' and 'kill')",
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        action = arguments.get("action", "")
+        registry = BackgroundRegistry.get()
+
+        if action == "status":
+            return self._status(registry)
+        elif action == "output":
+            return self._output(registry, arguments)
+        elif action == "kill":
+            return await self._kill(registry, arguments)
+
+        return ToolResult.failure(f"Invalid action: {action}")
+
+    def _status(self, registry: BackgroundRegistry) -> ToolResult:
+        processes = registry.list_all()
+        if not processes:
+            return ToolResult.success("No background processes.")
+
+        lines = []
+        for proc in processes:
+            status = "running" if proc.is_running else f"exited ({proc.returncode})"
+            elapsed = f"{proc.elapsed_secs:.1f}s"
+            lines.append(f"  [{proc.id}] {status} ({elapsed}) — {proc.command[:80]}")
+
+        return ToolResult.success("\n".join(lines))
+
+    def _output(self, registry: BackgroundRegistry, arguments: dict[str, Any]) -> ToolResult:
+        pid = arguments.get("id")
+        if pid is None:
+            return ToolResult.failure("id is required for 'output' action")
+
+        proc = registry.get_process(pid)
+        if proc is None:
+            return ToolResult.failure(f"No process with id {pid}")
+
+        parts = []
+        if proc.stdout:
+            parts.append(f"STDOUT:\n{proc.stdout}")
+        if proc.stderr:
+            parts.append(f"STDERR:\n{proc.stderr}")
+        if not parts:
+            parts.append("(no output yet)")
+
+        status = "running" if proc.is_running else f"exited ({proc.returncode})"
+        header = f"Process {pid} [{status}]"
+        return ToolResult.success(f"{header}\n" + "\n".join(parts))
+
+    async def _kill(self, registry: BackgroundRegistry, arguments: dict[str, Any]) -> ToolResult:
+        pid = arguments.get("id")
+        if pid is None:
+            return ToolResult.failure("id is required for 'kill' action")
+
+        proc = registry.get_process(pid)
+        if proc is None:
+            return ToolResult.failure(f"No process with id {pid}")
+
+        if not proc.is_running:
+            return ToolResult.success(f"Process {pid} already exited ({proc.returncode})")
+
+        proc.process.terminate()
+        try:
+            await asyncio.wait_for(proc.process.wait(), timeout=5)
+        except TimeoutError:
+            proc.process.kill()
+
+        return ToolResult.success(f"Process {pid} terminated")

--- a/src/godspeed/tools/diff_apply.py
+++ b/src/godspeed/tools/diff_apply.py
@@ -1,0 +1,362 @@
+"""Unified diff apply tool — parse and apply unified diffs to files."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+from godspeed.tools.path_utils import resolve_tool_path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Hunk:
+    """A single hunk from a unified diff."""
+
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FileDiff:
+    """All hunks targeting a single file."""
+
+    old_path: str
+    new_path: str
+    hunks: list[Hunk] = field(default_factory=list)
+    is_new_file: bool = False
+
+
+def parse_unified_diff(diff_text: str) -> list[FileDiff]:
+    """Parse a unified diff string into structured FileDiff objects.
+
+    Raises:
+        ValueError: On malformed diff content.
+    """
+    diff_text = diff_text.replace("\r\n", "\n").replace("\r", "\n")
+
+    file_diffs: list[FileDiff] = []
+    lines = diff_text.split("\n")
+    i = 0
+
+    while i < len(lines):
+        if lines[i].startswith("--- "):
+            old_header = lines[i]
+            if i + 1 >= len(lines) or not lines[i + 1].startswith("+++ "):
+                msg = f"Expected '+++ ' after '--- ' at line {i + 1}"
+                raise ValueError(msg)
+            new_header = lines[i + 1]
+            i += 2
+
+            old_path = _extract_path(old_header)
+            new_path = _extract_path(new_header)
+            is_new = old_path == "/dev/null"
+
+            file_diff = FileDiff(
+                old_path=old_path,
+                new_path=new_path,
+                is_new_file=is_new,
+            )
+
+            # Parse hunks for this file
+            while i < len(lines) and lines[i].startswith("@@"):
+                hunk, i = _parse_hunk(lines, i)
+                file_diff.hunks.append(hunk)
+
+            file_diffs.append(file_diff)
+        else:
+            i += 1
+
+    return file_diffs
+
+
+def _extract_path(header: str) -> str:
+    """Extract file path from --- or +++ header line.
+
+    Handles formats like:
+        --- a/path/to/file
+        +++ b/path/to/file
+        --- /dev/null
+    """
+    rest = header[4:].strip()
+    if rest == "/dev/null":
+        return rest
+    if rest.startswith("a/") or rest.startswith("b/"):
+        return rest[2:]
+    return rest
+
+
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def _parse_hunk(lines: list[str], start: int) -> tuple[Hunk, int]:
+    """Parse a single hunk starting at the @@ line.
+
+    Returns the Hunk and the next line index after the hunk.
+    """
+    match = _HUNK_RE.match(lines[start])
+    if not match:
+        msg = f"Malformed hunk header at line {start + 1}: {lines[start]}"
+        raise ValueError(msg)
+
+    old_start = int(match.group(1))
+    old_count = int(match.group(2)) if match.group(2) is not None else 1
+    new_start = int(match.group(3))
+    new_count = int(match.group(4)) if match.group(4) is not None else 1
+
+    hunk = Hunk(
+        old_start=old_start,
+        old_count=old_count,
+        new_start=new_start,
+        new_count=new_count,
+    )
+
+    i = start + 1
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("@@") or line.startswith("--- "):
+            break
+        if line.startswith("+") or line.startswith("-") or line.startswith(" "):
+            hunk.lines.append(line)
+            i += 1
+        elif line == "":
+            # Bare empty line — could be context with stripped trailing space.
+            # Treat as context if the next line continues the hunk.
+            if i + 1 < len(lines) and (
+                lines[i + 1].startswith("+")
+                or lines[i + 1].startswith("-")
+                or lines[i + 1].startswith(" ")
+            ):
+                hunk.lines.append(" ")
+                i += 1
+            else:
+                break
+        else:
+            break
+
+    return hunk, i
+
+
+def _apply_hunk_to_lines(
+    file_lines: list[str],
+    hunk: Hunk,
+    fuzzy_range: int = 3,
+) -> tuple[list[str], bool]:
+    """Apply a single hunk to file lines with fuzzy matching.
+
+    Tries exact position first, then searches +/-fuzzy_range lines.
+
+    Returns:
+        Tuple of (new_lines, used_fuzzy). Raises ValueError on failure.
+    """
+    # Build expected old block (context + removals)
+    old_block: list[str] = []
+    for ln in hunk.lines:
+        if ln.startswith(" ") or ln.startswith("-"):
+            old_block.append(ln[1:])
+
+    # Build new block (context + additions)
+    new_block: list[str] = []
+    for ln in hunk.lines:
+        if ln.startswith(" ") or ln.startswith("+"):
+            new_block.append(ln[1:])
+
+    # 1-indexed to 0-indexed
+    target_line = hunk.old_start - 1
+
+    # Try exact position, then fuzzy offsets
+    offsets = [0] + [d for delta in range(1, fuzzy_range + 1) for d in (-delta, delta)]
+
+    for offset in offsets:
+        pos = target_line + offset
+        if pos < 0 or pos + len(old_block) > len(file_lines):
+            continue
+
+        candidate = file_lines[pos : pos + len(old_block)]
+        if candidate == old_block:
+            new_lines = file_lines[:pos] + new_block + file_lines[pos + len(old_block) :]
+            return new_lines, offset != 0
+
+    expected_preview = "\n".join(old_block[:5])
+    actual_start = max(0, target_line)
+    actual_end = min(len(file_lines), target_line + len(old_block))
+    actual_preview = "\n".join(file_lines[actual_start:actual_end][:5])
+    msg = (
+        f"Hunk at line {hunk.old_start} failed to match.\n"
+        f"Expected:\n{expected_preview}\n"
+        f"Got:\n{actual_preview}"
+    )
+    raise ValueError(msg)
+
+
+def apply_file_diff(
+    file_diff: FileDiff,
+    cwd: Path,
+    *,
+    dry_run: bool = False,
+    fuzzy_range: int = 3,
+) -> tuple[int, int]:
+    """Apply all hunks for a single file.
+
+    Args:
+        file_diff: Parsed diff for one file.
+        cwd: Working directory for path resolution.
+        dry_run: If True, validate without writing.
+        fuzzy_range: Max lines to search for fuzzy context match.
+
+    Returns:
+        Tuple of (hunks_applied, fuzzy_count).
+
+    Raises:
+        ValueError: If path resolution or hunk application fails.
+    """
+    target_path_str = file_diff.new_path
+
+    resolved = resolve_tool_path(target_path_str, cwd)
+
+    if file_diff.is_new_file:
+        new_content_lines: list[str] = []
+        for hunk in file_diff.hunks:
+            for ln in hunk.lines:
+                if ln.startswith("+"):
+                    new_content_lines.append(ln[1:])
+        if not dry_run:
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+            resolved.write_text(
+                "\n".join(new_content_lines) + "\n",
+                encoding="utf-8",
+            )
+        logger.info(
+            "diff_apply action=%s path=%s hunks=%d",
+            "dry_run_new" if dry_run else "created",
+            target_path_str,
+            len(file_diff.hunks),
+        )
+        return len(file_diff.hunks), 0
+
+    if not resolved.exists():
+        msg = f"File not found: {target_path_str}"
+        raise ValueError(msg)
+
+    content = resolved.read_text(encoding="utf-8")
+    content = content.replace("\r\n", "\n").replace("\r", "\n")
+    file_lines = content.split("\n")
+
+    trailing_newline = content.endswith("\n")
+    if trailing_newline and file_lines and file_lines[-1] == "":
+        file_lines = file_lines[:-1]
+
+    fuzzy_count = 0
+    # Apply hunks in REVERSE order to preserve line numbers
+    for hunk in reversed(file_diff.hunks):
+        file_lines, used_fuzzy = _apply_hunk_to_lines(file_lines, hunk, fuzzy_range)
+        if used_fuzzy:
+            fuzzy_count += 1
+
+    if not dry_run:
+        out = "\n".join(file_lines)
+        if trailing_newline:
+            out += "\n"
+        resolved.write_text(out, encoding="utf-8")
+
+    logger.info(
+        "diff_apply action=%s path=%s hunks=%d fuzzy=%d",
+        "dry_run" if dry_run else "applied",
+        target_path_str,
+        len(file_diff.hunks),
+        fuzzy_count,
+    )
+    return len(file_diff.hunks), fuzzy_count
+
+
+class DiffApplyTool(Tool):
+    """Apply a unified diff to one or more files.
+
+    Parses standard unified diff format and applies hunks in reverse order
+    to preserve line numbers. Supports fuzzy context matching (+-3 lines)
+    when exact position doesn't match.
+    """
+
+    @property
+    def name(self) -> str:
+        return "diff_apply"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Apply a unified diff to files. Supports multi-file diffs, "
+            "fuzzy context matching, dry-run validation, and new file creation."
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.LOW
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "diff": {
+                    "type": "string",
+                    "description": (
+                        "Unified diff text to apply. Must include --- a/file and "
+                        "+++ b/file headers and @@ hunk headers."
+                    ),
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": ("If true, validate the diff can be applied without writing."),
+                    "default": False,
+                },
+            },
+            "required": ["diff"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        diff_text = arguments.get("diff", "")
+        dry_run = bool(arguments.get("dry_run", False))
+
+        if not isinstance(diff_text, str) or not diff_text.strip():
+            return ToolResult.failure("diff must be a non-empty string")
+
+        try:
+            file_diffs = parse_unified_diff(diff_text)
+        except ValueError as exc:
+            return ToolResult.failure(f"Failed to parse diff: {exc}")
+
+        if not file_diffs:
+            return ToolResult.failure("No file diffs found in the provided diff content")
+
+        total_hunks = 0
+        total_fuzzy = 0
+        files_modified = 0
+
+        for file_diff in file_diffs:
+            try:
+                hunks_applied, fuzzy_count = apply_file_diff(
+                    file_diff, context.cwd, dry_run=dry_run
+                )
+            except ValueError as exc:
+                return ToolResult.failure(str(exc))
+
+            total_hunks += hunks_applied
+            total_fuzzy += fuzzy_count
+            files_modified += 1
+
+        if dry_run:
+            summary = f"Dry run: {total_hunks} hunks to {files_modified} files would apply"
+        else:
+            summary = f"Applied {total_hunks} hunks to {files_modified} files"
+
+        if total_fuzzy > 0:
+            summary += f" ({total_fuzzy} with fuzzy matching)"
+
+        return ToolResult.success(summary)

--- a/src/godspeed/tools/file_read.py
+++ b/src/godspeed/tools/file_read.py
@@ -91,6 +91,10 @@ class FileReadTool(Tool):
         if not file_path.is_file():
             return ToolResult.failure(f"Not a file: {file_path}")
 
+        # Notebook: render as structured text
+        if file_path.suffix.lower() == ".ipynb":
+            return self._read_notebook(file_path)
+
         # Size check
         size_kb = file_path.stat().st_size / 1024
         if size_kb > MAX_FILE_SIZE_KB:
@@ -128,3 +132,48 @@ class FileReadTool(Tool):
             output += f"\n\n... ({total_lines - end_idx} more lines)"
 
         return ToolResult.success(output)
+
+    @staticmethod
+    def _read_notebook(file_path: Any) -> ToolResult:
+        """Parse a .ipynb notebook and render cells as structured text."""
+        import json
+
+        try:
+            data = json.loads(file_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            return ToolResult.failure(f"Failed to parse notebook: {exc}")
+
+        cells = data.get("cells", [])
+        if not cells:
+            return ToolResult.success("(empty notebook — no cells)")
+
+        parts: list[str] = []
+        for idx, cell in enumerate(cells):
+            cell_type = cell.get("cell_type", "unknown")
+            source_lines = cell.get("source", [])
+            source = "".join(source_lines) if isinstance(source_lines, list) else str(source_lines)
+
+            parts.append(f"[Cell {idx}: {cell_type}]")
+            parts.append(source.rstrip())
+
+            # Render outputs for code cells
+            outputs = cell.get("outputs", [])
+            for out in outputs:
+                out_type = out.get("output_type", "")
+                if out_type == "stream":
+                    text = "".join(out.get("text", []))
+                    parts.append("[Output: stream]")
+                    parts.append(text.rstrip())
+                elif out_type in ("execute_result", "display_data"):
+                    text_data = out.get("data", {}).get("text/plain", [])
+                    text = "".join(text_data) if isinstance(text_data, list) else str(text_data)
+                    parts.append(f"[Output: {out_type}]")
+                    parts.append(text.rstrip())
+                elif out_type == "error":
+                    ename = out.get("ename", "Error")
+                    evalue = out.get("evalue", "")
+                    parts.append(f"[Output: error] {ename}: {evalue}")
+
+            parts.append("")  # blank line between cells
+
+        return ToolResult.success("\n".join(parts))

--- a/src/godspeed/tools/github.py
+++ b/src/godspeed/tools/github.py
@@ -1,0 +1,331 @@
+"""GitHub tool — PR/issue workflow via the gh CLI."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+logger = logging.getLogger(__name__)
+
+VALID_ACTIONS = frozenset(
+    {
+        "create_pr",
+        "list_prs",
+        "get_pr",
+        "list_issues",
+        "get_issue",
+        "create_issue",
+        "comment_issue",
+        "comment_pr",
+    }
+)
+
+_GH_TIMEOUT = 30
+
+
+async def _run_gh(args: list[str], cwd: str) -> tuple[int, str, str]:
+    """Run a gh CLI command via asyncio subprocess and return (returncode, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_exec(
+        "gh",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+    )
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=_GH_TIMEOUT)
+    except TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        raise
+
+    stdout = stdout_bytes.decode("utf-8", errors="replace") if stdout_bytes else ""
+    stderr = stderr_bytes.decode("utf-8", errors="replace") if stderr_bytes else ""
+    return proc.returncode or 0, stdout, stderr
+
+
+class GithubTool(Tool):
+    """GitHub PR and issue operations via the gh CLI.
+
+    Supports creating/listing/viewing PRs and issues, and adding comments.
+    Requires the ``gh`` CLI to be installed and authenticated.
+    """
+
+    @property
+    def name(self) -> str:
+        return "github"
+
+    @property
+    def description(self) -> str:
+        return (
+            "GitHub operations via the gh CLI: create/list/view pull requests and issues, "
+            "add comments. Requires gh to be installed and authenticated."
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.HIGH
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": sorted(VALID_ACTIONS),
+                    "description": "GitHub action to perform",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Title for create_pr or create_issue",
+                },
+                "body": {
+                    "type": "string",
+                    "description": (
+                        "Body text for create_pr, create_issue, comment_issue, or comment_pr"
+                    ),
+                },
+                "base": {
+                    "type": "string",
+                    "description": "Base branch for create_pr (default: main)",
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["open", "closed", "all"],
+                    "description": "Filter state for list_prs / list_issues (default: open)",
+                },
+                "labels": {
+                    "type": "string",
+                    "description": "Comma-separated labels for list_issues or create_issue",
+                },
+                "number": {
+                    "type": "integer",
+                    "description": (
+                        "PR or issue number for get_pr, get_issue, comment_pr, comment_issue"
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        action = arguments.get("action", "")
+        if action not in VALID_ACTIONS:
+            return ToolResult.failure(
+                f"Invalid action: '{action}'. Must be one of: {', '.join(sorted(VALID_ACTIONS))}"
+            )
+
+        if not shutil.which("gh"):
+            return ToolResult.failure(
+                "gh CLI is not installed. Install from https://cli.github.com/"
+            )
+
+        cwd = str(context.cwd)
+        logger.info("github.execute action=%s cwd=%s", action, cwd)
+
+        try:
+            if action == "create_pr":
+                return await self._create_pr(arguments, cwd)
+            if action == "list_prs":
+                return await self._list_prs(arguments, cwd)
+            if action == "get_pr":
+                return await self._get_pr(arguments, cwd)
+            if action == "list_issues":
+                return await self._list_issues(arguments, cwd)
+            if action == "get_issue":
+                return await self._get_issue(arguments, cwd)
+            if action == "create_issue":
+                return await self._create_issue(arguments, cwd)
+            if action == "comment_issue":
+                return await self._comment_issue(arguments, cwd)
+            if action == "comment_pr":
+                return await self._comment_pr(arguments, cwd)
+        except TimeoutError:
+            logger.warning("github.timeout action=%s", action)
+            return ToolResult.failure(f"gh command timed out after {_GH_TIMEOUT}s")
+
+        return ToolResult.failure(f"Unhandled action: {action}")
+
+    # ------------------------------------------------------------------
+    # Pull Request actions
+    # ------------------------------------------------------------------
+
+    async def _create_pr(self, arguments: dict[str, Any], cwd: str) -> ToolResult:
+        title = arguments.get("title")
+        if not title:
+            return ToolResult.failure("title is required for create_pr")
+
+        body = arguments.get("body", "")
+        base = arguments.get("base", "main")
+
+        args = [
+            "pr",
+            "create",
+            "--title",
+            title,
+            "--body",
+            body,
+            "--base",
+            base,
+        ]
+        returncode, stdout, stderr = await _run_gh(args, cwd)
+        if returncode != 0:
+            return ToolResult.failure(f"gh pr create failed: {stderr.strip()}")
+
+        return ToolResult.success(stdout.strip())
+
+    async def _list_prs(self, arguments: dict[str, Any], cwd: str) -> ToolResult:
+        state = arguments.get("state", "open")
+
+        args = [
+            "pr",
+            "list",
+            "--state",
+            state,
+            "--json",
+            "number,title,state,author",
+        ]
+        returncode, stdout, stderr = await _run_gh(args, cwd)
+        if returncode != 0:
+            return ToolResult.failure(f"gh pr list failed: {stderr.strip()}")
+
+        return self._format_json(stdout)
+
+    async def _get_pr(self, arguments: dict[str, Any], cwd: str) -> ToolResult:
+        number = arguments.get("number")
+        if number is None:
+            return ToolResult.failure("number is required for get_pr")
+
+        args = [
+            "pr",
+            "view",
+            str(number),
+            "--json",
+            "number,title,state,body,additions,deletions,files",
+        ]
+        returncode, stdout, stderr = await _run_gh(args, cwd)
+        if returncode != 0:
+            return ToolResult.failure(f"gh pr view failed: {stderr.strip()}")
+
+        return self._format_json(stdout)
+
+    # ------------------------------------------------------------------
+    # Issue actions
+    # ------------------------------------------------------------------
+
+    async def _list_issues(self, arguments: dict[str, Any], cwd: str) -> ToolResult:
+        state = arguments.get("state", "open")
+        labels = arguments.get("labels")
+
+        args = [
+            "issue",
+            "list",
+            "--state",
+            state,
+            "--json",
+            "number,title,state,labels",
+        ]
+        if labels:
+            args.extend(["--label", labels])
+
+        returncode, stdout, stderr = await _run_gh(args, cwd)
+        if returncode != 0:
+            return ToolResult.failure(f"gh issue list failed: {stderr.strip()}")
+
+        return self._format_json(stdout)
+
+    async def _get_issue(self, arguments: dict[str, Any], cwd: str) -> ToolResult:
+        number = arguments.get("number")
+        if number is None:
+            return ToolResult.failure("number is required for get_issue")
+
+        args = [
+            "issue",
+            "view",
+            str(number),
+            "--json",
+            "number,title,state,body,labels,comments",
+        ]
+        returncode, stdout, stderr = await _run_gh(args, cwd)
+        if returncode != 0:
+            return ToolResult.failure(f"gh issue view failed: {stderr.strip()}")
+
+        return self._format_json(stdout)
+
+    async def _create_issue(self, arguments: dict[str, Any], cwd: str) -> ToolResult:
+        title = arguments.get("title")
+        if not title:
+            return ToolResult.failure("title is required for create_issue")
+
+        body = arguments.get("body", "")
+        labels = arguments.get("labels")
+
+        args = [
+            "issue",
+            "create",
+            "--title",
+            title,
+            "--body",
+            body,
+        ]
+        if labels:
+            args.extend(["--label", labels])
+
+        returncode, stdout, stderr = await _run_gh(args, cwd)
+        if returncode != 0:
+            return ToolResult.failure(f"gh issue create failed: {stderr.strip()}")
+
+        return ToolResult.success(stdout.strip())
+
+    # ------------------------------------------------------------------
+    # Comment actions
+    # ------------------------------------------------------------------
+
+    async def _comment_issue(self, arguments: dict[str, Any], cwd: str) -> ToolResult:
+        number = arguments.get("number")
+        body = arguments.get("body")
+        if number is None:
+            return ToolResult.failure("number is required for comment_issue")
+        if not body:
+            return ToolResult.failure("body is required for comment_issue")
+
+        args = ["issue", "comment", str(number), "--body", body]
+        returncode, _stdout, stderr = await _run_gh(args, cwd)
+        if returncode != 0:
+            return ToolResult.failure(f"gh issue comment failed: {stderr.strip()}")
+
+        return ToolResult.success(f"Commented on issue #{number}")
+
+    async def _comment_pr(self, arguments: dict[str, Any], cwd: str) -> ToolResult:
+        number = arguments.get("number")
+        body = arguments.get("body")
+        if number is None:
+            return ToolResult.failure("number is required for comment_pr")
+        if not body:
+            return ToolResult.failure("body is required for comment_pr")
+
+        args = ["pr", "comment", str(number), "--body", body]
+        returncode, _stdout, stderr = await _run_gh(args, cwd)
+        if returncode != 0:
+            return ToolResult.failure(f"gh pr comment failed: {stderr.strip()}")
+
+        return ToolResult.success(f"Commented on PR #{number}")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_json(raw: str) -> ToolResult:
+        """Parse gh JSON output and re-format for readability."""
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return ToolResult.success(raw.strip())
+
+        return ToolResult.success(json.dumps(data, indent=2))

--- a/src/godspeed/tools/image_read.py
+++ b/src/godspeed/tools/image_read.py
@@ -1,0 +1,112 @@
+"""Image read tool — read image files as base64-encoded content for vision LLMs."""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+from godspeed.tools.path_utils import resolve_tool_path
+
+logger = logging.getLogger(__name__)
+
+MAX_FILE_SIZE_BYTES = 20 * 1024 * 1024  # 20MB hard limit
+WARN_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB warning threshold
+
+SUPPORTED_FORMATS: dict[str, str] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
+
+class ImageReadTool(Tool):
+    """Read an image file and return base64-encoded content for vision-capable LLMs.
+
+    Supports PNG, JPG/JPEG, GIF, and WebP formats. Returns a JSON object
+    with a data URI suitable for multimodal LLM content blocks.
+    """
+
+    @property
+    def name(self) -> str:
+        return "image_read"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Read an image file from disk and return base64-encoded content "
+            "for vision-capable LLMs. Supports PNG, JPG, JPEG, GIF, and WebP."
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the image file to read (relative to project root)",
+                },
+            },
+            "required": ["file_path"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        file_path_str = arguments.get("file_path", "")
+        if not isinstance(file_path_str, str) or not file_path_str:
+            return ToolResult.failure("file_path must be a non-empty string")
+
+        try:
+            file_path = resolve_tool_path(file_path_str, context.cwd)
+        except ValueError as exc:
+            return ToolResult.failure(str(exc))
+
+        if not file_path.exists():
+            return ToolResult.failure(f"File not found: {file_path}")
+
+        if not file_path.is_file():
+            return ToolResult.failure(f"Not a file (is a directory?): {file_path}")
+
+        # Check supported format
+        suffix = file_path.suffix.lower()
+        mime_type = SUPPORTED_FORMATS.get(suffix)
+        if mime_type is None:
+            supported = ", ".join(sorted(SUPPORTED_FORMATS))
+            return ToolResult.failure(
+                f"Unsupported image format '{suffix}'. Supported formats: {supported}"
+            )
+
+        # Size checks
+        file_size = file_path.stat().st_size
+        if file_size > MAX_FILE_SIZE_BYTES:
+            size_mb = file_size / (1024 * 1024)
+            return ToolResult.failure(f"Image too large: {size_mb:.1f}MB (max 20MB)")
+
+        warning = ""
+        if file_size > WARN_FILE_SIZE_BYTES:
+            size_mb = file_size / (1024 * 1024)
+            warning = f" [WARNING: large image {size_mb:.1f}MB]"
+            logger.warning("large image file size=%d path=%s", file_size, file_path)
+
+        # Read and encode
+        try:
+            raw_bytes = file_path.read_bytes()
+        except OSError as exc:
+            return ToolResult.failure(f"Failed to read image: {exc}")
+
+        b64_data = base64.b64encode(raw_bytes).decode("ascii")
+        size_kb = file_size / 1024
+        filename = file_path.name
+
+        output = (
+            f"[Image: {filename}] ({mime_type}, {size_kb:.1f}KB){warning}\n"
+            f"data:{mime_type};base64,{b64_data}"
+        )
+
+        return ToolResult.success(output)

--- a/src/godspeed/tools/notebook.py
+++ b/src/godspeed/tools/notebook.py
@@ -1,0 +1,201 @@
+"""Notebook edit tool — cell-level operations on .ipynb files."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+from godspeed.tools.path_utils import resolve_tool_path
+
+logger = logging.getLogger(__name__)
+
+
+class NotebookEditTool(Tool):
+    """Edit Jupyter notebooks at the cell level.
+
+    Supports adding, editing, deleting, and moving cells within .ipynb files.
+    """
+
+    @property
+    def name(self) -> str:
+        return "notebook_edit"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Edit Jupyter notebook cells. Actions: edit_cell, add_cell, delete_cell, "
+            "move_cell. Operates on .ipynb files by cell index."
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.LOW
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the .ipynb notebook file",
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["edit_cell", "add_cell", "delete_cell", "move_cell"],
+                    "description": "The cell operation to perform",
+                },
+                "cell_index": {
+                    "type": "integer",
+                    "description": "0-based index of the target cell",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "New cell content (for edit_cell and add_cell)",
+                },
+                "cell_type": {
+                    "type": "string",
+                    "enum": ["code", "markdown", "raw"],
+                    "description": "Cell type for add_cell (default: code)",
+                },
+                "target_index": {
+                    "type": "integer",
+                    "description": "Destination index for move_cell",
+                },
+            },
+            "required": ["file_path", "action"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        file_path_str = arguments.get("file_path", "")
+        if not isinstance(file_path_str, str) or not file_path_str.strip():
+            return ToolResult.failure("file_path must be a non-empty string")
+
+        if not file_path_str.endswith(".ipynb"):
+            return ToolResult.failure("file_path must be a .ipynb file")
+
+        try:
+            file_path = resolve_tool_path(file_path_str, context.cwd)
+        except ValueError as exc:
+            return ToolResult.failure(str(exc))
+
+        if not file_path.exists():
+            return ToolResult.failure(f"File not found: {file_path_str}")
+
+        action = arguments.get("action", "")
+        if action not in ("edit_cell", "add_cell", "delete_cell", "move_cell"):
+            return ToolResult.failure(f"Invalid action: {action}")
+
+        try:
+            notebook = json.loads(file_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            return ToolResult.failure(f"Failed to parse notebook: {exc}")
+
+        cells = notebook.get("cells", [])
+
+        if action == "add_cell":
+            return self._add_cell(notebook, cells, arguments, file_path)
+        elif action == "edit_cell":
+            return self._edit_cell(cells, arguments, file_path, notebook)
+        elif action == "delete_cell":
+            return self._delete_cell(cells, arguments, file_path, notebook)
+        elif action == "move_cell":
+            return self._move_cell(cells, arguments, file_path, notebook)
+
+        return ToolResult.failure(f"Unknown action: {action}")
+
+    def _add_cell(
+        self,
+        notebook: dict[str, Any],
+        cells: list[dict[str, Any]],
+        arguments: dict[str, Any],
+        file_path: Any,
+    ) -> ToolResult:
+        content = arguments.get("content", "")
+        cell_type = arguments.get("cell_type", "code")
+        cell_index = arguments.get("cell_index")
+
+        new_cell: dict[str, Any] = {
+            "cell_type": cell_type,
+            "source": content.splitlines(keepends=True) if content else [],
+            "metadata": {},
+        }
+        if cell_type == "code":
+            new_cell["execution_count"] = None
+            new_cell["outputs"] = []
+
+        if cell_index is not None and 0 <= cell_index <= len(cells):
+            cells.insert(cell_index, new_cell)
+            pos = f"at index {cell_index}"
+        else:
+            cells.append(new_cell)
+            pos = f"at index {len(cells) - 1}"
+
+        notebook["cells"] = cells
+        file_path.write_text(json.dumps(notebook, indent=1, ensure_ascii=False), encoding="utf-8")
+        return ToolResult.success(f"Added {cell_type} cell {pos}")
+
+    def _edit_cell(
+        self,
+        cells: list[dict[str, Any]],
+        arguments: dict[str, Any],
+        file_path: Any,
+        notebook: dict[str, Any],
+    ) -> ToolResult:
+        cell_index = arguments.get("cell_index")
+        if cell_index is None:
+            return ToolResult.failure("cell_index is required for edit_cell")
+        if not (0 <= cell_index < len(cells)):
+            return ToolResult.failure(f"cell_index {cell_index} out of range (0-{len(cells) - 1})")
+
+        content = arguments.get("content", "")
+        cells[cell_index]["source"] = content.splitlines(keepends=True) if content else []
+
+        file_path.write_text(json.dumps(notebook, indent=1, ensure_ascii=False), encoding="utf-8")
+        return ToolResult.success(f"Updated cell {cell_index}")
+
+    def _delete_cell(
+        self,
+        cells: list[dict[str, Any]],
+        arguments: dict[str, Any],
+        file_path: Any,
+        notebook: dict[str, Any],
+    ) -> ToolResult:
+        cell_index = arguments.get("cell_index")
+        if cell_index is None:
+            return ToolResult.failure("cell_index is required for delete_cell")
+        if not (0 <= cell_index < len(cells)):
+            return ToolResult.failure(f"cell_index {cell_index} out of range (0-{len(cells) - 1})")
+
+        deleted = cells.pop(cell_index)
+        cell_type = deleted.get("cell_type", "unknown")
+        notebook["cells"] = cells
+
+        file_path.write_text(json.dumps(notebook, indent=1, ensure_ascii=False), encoding="utf-8")
+        return ToolResult.success(f"Deleted {cell_type} cell at index {cell_index}")
+
+    def _move_cell(
+        self,
+        cells: list[dict[str, Any]],
+        arguments: dict[str, Any],
+        file_path: Any,
+        notebook: dict[str, Any],
+    ) -> ToolResult:
+        cell_index = arguments.get("cell_index")
+        target_index = arguments.get("target_index")
+        if cell_index is None or target_index is None:
+            return ToolResult.failure("cell_index and target_index are required for move_cell")
+        if not (0 <= cell_index < len(cells)):
+            return ToolResult.failure(f"cell_index {cell_index} out of range (0-{len(cells) - 1})")
+        if not (0 <= target_index < len(cells)):
+            return ToolResult.failure(
+                f"target_index {target_index} out of range (0-{len(cells) - 1})"
+            )
+
+        cell = cells.pop(cell_index)
+        cells.insert(target_index, cell)
+        notebook["cells"] = cells
+
+        file_path.write_text(json.dumps(notebook, indent=1, ensure_ascii=False), encoding="utf-8")
+        return ToolResult.success(f"Moved cell from {cell_index} to {target_index}")

--- a/src/godspeed/tools/pdf_read.py
+++ b/src/godspeed/tools/pdf_read.py
@@ -1,0 +1,175 @@
+"""PDF read tool — extract text from PDF files with page range support."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+from godspeed.tools.path_utils import resolve_tool_path
+
+logger = logging.getLogger(__name__)
+
+MAX_PAGES_PER_REQUEST = 20
+
+
+def parse_page_range(pages_str: str, total_pages: int) -> tuple[list[int], str | None]:
+    """Parse a page range string into 0-based page indices.
+
+    Args:
+        pages_str: Human-readable page range, e.g. "1-5", "3", "10-20".
+        total_pages: Total number of pages in the document.
+
+    Returns:
+        Tuple of (list of 0-based page indices, error message or None).
+    """
+    pages_str = pages_str.strip()
+    if not pages_str:
+        return [], "pages must be a non-empty string"
+
+    if "-" in pages_str:
+        parts = pages_str.split("-", maxsplit=1)
+        try:
+            start = int(parts[0])
+            end = int(parts[1])
+        except ValueError:
+            return [], f"Invalid page range: '{pages_str}'. Expected format: '1-5' or '3'"
+        if start < 1:
+            return [], f"Page numbers must be >= 1, got {start}"
+        if end < start:
+            return [], f"Invalid range: end ({end}) < start ({start})"
+        if start > total_pages:
+            return [], f"Start page {start} exceeds document length ({total_pages} pages)"
+        # Clamp end to total_pages
+        end = min(end, total_pages)
+        indices = list(range(start - 1, end))
+    else:
+        try:
+            page_num = int(pages_str)
+        except ValueError:
+            return [], f"Invalid page number: '{pages_str}'. Expected format: '1-5' or '3'"
+        if page_num < 1:
+            return [], f"Page numbers must be >= 1, got {page_num}"
+        if page_num > total_pages:
+            return [], f"Page {page_num} exceeds document length ({total_pages} pages)"
+        indices = [page_num - 1]
+
+    if len(indices) > MAX_PAGES_PER_REQUEST:
+        return [], (
+            f"Requested {len(indices)} pages, max is {MAX_PAGES_PER_REQUEST} per request. "
+            f"Use a smaller range."
+        )
+
+    return indices, None
+
+
+class PdfReadTool(Tool):
+    """Read PDF files and extract text content with page range support.
+
+    Requires pymupdf (aka fitz). Install with: pip install pymupdf
+    """
+
+    @property
+    def name(self) -> str:
+        return "pdf_read"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Read a PDF file and extract text content. "
+            "Supports page ranges like '1-5', '3', or '10-20'. "
+            "Maximum 20 pages per request."
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the PDF file to read (relative to project root)",
+                },
+                "pages": {
+                    "type": "string",
+                    "description": (
+                        "Page range to read, e.g. '1-5', '3', '10-20'. "
+                        "1-based. Max 20 pages per request. "
+                        "Omit to read from the beginning."
+                    ),
+                },
+            },
+            "required": ["file_path"],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        try:
+            import pymupdf
+        except ImportError:
+            return ToolResult.failure(
+                "PDF support requires pymupdf. Install with: pip install pymupdf"
+            )
+
+        file_path_str = arguments.get("file_path", "")
+        if not isinstance(file_path_str, str) or not file_path_str:
+            return ToolResult.failure("file_path must be a non-empty string")
+
+        try:
+            file_path = resolve_tool_path(file_path_str, context.cwd)
+        except ValueError as exc:
+            return ToolResult.failure(str(exc))
+
+        if not file_path.exists():
+            return ToolResult.failure(f"File not found: {file_path}")
+
+        if not file_path.is_file():
+            return ToolResult.failure(f"Not a file: {file_path}")
+
+        if file_path.suffix.lower() != ".pdf":
+            return ToolResult.failure(
+                f"Not a PDF file: {file_path.name}. Only .pdf files are supported."
+            )
+
+        try:
+            doc = pymupdf.open(str(file_path))
+        except Exception as exc:
+            logger.error("Failed to open PDF %s", file_path, exc_info=True)
+            return ToolResult.failure(f"Failed to open PDF: {exc}")
+
+        total_pages = len(doc)
+        if total_pages == 0:
+            doc.close()
+            return ToolResult.failure("PDF has no pages")
+
+        pages_str = arguments.get("pages")
+        if pages_str is not None:
+            if not isinstance(pages_str, str):
+                pages_str = str(pages_str)
+            page_indices, error = parse_page_range(pages_str, total_pages)
+            if error:
+                doc.close()
+                return ToolResult.failure(error)
+        else:
+            # Default: read up to MAX_PAGES_PER_REQUEST from the beginning
+            page_count = min(total_pages, MAX_PAGES_PER_REQUEST)
+            page_indices = list(range(page_count))
+
+        blocks: list[str] = []
+        for idx in page_indices:
+            page = doc[idx]
+            text = page.get_text()
+            blocks.append(f"[Page {idx + 1}]:\n{text}")
+
+        doc.close()
+
+        output = "\n".join(blocks)
+        if total_pages > len(page_indices) and pages_str is None:
+            output += (
+                f"\n\n... ({total_pages - len(page_indices)} more pages. "
+                f"Use 'pages' parameter to read specific ranges.)"
+            )
+
+        return ToolResult.success(output)

--- a/src/godspeed/tools/registry.py
+++ b/src/godspeed/tools/registry.py
@@ -19,6 +19,7 @@ class ToolRegistry:
 
     def __init__(self) -> None:
         self._tools: dict[str, Tool] = {}
+        self._description_overrides: dict[str, str] = {}  # tool_name -> override
 
     def register(self, tool: Tool) -> None:
         """Register a tool. Raises ValueError on duplicate names."""
@@ -40,20 +41,48 @@ class ToolRegistry:
         """Return all registered tools."""
         return list(self._tools.values())
 
+    def update_description(self, tool_name: str, description: str) -> bool:
+        """Set a runtime description override for a tool.
+
+        The override is used in get_schemas() instead of the tool's built-in
+        description. Used by the self-evolution system to hot-swap descriptions.
+
+        Returns:
+            True if the tool exists and the override was set.
+        """
+        if tool_name not in self._tools:
+            return False
+        self._description_overrides[tool_name] = description
+        logger.debug("Description override set tool=%s len=%d", tool_name, len(description))
+        return True
+
+    def clear_description_override(self, tool_name: str) -> None:
+        """Remove a description override, reverting to the built-in description."""
+        self._description_overrides.pop(tool_name, None)
+
+    def get_description(self, tool_name: str) -> str | None:
+        """Get the effective description for a tool (override or built-in)."""
+        if tool_name in self._description_overrides:
+            return self._description_overrides[tool_name]
+        tool = self._tools.get(tool_name)
+        return tool.description if tool else None
+
     def get_schemas(self) -> list[dict[str, Any]]:
         """Generate tool schemas in the format expected by LLM APIs.
 
         Returns a list of tool definitions compatible with OpenAI/Anthropic
-        function calling format (LiteLLM normalizes this).
+        function calling format (LiteLLM normalizes this). Uses description
+        overrides from the self-evolution system when available.
         """
         schemas = []
         for tool in self._tools.values():
+            description = self._description_overrides.get(tool.name, tool.description)
             schemas.append(
                 {
                     "type": "function",
                     "function": {
                         "name": tool.name,
-                        "description": tool.description,
+                        "description": description,
                         "parameters": tool.get_schema(),
                     },
                 }

--- a/src/godspeed/tools/shell.py
+++ b/src/godspeed/tools/shell.py
@@ -71,6 +71,13 @@ class ShellTool(Tool):
                         f"Timeout in seconds (default: {DEFAULT_TIMEOUT}, max: {MAX_TIMEOUT})"
                     ),
                 },
+                "background": {
+                    "type": "boolean",
+                    "description": (
+                        "Run in background and return immediately. "
+                        "Use background_check tool to poll status."
+                    ),
+                },
             },
             "required": ["command"],
         }
@@ -79,6 +86,10 @@ class ShellTool(Tool):
         command = arguments.get("command", "")
         if not isinstance(command, str) or not command.strip():
             return ToolResult.failure("command must be a non-empty string")
+
+        # Background execution
+        if arguments.get("background", False):
+            return await self._execute_background(command, context)
 
         raw_timeout = arguments.get("timeout", DEFAULT_TIMEOUT)
         if not isinstance(raw_timeout, int):
@@ -121,3 +132,51 @@ class ShellTool(Tool):
             return ToolResult.failure(f"Exit code {proc.returncode}\n{output}")
 
         return ToolResult.success(output)
+
+    async def _execute_background(self, command: str, context: ToolContext) -> ToolResult:
+        """Spawn a command in the background and return its process ID."""
+        import asyncio
+        import time
+
+        from godspeed.tools.background import (
+            MAX_CONCURRENT,
+            BackgroundProcess,
+            BackgroundRegistry,
+            _collect_output,
+        )
+
+        registry = BackgroundRegistry.get()
+
+        if registry.active_count >= MAX_CONCURRENT:
+            return ToolResult.failure(
+                f"Too many background processes ({registry.active_count}/{MAX_CONCURRENT}). "
+                "Kill some before starting new ones."
+            )
+
+        shell_prefix = _detect_shell()
+        logger.info("shell.background command=%r", command)
+
+        proc = await asyncio.create_subprocess_exec(
+            *shell_prefix,
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=str(context.cwd),
+        )
+
+        pid = registry.next_id()
+        bg_proc = BackgroundProcess(
+            id=pid,
+            command=command,
+            process=proc,
+            started_at=time.monotonic(),
+        )
+        # Start collecting output in background
+        bg_proc._collection_task = asyncio.create_task(_collect_output(bg_proc))
+        registry.add(bg_proc)
+
+        return ToolResult.success(
+            f"Started background process {pid}\n"
+            f"Command: {command}\n"
+            f"Use background_check to poll status."
+        )

--- a/src/godspeed/tools/verify.py
+++ b/src/godspeed/tools/verify.py
@@ -21,6 +21,9 @@ from godspeed.tools.path_utils import resolve_tool_path
 
 logger = logging.getLogger(__name__)
 
+# Languages where auto-fix is safe and deterministic
+_FIXABLE_LANGUAGES: frozenset[str] = frozenset({"python", "javascript", "typescript"})
+
 # Timeout for linter subprocess
 VERIFY_TIMEOUT = 30
 
@@ -132,15 +135,22 @@ def _run_linter(cmd: list[str], display_path: str, linter_name: str) -> ToolResu
     return ToolResult.success(f"Lint issues in {display_path} ({linter_name}):\n{output}")
 
 
-def _verify_python(resolved: Path, display_path: str) -> ToolResult:
-    """Run ruff check on a Python file."""
+def _verify_python(resolved: Path, display_path: str, fix_mode: bool = False) -> ToolResult:
+    """Run ruff check on a Python file.
+
+    Args:
+        resolved: Absolute path to the file.
+        display_path: Relative path for user-facing messages.
+        fix_mode: When True, run ``ruff check --fix`` instead of ``--no-fix``.
+    """
     ruff_bin = shutil.which("ruff")
     if ruff_bin is None:
         return ToolResult.success(
             "ruff not found — skipping verification. Install with: pip install ruff"
         )
+    fix_flag = "--fix" if fix_mode else "--no-fix"
     return _run_linter(
-        [ruff_bin, "check", "--select=E,W,F", "--no-fix", str(resolved)],
+        [ruff_bin, "check", "--select=E,W,F", fix_flag, str(resolved)],
         display_path,
         "ruff",
     )
@@ -239,3 +249,109 @@ def _verify_c_cpp(resolved: Path, display_path: str) -> ToolResult:
         display_path,
         "clang-tidy",
     )
+
+
+def _has_lint_issues(result: ToolResult) -> bool:
+    """Return True if a verify ToolResult indicates lint issues (not a clean pass)."""
+    if result.is_error:
+        return True
+    output_lower = result.output.lower()
+    return "lint issues" in output_lower or "build issues" in output_lower
+
+
+def _verify_with_retry(
+    resolved: Path,
+    display_path: str,
+    lang: str,
+    cwd: Path,
+    max_retries: int = 3,
+) -> ToolResult:
+    """Run verify, auto-fix, and re-verify in a retry loop.
+
+    Only applies auto-fix for Python and JS/TS where fix tools are deterministic.
+    Go, Rust, and C/C++ skip the retry loop and return one-shot results.
+
+    Args:
+        resolved: Absolute path to the file.
+        display_path: Relative path for user-facing messages.
+        lang: Language key from ``_EXTENSION_MAP``.
+        cwd: Project working directory (needed for JS/TS linters).
+        max_retries: Maximum fix-then-recheck cycles. 0 means one-shot (no fix).
+
+    Returns:
+        ToolResult with summary of fixes applied and remaining issues.
+    """
+    # One-shot for non-fixable languages or when retries are disabled
+    if lang not in _FIXABLE_LANGUAGES or max_retries <= 0:
+        return _one_shot_verify(resolved, display_path, lang, cwd)
+
+    # Initial check
+    result = _one_shot_verify(resolved, display_path, lang, cwd)
+    if not _has_lint_issues(result):
+        return ToolResult.success(f"Verification passed: {display_path}")
+
+    total_fixed = 0
+    for attempt in range(max_retries):
+        # Run fix pass
+        _run_fix(resolved, display_path, lang, cwd)
+
+        # Re-check
+        recheck = _one_shot_verify(resolved, display_path, lang, cwd)
+        if not _has_lint_issues(recheck):
+            total_fixed += 1  # At least one round of fixes applied
+            return ToolResult.success(
+                f"Auto-fixed {attempt + 1} round(s) of issues, 0 remaining: {display_path}"
+            )
+        total_fixed += 1
+
+    # Exhausted retries — report remaining issues
+    final = _one_shot_verify(resolved, display_path, lang, cwd)
+    remaining_output = final.output if not final.is_error else (final.error or "")
+    return ToolResult.success(
+        f"Auto-fixed {total_fixed} round(s) of issues, "
+        f"some remaining: {display_path}\n{remaining_output}"
+    )
+
+
+def _one_shot_verify(resolved: Path, display_path: str, lang: str, cwd: Path) -> ToolResult:
+    """Run a single verify pass (no fix) for the given language."""
+    if lang == "python":
+        return _verify_python(resolved, display_path, fix_mode=False)
+    if lang in ("javascript", "typescript"):
+        return _verify_js_ts(resolved, display_path, cwd)
+    if lang == "go":
+        return _verify_go(resolved, display_path)
+    if lang == "rust":
+        return _verify_rust(resolved, display_path)
+    if lang == "c_cpp":
+        return _verify_c_cpp(resolved, display_path)
+    return ToolResult.success(f"No linter configured for {lang}. Skipping verification.")
+
+
+def _run_fix(resolved: Path, display_path: str, lang: str, cwd: Path) -> None:
+    """Run a fix pass for fixable languages. Errors are silently ignored."""
+    import contextlib
+
+    if lang == "python":
+        _verify_python(resolved, display_path, fix_mode=True)
+    elif lang in ("javascript", "typescript"):
+        # biome: `biome check --write`, eslint: `eslint --fix`
+        biome_bin = shutil.which("biome")
+        if biome_bin is not None:
+            with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+                subprocess.run(
+                    [biome_bin, "check", "--write", str(resolved)],
+                    capture_output=True,
+                    text=True,
+                    timeout=VERIFY_TIMEOUT,
+                )
+            return
+        eslint_bin = shutil.which("eslint")
+        if eslint_bin is not None:
+            with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+                subprocess.run(
+                    [eslint_bin, "--fix", str(resolved)],
+                    capture_output=True,
+                    text=True,
+                    timeout=VERIFY_TIMEOUT,
+                )

--- a/src/godspeed/tui/app.py
+++ b/src/godspeed/tui/app.py
@@ -25,9 +25,12 @@ from godspeed.tui.output import (
     console,
     format_assistant_text,
     format_error,
+    format_parallel_results,
+    format_parallel_tool_calls,
     format_permission_denied,
     format_permission_prompt,
     format_session_summary,
+    format_thinking,
     format_tool_call,
     format_tool_result,
     format_welcome,
@@ -194,6 +197,25 @@ class TUIApp:
                     break
                 continue
 
+            # Parse @-mentions from input and resolve to content blocks
+            effective_input = user_input
+            from godspeed.tui.mentions import parse_mentions, resolve_mentions
+
+            cleaned_text, mentions = parse_mentions(user_input)
+            if mentions:
+                try:
+                    mention_blocks = await resolve_mentions(mentions, self._tool_context.cwd)
+                    if mention_blocks:
+                        # Build multimodal message: cleaned text + resolved content
+
+                        content_blocks = [{"type": "text", "text": cleaned_text}]
+                        content_blocks.extend(mention_blocks)
+                        self._conversation.add_user_message(content_blocks)
+                        effective_input = ""  # Already added to conversation
+                except Exception as exc:
+                    logger.warning("Mention resolution failed: %s", exc)
+                    # Fall through with original input
+
             # Run agent loop with context-aware thinking indicator
             spinner = _ThinkingSpinner()
 
@@ -228,10 +250,32 @@ class TUIApp:
                 _s.stop()
                 format_permission_denied(tool_name, reason)
 
+            def _track_parallel_start(
+                calls: list[tuple[str, dict[str, Any]]],
+                _s: _ThinkingSpinner = spinner,
+            ) -> None:
+                _s.stop()
+                format_parallel_tool_calls(calls)
+
+            def _track_parallel_complete(
+                results: list[tuple[str, str, bool]],
+                _s: _ThinkingSpinner = spinner,
+            ) -> None:
+                format_parallel_results(results)
+                _s.start()
+
+            def _on_thinking(
+                text: str,
+                _s: _ThinkingSpinner = spinner,
+            ) -> None:
+                _s.stop()
+                format_thinking(text)
+                _s.start()
+
             try:
                 spinner.start()
                 await agent_loop(
-                    user_input=user_input,
+                    user_input=effective_input if effective_input else user_input,
                     conversation=self._conversation,
                     llm_client=self._llm_client,
                     tool_registry=self._tool_registry,
@@ -244,6 +288,10 @@ class TUIApp:
                     max_iterations=self._commands.max_iterations,
                     pause_event=self._pause_event,
                     hook_executor=self._hook_executor,
+                    skip_user_message=not effective_input,
+                    on_parallel_start=_track_parallel_start,
+                    on_parallel_complete=_track_parallel_complete,
+                    on_thinking=_on_thinking,
                 )
                 console.print()  # End streaming output with newline
             except KeyboardInterrupt:

--- a/src/godspeed/tui/commands.py
+++ b/src/godspeed/tui/commands.py
@@ -111,6 +111,7 @@ class Commands:
         self._handlers["/architect"] = self._cmd_architect
         self._handlers["/think"] = self._cmd_think
         self._handlers["/budget"] = self._cmd_budget
+        self._handlers["/evolve"] = self._cmd_evolve
         self._handlers["/export"] = self._cmd_export
         self._handlers["/quit"] = self._cmd_quit
         self._handlers["/exit"] = self._cmd_quit
@@ -171,6 +172,7 @@ class Commands:
                     ("/architect", "Toggle architect mode (plan then execute)"),
                     ("/think [budget]", "Toggle extended thinking or set token budget"),
                     ("/budget [amount]", "Show/set cost budget in USD"),
+                    ("/evolve [cmd]", "Self-evolution: status|run|history|rollback|review"),
                     ("/pause", "Pause the agent loop"),
                     ("/resume", "Resume a paused agent"),
                     ("/guidance <msg>", "Inject guidance and resume"),
@@ -509,6 +511,114 @@ class Commands:
 
         self._llm_client.max_cost_usd = limit
         format_success(f"Cost budget set to [{BOLD_PRIMARY}]${limit:.2f}[/{BOLD_PRIMARY}]")
+        return CommandResult(handled=True)
+
+    def _cmd_evolve(self, args: str = "") -> CommandResult:
+        """Self-evolution system commands."""
+        from godspeed.evolution.registry import EvolutionRegistry
+
+        parts = args.strip().split(None, 1)
+        subcmd = parts[0] if parts else "status"
+
+        # Use global dir for evolution storage
+        evo_dir = self._cwd / ".godspeed" / "evolution"
+
+        if subcmd == "status":
+            try:
+                registry = EvolutionRegistry(evo_dir)
+                stats = registry.stats()
+                format_info(
+                    f"[{BOLD_PRIMARY}]Evolution Status[/{BOLD_PRIMARY}]\n"
+                    f"  Total mutations: {stats['total_mutations']}\n"
+                    f"  Active: {stats['active']}\n"
+                    f"  Reverted: {stats['reverted']}\n"
+                    f"  Safety passed: {stats['safety_passed']}\n"
+                    f"  Safety failed: {stats['safety_failed']}\n"
+                    f"  Avg fitness: {stats['avg_fitness']:.3f}"
+                )
+            except Exception:
+                format_info(
+                    "No evolution data yet. "
+                    f"Run [{BOLD_PRIMARY}]/evolve run[/{BOLD_PRIMARY}] to start."
+                )
+            return CommandResult(handled=True)
+
+        if subcmd == "history":
+            artifact_id = parts[1] if len(parts) > 1 else ""
+            if not artifact_id:
+                format_error("Usage: /evolve history <artifact_id>")
+                return CommandResult(handled=True)
+
+            registry = EvolutionRegistry(evo_dir)
+            history = registry.get_history(artifact_id)
+            if not history:
+                format_info(
+                    f"No evolution history for [{BOLD_PRIMARY}]{artifact_id}[/{BOLD_PRIMARY}]"
+                )
+            else:
+                for rec in history:
+                    if rec.applied_at and not rec.reverted_at:
+                        status = "active"
+                    elif rec.reverted_at:
+                        status = "reverted"
+                    else:
+                        status = "candidate"
+                    format_info(
+                        f"  [{DIM}]{rec.record_id}[/{DIM}] fitness={rec.fitness_overall:.3f} "
+                        f"status={status} model={rec.model_used}"
+                    )
+            return CommandResult(handled=True)
+
+        if subcmd == "rollback":
+            record_id = parts[1] if len(parts) > 1 else ""
+            if not record_id:
+                format_error("Usage: /evolve rollback <record_id>")
+                return CommandResult(handled=True)
+
+            registry = EvolutionRegistry(evo_dir)
+            record = registry.get_record(record_id)
+            if record is None:
+                format_error(f"Record not found: {record_id}")
+            else:
+                registry.mark_reverted(record_id)
+                format_success(f"Rolled back [{BOLD_PRIMARY}]{record_id}[/{BOLD_PRIMARY}]")
+            return CommandResult(handled=True)
+
+        if subcmd == "review":
+            registry = EvolutionRegistry(evo_dir)
+            records = [
+                r
+                for r in registry._load_records()
+                if r.safety_passed and not r.applied_at and r.requires_review
+            ]
+            if not records:
+                format_info("No pending reviews.")
+            else:
+                for rec in records:
+                    format_info(
+                        f"  [{BOLD_PRIMARY}]{rec.record_id}[/{BOLD_PRIMARY}] "
+                        f"{rec.artifact_type}:{rec.artifact_id} "
+                        f"fitness={rec.fitness_overall:.3f}"
+                    )
+                format_info(f"\nApprove with: [{DIM}]/evolve approve <id>[/{DIM}]")
+            return CommandResult(handled=True)
+
+        if subcmd == "run":
+            format_info(
+                f"[{BOLD_PRIMARY}]Evolution run[/{BOLD_PRIMARY}] — analyzing traces...\n"
+                f"  [{DIM}]This runs asynchronously. Results will appear when complete.[/{DIM}]"
+            )
+            # The actual run is kicked off by the agent loop when it sees this message
+            return CommandResult(
+                handled=True,
+                message=(
+                    "Run evolution cycle: analyze traces → mutate → evaluate → apply improvements."
+                ),
+            )
+
+        format_error(
+            f"Unknown subcommand: {subcmd}\n  Usage: /evolve [status|run|history|rollback|review]"
+        )
         return CommandResult(handled=True)
 
     def _cmd_context(self, _args: str = "") -> CommandResult:

--- a/src/godspeed/tui/commands.py
+++ b/src/godspeed/tui/commands.py
@@ -83,6 +83,9 @@ class Commands:
         self._pause_event = pause_event
         self._handlers: dict[str, CommandHandler] = {}
         self.max_iterations: int | None = None  # None = use default
+        self.auto_commit: bool = False
+        self.auto_commit_threshold: int = 5
+        self.architect_mode: bool = False
         self._register_builtins()
 
     def _register_builtins(self) -> None:
@@ -104,6 +107,10 @@ class Commands:
         self._handlers["/tasks"] = self._cmd_tasks
         self._handlers["/reindex"] = self._cmd_reindex
         self._handlers["/stats"] = self._cmd_stats
+        self._handlers["/autocommit"] = self._cmd_autocommit
+        self._handlers["/architect"] = self._cmd_architect
+        self._handlers["/think"] = self._cmd_think
+        self._handlers["/budget"] = self._cmd_budget
         self._handlers["/export"] = self._cmd_export
         self._handlers["/quit"] = self._cmd_quit
         self._handlers["/exit"] = self._cmd_quit
@@ -160,6 +167,10 @@ class Commands:
                 [
                     ("/plan", "Toggle plan mode (read-only)"),
                     ("/extend [N]", "Set max iterations per turn"),
+                    ("/autocommit [on|off|N]", "Toggle auto-commit or set threshold"),
+                    ("/architect", "Toggle architect mode (plan then execute)"),
+                    ("/think [budget]", "Toggle extended thinking or set token budget"),
+                    ("/budget [amount]", "Show/set cost budget in USD"),
                     ("/pause", "Pause the agent loop"),
                     ("/resume", "Resume a paused agent"),
                     ("/guidance <msg>", "Inject guidance and resume"),
@@ -343,6 +354,161 @@ class Commands:
 
         self.max_iterations = value
         format_success(f"Max iterations set to [{BOLD_PRIMARY}]{value}[/{BOLD_PRIMARY}]")
+        return CommandResult(handled=True)
+
+    def _cmd_autocommit(self, args: str = "") -> CommandResult:
+        """Toggle auto-commit or set the file-change threshold."""
+        arg = args.strip().lower()
+
+        if arg == "on":
+            self.auto_commit = True
+            logger.info("autocommit toggled state=on threshold=%d", self.auto_commit_threshold)
+            format_success(
+                f"Auto-commit [{BOLD_PRIMARY}]ON[/{BOLD_PRIMARY}]"
+                f" (threshold: {self.auto_commit_threshold} files)"
+            )
+        elif arg == "off":
+            self.auto_commit = False
+            logger.info("autocommit toggled state=off")
+            format_info(f"Auto-commit [{BOLD_PRIMARY}]OFF[/{BOLD_PRIMARY}]")
+        elif arg:
+            # Numeric threshold
+            try:
+                value = int(arg)
+            except ValueError:
+                format_error(f"Invalid argument: {args.strip()}. Use on, off, or a number.")
+                return CommandResult(handled=True)
+
+            if value < 1:
+                format_error("Threshold must be at least 1.")
+                return CommandResult(handled=True)
+
+            self.auto_commit_threshold = value
+            self.auto_commit = True
+            logger.info(
+                "autocommit threshold_set threshold=%d state=on", self.auto_commit_threshold
+            )
+            format_success(
+                f"Auto-commit [{BOLD_PRIMARY}]ON[/{BOLD_PRIMARY}]"
+                f" — threshold set to [{BOLD_PRIMARY}]{value}[/{BOLD_PRIMARY}] files"
+            )
+        else:
+            # No args — toggle
+            self.auto_commit = not self.auto_commit
+            state = "ON" if self.auto_commit else "OFF"
+            logger.info(
+                "autocommit toggled state=%s threshold=%d",
+                state.lower(),
+                self.auto_commit_threshold,
+            )
+            format_info(
+                f"Auto-commit [{BOLD_PRIMARY}]{state}[/{BOLD_PRIMARY}]"
+                f" (threshold: {self.auto_commit_threshold} files)"
+            )
+
+        return CommandResult(handled=True)
+
+    def _cmd_architect(self, args: str = "") -> CommandResult:
+        """Toggle architect mode — two-phase plan-then-execute."""
+        self.architect_mode = not self.architect_mode
+        if self.architect_mode:
+            format_success(
+                f"Architect mode [{BOLD_PRIMARY}]ON[/{BOLD_PRIMARY}] "
+                "— requests will be planned before execution"
+            )
+        else:
+            format_info(f"Architect mode [{BOLD_PRIMARY}]OFF[/{BOLD_PRIMARY}]")
+        return CommandResult(handled=True)
+
+    def _cmd_think(self, args: str = "") -> CommandResult:
+        """Toggle extended thinking or set the thinking token budget."""
+        arg = args.strip()
+
+        if not arg:
+            # Toggle: off → default 10k, on → off
+            current = self._llm_client.thinking_budget
+            if current > 0:
+                self._llm_client.thinking_budget = 0
+                format_info(f"Extended thinking [{BOLD_PRIMARY}]OFF[/{BOLD_PRIMARY}]")
+            else:
+                self._llm_client.thinking_budget = 10_000
+                format_success(
+                    f"Extended thinking [{BOLD_PRIMARY}]ON[/{BOLD_PRIMARY}] (budget: 10,000 tokens)"
+                )
+            return CommandResult(handled=True)
+
+        if arg.lower() == "off":
+            self._llm_client.thinking_budget = 0
+            format_info(f"Extended thinking [{BOLD_PRIMARY}]OFF[/{BOLD_PRIMARY}]")
+            return CommandResult(handled=True)
+
+        try:
+            budget = int(arg.replace(",", "").replace("_", ""))
+        except ValueError:
+            format_error(f"Invalid budget: {arg}. Use a number or 'off'.")
+            return CommandResult(handled=True)
+
+        if budget < 1000:
+            format_error("Thinking budget must be at least 1,000 tokens.")
+            return CommandResult(handled=True)
+
+        self._llm_client.thinking_budget = budget
+        format_success(
+            f"Extended thinking [{BOLD_PRIMARY}]ON[/{BOLD_PRIMARY}] (budget: {budget:,} tokens)"
+        )
+        return CommandResult(handled=True)
+
+    def _cmd_budget(self, args: str = "") -> CommandResult:
+        """Show or set the cost budget in USD."""
+        from godspeed.llm.cost import format_cost
+
+        arg = args.strip()
+
+        if not arg:
+            # Show current cost and budget
+            spent = self._llm_client.total_cost_usd
+            limit = self._llm_client.max_cost_usd
+            model = self._llm_client.model
+            input_tokens = self._llm_client.total_input_tokens
+            output_tokens = self._llm_client.total_output_tokens
+
+            spent_str = format_cost(spent)
+            if limit > 0:
+                pct = (spent / limit * 100) if limit > 0 else 0
+                format_info(
+                    f"Cost: [{BOLD_PRIMARY}]{spent_str}[/{BOLD_PRIMARY}]"
+                    f" / ${limit:.2f} ({pct:.0f}%)"
+                )
+            else:
+                format_info(
+                    f"Cost: [{BOLD_PRIMARY}]{spent_str}[/{BOLD_PRIMARY}]"
+                    f" [{DIM}](no budget limit)[/{DIM}]"
+                )
+            console.print(
+                f"    [{DIM}]{input_tokens:,} input + {output_tokens:,} output tokens"
+                f" ({model})[/{DIM}]"
+            )
+            return CommandResult(handled=True)
+
+        if arg.lower() in ("off", "unlimited", "0"):
+            self._llm_client.max_cost_usd = 0.0
+            format_info(f"Cost budget [{BOLD_PRIMARY}]unlimited[/{BOLD_PRIMARY}]")
+            return CommandResult(handled=True)
+
+        # Strip $ prefix if present
+        cleaned = arg.lstrip("$")
+        try:
+            limit = float(cleaned)
+        except ValueError:
+            format_error(f"Invalid amount: {arg}. Use a number like 5.00 or 'off'.")
+            return CommandResult(handled=True)
+
+        if limit <= 0:
+            format_error("Budget must be positive. Use 'off' to disable.")
+            return CommandResult(handled=True)
+
+        self._llm_client.max_cost_usd = limit
+        format_success(f"Cost budget set to [{BOLD_PRIMARY}]${limit:.2f}[/{BOLD_PRIMARY}]")
         return CommandResult(handled=True)
 
     def _cmd_context(self, _args: str = "") -> CommandResult:

--- a/src/godspeed/tui/completions.py
+++ b/src/godspeed/tui/completions.py
@@ -18,8 +18,18 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/undo", "Undo last git commit"),
     ("/audit", "Show audit trail stats and verify chain"),
     ("/permissions", "Show current permission rules"),
+    ("/autocommit", "Toggle auto-commit or set threshold"),
+    ("/architect", "Toggle architect mode (plan then execute)"),
+    ("/think", "Toggle extended thinking or set token budget"),
+    ("/budget", "Show/set cost budget in USD"),
     ("/quit", "Exit Godspeed"),
     ("/exit", "Exit Godspeed"),
+]
+
+MENTION_TYPES: list[tuple[str, str]] = [
+    ("@file:", "Include file content"),
+    ("@folder:", "Include directory listing"),
+    ("@web:", "Fetch web page content (HTTPS only)"),
 ]
 
 
@@ -51,6 +61,12 @@ class GodspeedCompleter(Completer):
             yield from self._complete_slash_commands(stripped)
             return
 
+        # @-mention completion
+        mention_match = self._find_mention_at_cursor(text)
+        if mention_match is not None:
+            yield from self._complete_mentions(mention_match)
+            return
+
         # File path completion when there's a space (argument position)
         parts = stripped.split(maxsplit=1)
         if len(parts) == 2 and parts[0].startswith("/"):
@@ -65,6 +81,45 @@ class GodspeedCompleter(Completer):
                     cmd,
                     start_position=-len(text),
                     display_meta=description,
+                )
+
+    def _find_mention_at_cursor(self, text: str) -> str | None:
+        """Find an @-mention being typed at the cursor position.
+
+        Returns the partial mention text (e.g. "@file:src/m") or None.
+        """
+        # Walk backwards from cursor to find @ that starts a mention
+        import re
+
+        match = re.search(r"@(\S*)$", text)
+        if match:
+            return match.group(0)
+        return None
+
+    def _complete_mentions(self, partial: str) -> Iterable[Completion]:
+        """Complete @-mentions: type prefixes and file/folder paths."""
+        # If just "@" or partial type, suggest mention types
+        if ":" not in partial:
+            for mention, description in MENTION_TYPES:
+                if mention.startswith(partial):
+                    yield Completion(
+                        mention,
+                        start_position=-len(partial),
+                        display_meta=description,
+                    )
+            return
+
+        # If we have a type prefix (e.g. @file:src/), complete paths
+        prefix, path_part = partial.split(":", 1)
+        mention_type = prefix[1:]  # strip @
+
+        if mention_type in ("file", "folder"):
+            for completion in self._complete_file_paths(path_part):
+                # Re-wrap as full mention
+                yield Completion(
+                    f"{prefix}:{completion.text}",
+                    start_position=-len(partial),
+                    display_meta=completion.display_meta,
                 )
 
     def _complete_file_paths(self, partial: str) -> Iterable[Completion]:

--- a/src/godspeed/tui/completions.py
+++ b/src/godspeed/tui/completions.py
@@ -22,6 +22,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/architect", "Toggle architect mode (plan then execute)"),
     ("/think", "Toggle extended thinking or set token budget"),
     ("/budget", "Show/set cost budget in USD"),
+    ("/evolve", "Self-evolution: status|run|history|rollback|review"),
     ("/quit", "Exit Godspeed"),
     ("/exit", "Exit Godspeed"),
 ]

--- a/src/godspeed/tui/mentions.py
+++ b/src/godspeed/tui/mentions.py
@@ -1,0 +1,159 @@
+"""Parse and resolve @-mentions in user input.
+
+Supports @file:path, @folder:path, and @web:url syntax.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from godspeed.tools.path_utils import resolve_tool_path
+
+logger = logging.getLogger(__name__)
+
+# Match @file:path, @folder:path, @web:url — captures type and target
+_MENTION_PATTERN = re.compile(r"@(file|folder|web):(\S+)")
+
+
+@dataclass(frozen=True)
+class Mention:
+    """A parsed @-mention from user input."""
+
+    type: Literal["file", "folder", "web"]
+    raw: str  # Original matched text (e.g. "@file:src/main.py")
+    target: str  # The path or URL after the colon
+
+
+def parse_mentions(text: str) -> tuple[str, list[Mention]]:
+    """Extract @-mentions from user input text.
+
+    Args:
+        text: Raw user input string.
+
+    Returns:
+        Tuple of (cleaned_text, mentions) where cleaned_text has mentions
+        stripped and mentions is a list of parsed Mention objects.
+    """
+    mentions: list[Mention] = []
+    for match in _MENTION_PATTERN.finditer(text):
+        mention_type = match.group(1)
+        target = match.group(2)
+        mentions.append(
+            Mention(
+                type=mention_type,  # type: ignore[arg-type]
+                raw=match.group(0),
+                target=target,
+            )
+        )
+
+    cleaned = _MENTION_PATTERN.sub("", text).strip()
+    # Collapse multiple spaces left by stripping
+    cleaned = re.sub(r" {2,}", " ", cleaned)
+    return cleaned, mentions
+
+
+async def resolve_mentions(
+    mentions: list[Mention],
+    cwd: Path,
+) -> list[dict[str, Any]]:
+    """Resolve mentions to content blocks for multimodal messages.
+
+    Args:
+        mentions: List of parsed Mention objects.
+        cwd: Project working directory for path resolution.
+
+    Returns:
+        List of content blocks (text blocks with resolved content).
+    """
+    blocks: list[dict[str, Any]] = []
+
+    for mention in mentions:
+        try:
+            if mention.type == "file":
+                content = _resolve_file(mention.target, cwd)
+                blocks.append(
+                    {
+                        "type": "text",
+                        "text": f"[Content of {mention.target}]:\n{content}",
+                    }
+                )
+            elif mention.type == "folder":
+                content = _resolve_folder(mention.target, cwd)
+                blocks.append(
+                    {
+                        "type": "text",
+                        "text": f"[Directory listing of {mention.target}]:\n{content}",
+                    }
+                )
+            elif mention.type == "web":
+                content = await _resolve_web(mention.target)
+                blocks.append(
+                    {
+                        "type": "text",
+                        "text": f"[Content of {mention.target}]:\n{content}",
+                    }
+                )
+        except (ValueError, OSError) as exc:
+            logger.warning("Failed to resolve mention %s: %s", mention.raw, exc)
+            blocks.append(
+                {
+                    "type": "text",
+                    "text": f"[Error resolving {mention.raw}]: {exc}",
+                }
+            )
+
+    return blocks
+
+
+def _resolve_file(target: str, cwd: Path) -> str:
+    """Read file content with path traversal protection."""
+    resolved = resolve_tool_path(target, cwd)
+    if not resolved.is_file():
+        msg = f"Not a file: {target}"
+        raise ValueError(msg)
+    return resolved.read_text(encoding="utf-8", errors="replace")
+
+
+def _resolve_folder(target: str, cwd: Path) -> str:
+    """List directory contents with path traversal protection."""
+    resolved = resolve_tool_path(target, cwd)
+    if not resolved.is_dir():
+        msg = f"Not a directory: {target}"
+        raise ValueError(msg)
+
+    entries = sorted(resolved.iterdir())
+    lines = []
+    for entry in entries[:100]:  # Cap at 100 entries
+        suffix = "/" if entry.is_dir() else ""
+        rel = entry.relative_to(cwd.resolve()) if entry.is_relative_to(cwd.resolve()) else entry
+        lines.append(f"{rel}{suffix}")
+    if len(entries) > 100:
+        lines.append(f"... and {len(entries) - 100} more entries")
+    return "\n".join(lines)
+
+
+async def _resolve_web(url: str) -> str:
+    """Fetch web content. HTTPS only, with size limit."""
+    if not url.startswith("https://"):
+        msg = f"Only HTTPS URLs are allowed, got: {url}"
+        raise ValueError(msg)
+
+    try:
+        import httpx
+    except ImportError as exc:
+        msg = "httpx is required for @web mentions (pip install httpx)"
+        raise ImportError(msg) from exc
+
+    async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+        response = await client.get(url, headers={"User-Agent": "Godspeed/2.0"})
+        response.raise_for_status()
+
+        # Size limit: 100KB
+        content = response.text
+        if len(content) > 100_000:
+            content = content[:100_000] + "\n... [truncated at 100KB]"
+        return content

--- a/src/godspeed/tui/output.py
+++ b/src/godspeed/tui/output.py
@@ -28,6 +28,7 @@ from godspeed.tui.theme import (
     GUTTER_STYLE,
     MARKER_ERROR,
     MARKER_INFO,
+    MARKER_PARALLEL,
     MARKER_SUCCESS,
     MARKER_TOOL,
     MARKER_WARNING,
@@ -92,6 +93,30 @@ def format_warning(message: str) -> None:
 def format_error(message: str) -> None:
     """Display an error message with ✗ indicator."""
     console.print(f"  {styled(MARKER_ERROR, ERROR)} {styled(f'Error: {message}', BOLD_ERROR)}")
+
+
+# =============================================================================
+# Thinking display
+# =============================================================================
+
+
+def format_thinking(text: str) -> None:
+    """Display extended thinking content in a dim collapsible-style panel."""
+    if not text.strip():
+        return
+    # Truncate very long thinking for display (keep first 2000 chars)
+    display_text = text[:2000]
+    if len(text) > 2000:
+        display_text += f"\n... ({len(text) - 2000} chars truncated)"
+
+    panel = Panel(
+        styled(display_text, DIM),
+        title=styled("Thinking", MUTED),
+        border_style=MUTED,
+        expand=False,
+        padding=(0, 1),
+    )
+    console.print(panel)
 
 
 # =============================================================================
@@ -207,6 +232,75 @@ def format_tool_result(name: str, result: str, is_error: bool = False) -> None:
         else:
             # Long results: show summary
             console.print(f"  {marker} {tool}  {styled(f'({line_count} lines)', DIM)}")
+
+
+# =============================================================================
+# Parallel tool call display
+# =============================================================================
+
+# Max characters for inline argument preview in parallel header
+_PARALLEL_ARG_MAX = 40
+
+
+def _tool_brief(name: str, args: dict[str, Any]) -> str:
+    """Return a short one-line summary of a tool call for parallel headers."""
+    primary = (
+        args.get("file_path")
+        or args.get("command")
+        or args.get("pattern")
+        or args.get("action")
+        or ""
+    )
+    if primary and len(primary) > _PARALLEL_ARG_MAX:
+        primary = "..." + primary[-(_PARALLEL_ARG_MAX - 3) :]
+    if primary:
+        return f"{name} {styled(primary, DIM)}"
+    return name
+
+
+def format_parallel_tool_calls(calls: list[tuple[str, dict[str, Any]]]) -> None:
+    """Display a grouped header for parallel tool dispatch.
+
+    Shows count and brief tool names so the user knows what is running
+    concurrently before results arrive.
+    """
+    count = len(calls)
+    marker = styled(MARKER_PARALLEL, SECONDARY)
+    header = styled(f"Running {count} tools in parallel", BOLD_PRIMARY)
+    console.print(f"\n  {marker} {header}")
+
+    for name, args in calls:
+        brief = _tool_brief(name, args)
+        console.print(f"    {styled(MARKER_TOOL, MUTED)} {brief}")
+
+    console.print()
+
+
+def format_parallel_results(results: list[tuple[str, str, bool]]) -> None:
+    """Display a batch summary of parallel tool results.
+
+    Each entry is (tool_name, output_preview, is_error). Successes get a
+    compact one-liner; errors get the full treatment.
+    """
+    successes = [(n, o) for n, o, err in results if not err]
+    errors = [(n, o) for n, o, err in results if err]
+
+    # Compact success summary
+    if successes:
+        names = [styled(n, MUTED) for n, _ in successes]
+        label = f" {SEPARATOR_DOT} ".join(names)
+        console.print(f"  {styled(MARKER_SUCCESS, SUCCESS)} {label}")
+
+    # Expanded error display
+    for name, output in errors:
+        marker = styled(MARKER_ERROR, ERROR)
+        tool = styled(name, BOLD_ERROR)
+        preview = output.splitlines()[0] if output.strip() else "(no output)"
+        if len(preview) > 120:
+            preview = preview[:117] + "..."
+        console.print(f"  {marker} {tool}  {preview}")
+
+    console.print()
 
 
 def format_assistant_text(text: str) -> None:

--- a/src/godspeed/tui/theme.py
+++ b/src/godspeed/tui/theme.py
@@ -83,6 +83,7 @@ MARKER_ERROR = "\u2717"  # ✗
 MARKER_WARNING = "\u26a0"  # ⚠
 MARKER_TOOL = "\u25b8"  # ▸
 MARKER_INFO = "\u25cf"  # ●
+MARKER_PARALLEL = "\u26a1"  # ⚡ — parallel tool execution
 SEPARATOR_DOT = "\u00b7"  # ·
 
 # Structural characters — Crush-inspired decorative elements

--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -1,0 +1,439 @@
+"""Tests for architect mode — two-phase plan-then-execute pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from godspeed.agent.architect import (
+    ARCHITECT_SYSTEM_PROMPT,
+    _filter_read_only,
+    architect_loop,
+)
+from godspeed.agent.conversation import Conversation
+from godspeed.llm.client import LLMClient
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+from godspeed.tools.registry import ToolRegistry
+
+# -- Helpers ------------------------------------------------------------------
+
+
+class _FakeTool(Tool):
+    """Minimal tool stub for testing."""
+
+    def __init__(self, name: str, risk: RiskLevel) -> None:
+        self._name = name
+        self._risk = risk
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"Fake {self._name}"
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return self._risk
+
+    def get_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        return ToolResult.ok(f"{self._name} executed")
+
+
+def _make_registry() -> ToolRegistry:
+    """Build a registry with a mix of risk levels."""
+    registry = ToolRegistry()
+    registry.register(_FakeTool("file_read", RiskLevel.READ_ONLY))
+    registry.register(_FakeTool("glob_search", RiskLevel.READ_ONLY))
+    registry.register(_FakeTool("grep_search", RiskLevel.READ_ONLY))
+    registry.register(_FakeTool("file_edit", RiskLevel.LOW))
+    registry.register(_FakeTool("file_write", RiskLevel.HIGH))
+    registry.register(_FakeTool("shell", RiskLevel.DESTRUCTIVE))
+    return registry
+
+
+def _make_context(tmp_path: Path) -> ToolContext:
+    return ToolContext(cwd=tmp_path, session_id="test-session-001")
+
+
+def _make_conversation() -> Conversation:
+    return Conversation(
+        system_prompt="You are a helpful assistant.",
+        model="test-model",
+        max_tokens=100_000,
+    )
+
+
+def _make_llm_client() -> LLMClient:
+    client = MagicMock(spec=LLMClient)
+    client.model = "main-model"
+    return client
+
+
+# -- Tests: _filter_read_only ------------------------------------------------
+
+
+class TestFilterReadOnly:
+    """Tests for the read-only registry filter."""
+
+    def test_returns_only_read_only_tools(self) -> None:
+        registry = _make_registry()
+        filtered = _filter_read_only(registry)
+
+        tool_names = {t.name for t in filtered.list_tools()}
+        assert tool_names == {"file_read", "glob_search", "grep_search"}
+
+    def test_excludes_low_risk_tools(self) -> None:
+        registry = _make_registry()
+        filtered = _filter_read_only(registry)
+
+        assert filtered.get("file_edit") is None
+
+    def test_excludes_high_risk_tools(self) -> None:
+        registry = _make_registry()
+        filtered = _filter_read_only(registry)
+
+        assert filtered.get("file_write") is None
+
+    def test_excludes_destructive_tools(self) -> None:
+        registry = _make_registry()
+        filtered = _filter_read_only(registry)
+
+        assert filtered.get("shell") is None
+
+    def test_empty_registry_returns_empty(self) -> None:
+        registry = ToolRegistry()
+        filtered = _filter_read_only(registry)
+
+        assert filtered.list_tools() == []
+
+    def test_all_read_only_registry_passes_all(self) -> None:
+        registry = ToolRegistry()
+        registry.register(_FakeTool("a", RiskLevel.READ_ONLY))
+        registry.register(_FakeTool("b", RiskLevel.READ_ONLY))
+        filtered = _filter_read_only(registry)
+
+        assert len(filtered.list_tools()) == 2
+
+
+# -- Tests: architect_loop ---------------------------------------------------
+
+
+class TestArchitectLoop:
+    """Tests for the two-phase architect loop."""
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_plan_phase_uses_read_only_registry(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Phase 1 should receive a registry containing only READ_ONLY tools."""
+        mock_agent_loop.side_effect = [
+            "Step 1: Read main.py\nStep 2: Edit it",  # plan
+            "Done implementing.",  # execute
+        ]
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+
+        await architect_loop(
+            user_input="Add logging to main.py",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+        )
+
+        # First call is the plan phase
+        plan_call_kwargs = mock_agent_loop.call_args_list[0].kwargs
+        plan_registry = plan_call_kwargs["tool_registry"]
+        plan_tool_names = {t.name for t in plan_registry.list_tools()}
+        assert plan_tool_names == {"file_read", "glob_search", "grep_search"}
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_execute_phase_uses_full_registry(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Phase 2 should receive the full (unfiltered) tool registry."""
+        mock_agent_loop.side_effect = [
+            "Step 1: Read main.py\nStep 2: Edit it",  # plan
+            "Done implementing.",  # execute
+        ]
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+
+        await architect_loop(
+            user_input="Add logging to main.py",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+        )
+
+        # Second call is the execute phase
+        exec_call_kwargs = mock_agent_loop.call_args_list[1].kwargs
+        exec_registry = exec_call_kwargs["tool_registry"]
+        exec_tool_names = {t.name for t in exec_registry.list_tools()}
+        assert "file_edit" in exec_tool_names
+        assert "shell" in exec_tool_names
+        assert len(exec_tool_names) == 6
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_plan_injected_into_execute_context(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """The plan from phase 1 should appear in the user_input of phase 2."""
+        plan_text = "Step 1: Read file\nStep 2: Add import\nStep 3: Write file"
+        mock_agent_loop.side_effect = [plan_text, "All done."]
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+
+        await architect_loop(
+            user_input="Add logging",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+        )
+
+        exec_call_kwargs = mock_agent_loop.call_args_list[1].kwargs
+        exec_input = exec_call_kwargs["user_input"]
+        assert plan_text in exec_input
+        assert "Add logging" in exec_input
+        assert "Execute this plan" in exec_input
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_plan_failure_returns_error(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """If the plan phase returns an error, architect_loop should return it."""
+        mock_agent_loop.return_value = "Error: LLM call failed — timeout"
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+
+        result = await architect_loop(
+            user_input="Do something",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+        )
+
+        assert result.startswith("Error:")
+        assert mock_agent_loop.call_count == 1  # No execute phase
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_empty_plan_returns_error(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """If the plan phase returns empty string, return an error."""
+        mock_agent_loop.return_value = ""
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+
+        result = await architect_loop(
+            user_input="Do something",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+        )
+
+        assert "no output" in result.lower() or result.startswith("Error:")
+        assert mock_agent_loop.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_phase_change_callback_called(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """on_phase_change should be called for both phases."""
+        mock_agent_loop.side_effect = ["The plan.", "Executed."]
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+
+        phase_changes: list[tuple[str, str]] = []
+
+        def on_phase(phase: str, model: str) -> None:
+            phase_changes.append((phase, model))
+
+        await architect_loop(
+            user_input="Build it",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+            on_phase_change=on_phase,
+        )
+
+        assert len(phase_changes) == 2
+        assert phase_changes[0][0] == "plan"
+        assert phase_changes[1][0] == "execute"
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_architect_model_switches_for_plan(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """When architect_model differs from main, it should switch during plan."""
+        mock_agent_loop.side_effect = ["The plan.", "Done."]
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+        client.model = "main-model"
+
+        phase_models: list[str] = []
+
+        def on_phase(phase: str, model: str) -> None:
+            phase_models.append(model)
+
+        await architect_loop(
+            user_input="Build it",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+            architect_model="planning-model",
+            on_phase_change=on_phase,
+        )
+
+        assert phase_models[0] == "planning-model"
+        assert phase_models[1] == "main-model"
+        # Model should be restored after plan phase
+        assert client.model == "main-model"
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_plan_conversation_uses_architect_system_prompt(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Phase 1 conversation should use the ARCHITECT_SYSTEM_PROMPT."""
+        mock_agent_loop.side_effect = ["Plan.", "Done."]
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+
+        await architect_loop(
+            user_input="Build it",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+        )
+
+        plan_call_kwargs = mock_agent_loop.call_args_list[0].kwargs
+        plan_conv = plan_call_kwargs["conversation"]
+        system_msg = plan_conv.messages[0]
+        assert system_msg["content"] == ARCHITECT_SYSTEM_PROMPT
+
+    @pytest.mark.asyncio
+    @patch("godspeed.agent.architect.agent_loop", new_callable=AsyncMock)
+    async def test_execute_uses_original_conversation(
+        self, mock_agent_loop: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Phase 2 should use the caller's conversation, not the plan conversation."""
+        mock_agent_loop.side_effect = ["Plan.", "Done."]
+
+        registry = _make_registry()
+        context = _make_context(tmp_path)
+        conversation = _make_conversation()
+        client = _make_llm_client()
+
+        await architect_loop(
+            user_input="Build it",
+            conversation=conversation,
+            llm_client=client,
+            tool_registry=registry,
+            tool_context=context,
+        )
+
+        exec_call_kwargs = mock_agent_loop.call_args_list[1].kwargs
+        assert exec_call_kwargs["conversation"] is conversation
+
+
+# -- Tests: /architect command toggle -----------------------------------------
+
+
+class TestArchitectCommand:
+    """/architect command toggles architect_mode on the Commands instance."""
+
+    def test_toggle_on(self) -> None:
+        from godspeed.tui.commands import Commands
+
+        cmds = Commands(
+            conversation=MagicMock(),
+            llm_client=MagicMock(),
+            permission_engine=MagicMock(),
+            audit_trail=None,
+            session_id="test",
+            cwd=Path("."),
+        )
+        assert cmds.architect_mode is False
+        result = cmds.dispatch("/architect")
+        assert result is not None
+        assert result.handled is True
+        assert cmds.architect_mode is True
+
+    def test_toggle_off(self) -> None:
+        from godspeed.tui.commands import Commands
+
+        cmds = Commands(
+            conversation=MagicMock(),
+            llm_client=MagicMock(),
+            permission_engine=MagicMock(),
+            audit_trail=None,
+            session_id="test",
+            cwd=Path("."),
+        )
+        cmds.architect_mode = True
+        result = cmds.dispatch("/architect")
+        assert result is not None
+        assert result.handled is True
+        assert cmds.architect_mode is False
+
+    def test_double_toggle_returns_to_original(self) -> None:
+        from godspeed.tui.commands import Commands
+
+        cmds = Commands(
+            conversation=MagicMock(),
+            llm_client=MagicMock(),
+            permission_engine=MagicMock(),
+            audit_trail=None,
+            session_id="test",
+            cwd=Path("."),
+        )
+        cmds.dispatch("/architect")
+        cmds.dispatch("/architect")
+        assert cmds.architect_mode is False

--- a/tests/test_auto_commit.py
+++ b/tests/test_auto_commit.py
@@ -1,0 +1,241 @@
+"""Tests for auto-commit workflow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import git
+import pytest
+
+from godspeed.agent.auto_commit import (
+    FALLBACK_MESSAGE,
+    auto_commit,
+    generate_commit_message,
+)
+from godspeed.agent.conversation import Conversation
+from godspeed.agent.loop import agent_loop
+from godspeed.llm.client import ChatResponse, LLMClient
+from godspeed.tools.base import ToolContext, ToolResult
+from godspeed.tools.registry import ToolRegistry
+from tests.conftest import MockTool
+
+
+def _make_text_response(text: str) -> ChatResponse:
+    return ChatResponse(content=text, tool_calls=[], finish_reason="stop")
+
+
+def _make_tool_response(
+    tool_name: str, arguments: dict[str, Any], call_id: str = "call_001"
+) -> ChatResponse:
+    return ChatResponse(
+        content="",
+        tool_calls=[
+            {
+                "id": call_id,
+                "function": {
+                    "name": tool_name,
+                    "arguments": json.dumps(arguments),
+                },
+            }
+        ],
+        finish_reason="tool_calls",
+    )
+
+
+class TestAutoCommit:
+    """Tests for auto-commit module functions and agent loop integration."""
+
+    @pytest.mark.asyncio
+    async def test_generate_commit_message(self) -> None:
+        """Mock LLM returns a valid commit message."""
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            return_value=ChatResponse(
+                content="feat(api): add user authentication",
+                tool_calls=[],
+                finish_reason="stop",
+            )
+        )
+        result = await generate_commit_message(
+            ["file_edit src/auth.py", "file_write tests/test_auth.py"],
+            client,
+        )
+        assert result == "feat(api): add user authentication"
+        client.chat.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_generate_commit_message_empty_response_fallback(self) -> None:
+        """LLM returns empty string — fall back to generic message."""
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            return_value=ChatResponse(content="   ", tool_calls=[], finish_reason="stop")
+        )
+        result = await generate_commit_message(["file_edit src/main.py"], client)
+        assert result == FALLBACK_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_generate_commit_message_whitespace_only_fallback(self) -> None:
+        """LLM returns only whitespace/newlines — falls back after strip()."""
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            return_value=ChatResponse(content="\n\t  \n", tool_calls=[], finish_reason="stop")
+        )
+        result = await generate_commit_message(["file_write config.yaml"], client)
+        assert result == FALLBACK_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_generate_commit_message_exception_fallback(self) -> None:
+        """LLM call raises — fall back and log warning."""
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(side_effect=RuntimeError("LLM down"))
+        result = await generate_commit_message(["file_edit src/main.py"], client)
+        assert result == FALLBACK_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_auto_commit_stages_and_commits(self, tmp_path: Path) -> None:
+        """With a real git repo, verify commit is created."""
+        # Set up a real git repo
+        repo = git.Repo.init(tmp_path)
+        repo.config_writer().set_value("user", "name", "Test").release()
+        repo.config_writer().set_value("user", "email", "test@test.com").release()
+
+        # Create and commit an initial file
+        test_file = tmp_path / "hello.py"
+        test_file.write_text("print('hello')\n")
+        repo.index.add(["hello.py"])
+        repo.index.commit("initial commit")
+
+        # Modify the tracked file
+        test_file.write_text("print('hello world')\n")
+
+        result = await auto_commit(tmp_path, "feat: update greeting")
+        assert not result.is_error
+        assert "Auto-committed:" in result.output
+        assert "feat: update greeting" in result.output
+
+        # Verify commit exists
+        latest = repo.head.commit
+        assert "feat: update greeting" in latest.message
+
+    @pytest.mark.asyncio
+    async def test_auto_commit_includes_co_authored_by(self, tmp_path: Path) -> None:
+        """Verify Godspeed attribution in commit message."""
+        repo = git.Repo.init(tmp_path)
+        repo.config_writer().set_value("user", "name", "Test").release()
+        repo.config_writer().set_value("user", "email", "test@test.com").release()
+
+        test_file = tmp_path / "app.py"
+        test_file.write_text("# app\n")
+        repo.index.add(["app.py"])
+        repo.index.commit("initial")
+
+        test_file.write_text("# app v2\n")
+
+        result = await auto_commit(tmp_path, "chore: update app")
+        assert not result.is_error
+
+        latest = repo.head.commit
+        assert "Co-Authored-By: Godspeed <noreply@godspeed.dev>" in latest.message
+
+    @pytest.mark.asyncio
+    async def test_auto_commit_disabled_by_default(self, tool_context: ToolContext) -> None:
+        """Counter reaches threshold but no commit when auto_commit=False."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        tool = MockTool(name="file_edit", result=ToolResult.success("edited"))
+        registry.register(tool)
+
+        client = LLMClient(model="test")
+        # 5 file_edit calls then a text response
+        responses = [
+            _make_tool_response("file_edit", {"file_path": f"f{i}.py"}, f"call_{i:03d}")
+            for i in range(5)
+        ]
+        responses.append(_make_text_response("Done"))
+        client.chat = AsyncMock(side_effect=responses)
+
+        result = await agent_loop(
+            "edit files",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            parallel_tool_calls=False,
+            auto_commit=False,
+            auto_commit_threshold=5,
+        )
+        assert result == "Done"
+        # No auto-commit message should appear in conversation
+        messages_text = " ".join(m.get("content", "") or "" for m in conversation.messages)
+        assert "[Auto-commit]" not in messages_text
+
+    @pytest.mark.asyncio
+    async def test_auto_commit_resets_counter(self, tmp_path: Path) -> None:
+        """After commit, counter resets to 0 allowing subsequent commits."""
+        # Set up real git repo for auto-commit to succeed
+        repo = git.Repo.init(tmp_path)
+        repo.config_writer().set_value("user", "name", "Test").release()
+        repo.config_writer().set_value("user", "email", "test@test.com").release()
+        test_file = tmp_path / "main.py"
+        test_file.write_text("v1\n")
+        repo.index.add(["main.py"])
+        repo.index.commit("initial")
+
+        tool_ctx = ToolContext(cwd=tmp_path, session_id="test-session")
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+
+        # MockTool that also writes to the file so git has something to commit
+        call_count = 0
+
+        class WritingMockTool(MockTool):
+            async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+                nonlocal call_count
+                call_count += 1
+                test_file.write_text(f"v{call_count + 1}\n")
+                return ToolResult.success("edited")
+
+        tool = WritingMockTool(name="file_edit", result=ToolResult.success("edited"))
+        registry.register(tool)
+
+        client = LLMClient(model="test")
+        # Generate commit message mock
+        commit_msg_response = ChatResponse(
+            content="chore: auto update", tool_calls=[], finish_reason="stop"
+        )
+
+        # 3 edits (threshold=2), then done -- should trigger commit after 2nd edit
+        responses = [
+            _make_tool_response("file_edit", {"file_path": "main.py"}, "c001"),
+            commit_msg_response,  # generate_commit_message call after 2nd edit
+            _make_tool_response("file_edit", {"file_path": "main.py"}, "c002"),
+            _make_tool_response("file_edit", {"file_path": "main.py"}, "c003"),
+            commit_msg_response,  # commit msg after counter resets
+            _make_text_response("Done"),
+        ]
+        client.chat = AsyncMock(side_effect=responses)
+
+        result = await agent_loop(
+            "edit files",
+            conversation,
+            client,
+            registry,
+            tool_ctx,
+            parallel_tool_calls=False,
+            auto_commit=True,
+            auto_commit_threshold=2,
+        )
+        # Should complete without error (commits may or may not succeed depending on
+        # git state, but the counter reset logic is exercised)
+        assert result == "Done" or "Error" not in result
+
+    @pytest.mark.asyncio
+    async def test_auto_commit_no_repo_graceful_failure(self, tmp_path: Path) -> None:
+        """Outside a git repo, auto_commit returns error without crashing."""
+        # tmp_path is not a git repo
+        result = await auto_commit(tmp_path, "test commit")
+        assert result.is_error
+        assert result.error is not None

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,0 +1,240 @@
+"""Tests for background command execution (Unit 7)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from godspeed.tools.background import BackgroundCheckTool, BackgroundRegistry
+from godspeed.tools.base import ToolContext
+from godspeed.tools.shell import ShellTool
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Reset the singleton registry before each test."""
+    BackgroundRegistry.reset()
+    yield
+    BackgroundRegistry.reset()
+
+
+# ---------------------------------------------------------------------------
+# BackgroundRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_singleton():
+    """BackgroundRegistry.get() returns the same instance."""
+    r1 = BackgroundRegistry.get()
+    r2 = BackgroundRegistry.get()
+    assert r1 is r2
+
+
+def test_registry_empty():
+    """Empty registry has no processes."""
+    reg = BackgroundRegistry.get()
+    assert reg.count == 0
+    assert reg.list_all() == []
+
+
+def test_registry_next_id():
+    """IDs increment sequentially."""
+    reg = BackgroundRegistry.get()
+    assert reg.next_id() == 1
+    assert reg.next_id() == 2
+    assert reg.next_id() == 3
+
+
+# ---------------------------------------------------------------------------
+# ShellTool: background=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shell_background_starts_process(tmp_path):
+    """shell with background=True spawns a process and returns immediately."""
+    tool = ShellTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+
+    cmd = "sleep 0.1 && echo done"
+    result = await tool.execute({"command": cmd, "background": True}, ctx)
+
+    assert not result.is_error
+    assert "background process" in result.output.lower()
+    assert "1" in result.output  # Process ID 1
+
+    # Verify it's in the registry
+    reg = BackgroundRegistry.get()
+    assert reg.count == 1
+    proc = reg.get_process(1)
+    assert proc is not None
+    assert proc.command == cmd
+
+    # Wait for it to finish
+    await asyncio.sleep(0.5)
+    assert not proc.is_running
+
+
+@pytest.mark.asyncio
+async def test_shell_background_max_concurrent(tmp_path):
+    """Rejects background process when max concurrent reached."""
+    from godspeed.tools.background import MAX_CONCURRENT
+
+    tool = ShellTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+
+    # Fill up with sleeping processes
+    for _ in range(MAX_CONCURRENT):
+        result = await tool.execute({"command": "sleep 60", "background": True}, ctx)
+        assert not result.is_error
+
+    # Next one should fail
+    result = await tool.execute(
+        {
+            "command": "echo over",
+            "background": True,
+        },
+        ctx,
+    )
+    assert result.is_error
+    assert "Too many" in result.error
+
+    # Clean up
+    reg = BackgroundRegistry.get()
+    for proc in reg.list_all():
+        proc.process.terminate()
+        await asyncio.wait_for(proc.process.wait(), timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# BackgroundCheckTool: status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_no_processes(tmp_path):
+    """Status with no processes returns informative message."""
+    tool = BackgroundCheckTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute({"action": "status"}, ctx)
+    assert "No background processes" in result.output
+
+
+@pytest.mark.asyncio
+async def test_status_shows_running(tmp_path):
+    """Status shows running processes."""
+    shell = ShellTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+
+    await shell.execute({"command": "sleep 5", "background": True}, ctx)
+
+    check = BackgroundCheckTool()
+    result = await check.execute({"action": "status"}, ctx)
+
+    assert "running" in result.output
+    assert "[1]" in result.output
+
+    # Clean up
+    reg = BackgroundRegistry.get()
+    proc = reg.get_process(1)
+    proc.process.terminate()
+    await asyncio.wait_for(proc.process.wait(), timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# BackgroundCheckTool: output
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_output_after_completion(tmp_path):
+    """Output shows captured stdout after process completes."""
+    shell = ShellTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+
+    cmd = "echo hello_background"
+    await shell.execute({"command": cmd, "background": True}, ctx)
+
+    # Wait for process to finish and output to be collected
+    await asyncio.sleep(1.0)
+
+    check = BackgroundCheckTool()
+    result = await check.execute({"action": "output", "id": 1}, ctx)
+
+    assert not result.is_error
+    assert "hello_background" in result.output
+
+
+@pytest.mark.asyncio
+async def test_output_missing_id(tmp_path):
+    """Output without id returns error."""
+    check = BackgroundCheckTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await check.execute({"action": "output"}, ctx)
+    assert result.is_error
+    assert "id is required" in result.error
+
+
+@pytest.mark.asyncio
+async def test_output_invalid_id(tmp_path):
+    """Output with non-existent id returns error."""
+    check = BackgroundCheckTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await check.execute({"action": "output", "id": 999}, ctx)
+    assert result.is_error
+    assert "999" in result.error
+
+
+# ---------------------------------------------------------------------------
+# BackgroundCheckTool: kill
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_running_process(tmp_path):
+    """Kill terminates a running process."""
+    shell = ShellTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+
+    await shell.execute({"command": "sleep 30", "background": True}, ctx)
+
+    reg = BackgroundRegistry.get()
+    proc = reg.get_process(1)
+    assert proc.is_running
+
+    check = BackgroundCheckTool()
+    result = await check.execute({"action": "kill", "id": 1}, ctx)
+
+    assert not result.is_error
+    assert "terminated" in result.output.lower()
+    # Wait a moment for termination
+    await asyncio.sleep(0.5)
+    assert not proc.is_running
+
+
+@pytest.mark.asyncio
+async def test_kill_already_exited(tmp_path):
+    """Kill on already-exited process returns success."""
+    shell = ShellTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+
+    await shell.execute({"command": "echo quick", "background": True}, ctx)
+
+    await asyncio.sleep(1.0)
+
+    check = BackgroundCheckTool()
+    result = await check.execute({"action": "kill", "id": 1}, ctx)
+
+    assert not result.is_error
+    assert "already exited" in result.output.lower()
+
+
+@pytest.mark.asyncio
+async def test_invalid_action(tmp_path):
+    """Invalid action returns error."""
+    check = BackgroundCheckTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await check.execute({"action": "restart"}, ctx)
+    assert result.is_error
+    assert "Invalid action" in result.error

--- a/tests/test_cheapest_compaction.py
+++ b/tests/test_cheapest_compaction.py
@@ -1,0 +1,149 @@
+"""Tests for cheapest-model compaction and risk-based dispatch (Units 17 & 18)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from godspeed.llm.cost import get_cheapest_model
+
+# ---------------------------------------------------------------------------
+# get_cheapest_model
+# ---------------------------------------------------------------------------
+
+
+def test_cheapest_model_empty_list():
+    """Empty list returns empty string."""
+    assert get_cheapest_model([]) == ""
+
+
+def test_cheapest_model_single():
+    """Single model is always returned."""
+    assert get_cheapest_model(["claude-sonnet-4-20250514"]) == "claude-sonnet-4-20250514"
+
+
+def test_cheapest_model_ollama_wins():
+    """Ollama (free) is always cheapest."""
+    models = ["claude-opus-4-20250514", "ollama/qwen3:4b", "gpt-4o"]
+    assert get_cheapest_model(models) == "ollama/qwen3:4b"
+
+
+def test_cheapest_model_haiku_cheapest_among_paid():
+    """Haiku is cheaper than Sonnet and GPT-4o."""
+    models = ["claude-sonnet-4-20250514", "claude-haiku-3.5", "gpt-4o"]
+    result = get_cheapest_model(models)
+    assert "haiku" in result.lower()
+
+
+def test_cheapest_model_all_unknown():
+    """Unknown models: returns first."""
+    models = ["custom/model-a", "custom/model-b"]
+    assert get_cheapest_model(models) == "custom/model-a"
+
+
+def test_cheapest_model_ollama_chat_prefix():
+    """ollama_chat/ prefix is also free."""
+    models = ["gpt-4o", "ollama_chat/llama3:8b"]
+    assert get_cheapest_model(models) == "ollama_chat/llama3:8b"
+
+
+# ---------------------------------------------------------------------------
+# Risk-based parallel/serial split
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_risk_based_split_read_only_parallel(tmp_path):
+    """READ_ONLY tools run in parallel, write tools run serially."""
+    from godspeed.agent.conversation import Conversation
+    from godspeed.agent.loop import agent_loop
+    from godspeed.llm.client import ChatResponse, LLMClient
+    from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+    from godspeed.tools.registry import ToolRegistry
+
+    execution_order: list[str] = []
+
+    class ReadTool(Tool):
+        @property
+        def name(self) -> str:
+            return "read_tool"
+
+        @property
+        def description(self) -> str:
+            return "test read"
+
+        @property
+        def risk_level(self) -> RiskLevel:
+            return RiskLevel.READ_ONLY
+
+        def get_schema(self):
+            return {"type": "object", "properties": {}}
+
+        async def execute(self, arguments, context):
+            execution_order.append("read")
+            return ToolResult.success("read ok")
+
+    class WriteTool(Tool):
+        @property
+        def name(self) -> str:
+            return "write_tool"
+
+        @property
+        def description(self) -> str:
+            return "test write"
+
+        @property
+        def risk_level(self) -> RiskLevel:
+            return RiskLevel.LOW
+
+        def get_schema(self):
+            return {"type": "object", "properties": {}}
+
+        async def execute(self, arguments, context):
+            execution_order.append("write")
+            return ToolResult.success("write ok")
+
+    registry = ToolRegistry()
+    registry.register(ReadTool())
+    registry.register(WriteTool())
+
+    # First response: 2 tool calls (one read, one write)
+    # Second response: text-only (stop)
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat = AsyncMock(
+        side_effect=[
+            ChatResponse(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "tc1",
+                        "function": {"name": "read_tool", "arguments": "{}"},
+                    },
+                    {
+                        "id": "tc2",
+                        "function": {"name": "write_tool", "arguments": "{}"},
+                    },
+                ],
+                finish_reason="tool_calls",
+                thinking="",
+            ),
+            ChatResponse(content="Done", finish_reason="stop", thinking=""),
+        ]
+    )
+
+    conversation = Conversation(system_prompt="test", model="test", max_tokens=10000)
+    context = ToolContext(cwd=tmp_path, session_id="test")
+
+    await agent_loop(
+        user_input="test",
+        conversation=conversation,
+        llm_client=mock_llm,
+        tool_registry=registry,
+        tool_context=context,
+        parallel_tool_calls=True,
+    )
+
+    # Both tools should have executed
+    assert "read" in execution_order
+    assert "write" in execution_order

--- a/tests/test_cost_budget.py
+++ b/tests/test_cost_budget.py
@@ -1,0 +1,299 @@
+"""Tests for cost budget enforcement (Unit 5)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from godspeed.llm.client import BudgetExceededError, LLMClient
+
+# ---------------------------------------------------------------------------
+# Config: max_cost_usd field
+# ---------------------------------------------------------------------------
+
+
+def test_max_cost_defaults_zero():
+    """max_cost_usd defaults to 0 (unlimited)."""
+    from godspeed.config import GodspeedSettings
+
+    with patch("godspeed.config.DEFAULT_GLOBAL_DIR", MagicMock(exists=lambda: False)):
+        settings = GodspeedSettings(model="test")
+    assert settings.max_cost_usd == 0.0
+
+
+def test_max_cost_config_value():
+    """max_cost_usd can be set via constructor."""
+    from godspeed.config import GodspeedSettings
+
+    with patch("godspeed.config.DEFAULT_GLOBAL_DIR", MagicMock(exists=lambda: False)):
+        settings = GodspeedSettings(model="test", max_cost_usd=5.0)
+    assert settings.max_cost_usd == 5.0
+
+
+# ---------------------------------------------------------------------------
+# LLMClient: budget tracking
+# ---------------------------------------------------------------------------
+
+
+def test_llm_client_stores_max_cost():
+    """LLMClient stores max_cost_usd."""
+    client = LLMClient(model="gpt-4o", max_cost_usd=10.0)
+    assert client.max_cost_usd == 10.0
+    assert client.total_cost_usd == 0.0
+
+
+def test_check_budget_no_limit():
+    """_check_budget does nothing when limit is 0 (unlimited)."""
+    client = LLMClient(model="gpt-4o", max_cost_usd=0.0)
+    client.total_cost_usd = 100.0
+    client._check_budget()  # Should not raise
+
+
+def test_check_budget_under_limit():
+    """_check_budget does nothing when under limit."""
+    client = LLMClient(model="gpt-4o", max_cost_usd=10.0)
+    client.total_cost_usd = 5.0
+    client._check_budget()  # Should not raise
+
+
+def test_check_budget_exceeded():
+    """_check_budget raises BudgetExceededError when over limit."""
+    client = LLMClient(model="gpt-4o", max_cost_usd=5.0)
+    client.total_cost_usd = 5.01
+    with pytest.raises(BudgetExceededError) as exc_info:
+        client._check_budget()
+    assert exc_info.value.spent == 5.01
+    assert exc_info.value.limit == 5.0
+
+
+def test_budget_exceeded_error_message():
+    """BudgetExceededError has informative message."""
+    err = BudgetExceededError(spent=7.50, limit=5.00)
+    assert "$7.50" in str(err)
+    assert "$5.00" in str(err)
+
+
+@pytest.mark.asyncio
+async def test_cost_tracked_after_call():
+    """LLM call tracks cost in total_cost_usd."""
+    client = LLMClient(model="claude-sonnet-4-20250514")
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(content="Hello", tool_calls=None, thinking=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.usage = MagicMock(prompt_tokens=1000, completion_tokens=500)
+
+    with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+        mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_response)
+        await client._call("claude-sonnet-4-20250514", [{"role": "user", "content": "hi"}], None)
+
+    # Claude Sonnet pricing: $3/M input + $15/M output
+    # 1000 input tokens = $0.003, 500 output tokens = $0.0075
+    assert client.total_cost_usd > 0
+    assert client.total_cost_usd == pytest.approx(0.0105, abs=0.001)
+
+
+@pytest.mark.asyncio
+async def test_budget_exceeded_during_call():
+    """LLM call raises BudgetExceededError when budget exceeded mid-session."""
+    client = LLMClient(model="claude-sonnet-4-20250514", max_cost_usd=0.001)
+    # Pre-fill some cost close to limit
+    client.total_cost_usd = 0.0009
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(content="Hello", tool_calls=None, thinking=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.usage = MagicMock(prompt_tokens=1000, completion_tokens=500)
+
+    with (
+        patch("godspeed.llm.client._get_litellm") as mock_litellm,
+        pytest.raises(BudgetExceededError),
+    ):
+        mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_response)
+        await client._call("claude-sonnet-4-20250514", [{"role": "user", "content": "hi"}], None)
+
+
+@pytest.mark.asyncio
+async def test_ollama_always_free():
+    """Ollama models never accumulate cost."""
+    client = LLMClient(model="ollama/qwen3:4b", max_cost_usd=0.001)
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(content="Hello", tool_calls=None, thinking=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.usage = MagicMock(prompt_tokens=10000, completion_tokens=5000)
+
+    with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+        mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_response)
+        await client._call("ollama_chat/qwen3:4b", [{"role": "user", "content": "hi"}], None)
+
+    assert client.total_cost_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Agent loop: budget exceeded handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_catches_budget_exceeded(tmp_path):
+    """Agent loop catches BudgetExceededError and returns informative message."""
+    from godspeed.agent.conversation import Conversation
+    from godspeed.agent.loop import agent_loop
+    from godspeed.tools.base import ToolContext
+    from godspeed.tools.registry import ToolRegistry
+
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat = AsyncMock(side_effect=BudgetExceededError(spent=5.50, limit=5.00))
+
+    conversation = Conversation(system_prompt="test", model="test", max_tokens=10000)
+    registry = ToolRegistry()
+    context = ToolContext(cwd=tmp_path, session_id="test")
+
+    result = await agent_loop(
+        user_input="Write some code",
+        conversation=conversation,
+        llm_client=mock_llm,
+        tool_registry=registry,
+        tool_context=context,
+    )
+
+    assert "Budget exceeded" in result
+    assert "$5.50" in result or "5.5" in result
+    assert "/budget" in result
+
+
+# ---------------------------------------------------------------------------
+# TUI: /budget command
+# ---------------------------------------------------------------------------
+
+
+def test_budget_command_show(tmp_path):
+    """'/budget' with no args shows current cost and limit."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.total_cost_usd = 1.50
+    llm_client.max_cost_usd = 10.0
+    llm_client.model = "claude-sonnet-4-20250514"
+    llm_client.total_input_tokens = 5000
+    llm_client.total_output_tokens = 2000
+
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/budget")
+    assert result.handled
+
+
+def test_budget_command_set(tmp_path):
+    """'/budget 5.00' sets the budget."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.max_cost_usd = 0.0
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/budget 5.00")
+    assert result.handled
+    assert llm_client.max_cost_usd == 5.0
+
+
+def test_budget_command_set_with_dollar(tmp_path):
+    """'/budget $10' strips $ prefix."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.max_cost_usd = 0.0
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/budget $10")
+    assert result.handled
+    assert llm_client.max_cost_usd == 10.0
+
+
+def test_budget_command_off(tmp_path):
+    """'/budget off' disables budget."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.max_cost_usd = 5.0
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/budget off")
+    assert result.handled
+    assert llm_client.max_cost_usd == 0.0
+
+
+def test_budget_command_unlimited(tmp_path):
+    """'/budget unlimited' disables budget."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.max_cost_usd = 5.0
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/budget unlimited")
+    assert result.handled
+    assert llm_client.max_cost_usd == 0.0
+
+
+def test_budget_command_invalid(tmp_path):
+    """'/budget abc' shows error."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.max_cost_usd = 0.0
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/budget abc")
+    assert result.handled
+    assert llm_client.max_cost_usd == 0.0  # unchanged

--- a/tests/test_diff_apply.py
+++ b/tests/test_diff_apply.py
@@ -1,0 +1,239 @@
+"""Tests for the unified diff apply tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+from godspeed.tools.diff_apply import DiffApplyTool
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(cwd=tmp_path, session_id="test")
+
+
+def _make_file(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def tool() -> DiffApplyTool:
+    return DiffApplyTool()
+
+
+# ── Single file, single hunk: add lines ─────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_add_lines(tmp_path: Path, tool: DiffApplyTool) -> None:
+    _make_file(tmp_path, "hello.txt", "line1\nline2\nline3\n")
+    diff = (
+        "--- a/hello.txt\n"
+        "+++ b/hello.txt\n"
+        "@@ -1,3 +1,5 @@\n"
+        " line1\n"
+        " line2\n"
+        "+inserted_a\n"
+        "+inserted_b\n"
+        " line3\n"
+    )
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert not result.is_error
+    assert "1 hunks" in result.output
+    content = (tmp_path / "hello.txt").read_text(encoding="utf-8")
+    assert content == "line1\nline2\ninserted_a\ninserted_b\nline3\n"
+
+
+# ── Single file, single hunk: remove lines ──────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_remove_lines(tmp_path: Path, tool: DiffApplyTool) -> None:
+    _make_file(tmp_path, "hello.txt", "line1\nline2\nline3\nline4\n")
+    diff = "--- a/hello.txt\n+++ b/hello.txt\n@@ -1,4 +1,2 @@\n line1\n-line2\n-line3\n line4\n"
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert not result.is_error
+    content = (tmp_path / "hello.txt").read_text(encoding="utf-8")
+    assert content == "line1\nline4\n"
+
+
+# ── Single file, single hunk: modify lines ──────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_modify_lines(tmp_path: Path, tool: DiffApplyTool) -> None:
+    _make_file(tmp_path, "hello.txt", "alpha\nbeta\ngamma\n")
+    diff = "--- a/hello.txt\n+++ b/hello.txt\n@@ -1,3 +1,3 @@\n alpha\n-beta\n+BETA\n gamma\n"
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert not result.is_error
+    content = (tmp_path / "hello.txt").read_text(encoding="utf-8")
+    assert content == "alpha\nBETA\ngamma\n"
+
+
+# ── Multi-hunk single file ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_multi_hunk(tmp_path: Path, tool: DiffApplyTool) -> None:
+    _make_file(
+        tmp_path,
+        "code.py",
+        "import os\nimport sys\n\ndef foo():\n    pass\n\ndef bar():\n    pass\n",
+    )
+    diff = (
+        "--- a/code.py\n"
+        "+++ b/code.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " import os\n"
+        " import sys\n"
+        "+import json\n"
+        "@@ -7,2 +8,2 @@\n"
+        " def bar():\n"
+        "-    pass\n"
+        "+    return 42\n"
+    )
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert not result.is_error
+    assert "2 hunks" in result.output
+    content = (tmp_path / "code.py").read_text(encoding="utf-8")
+    assert "import json" in content
+    assert "return 42" in content
+    assert content.count("pass") == 1  # only foo's pass remains
+
+
+# ── Multi-file diff ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_multi_file(tmp_path: Path, tool: DiffApplyTool) -> None:
+    _make_file(tmp_path, "a.txt", "aaa\nbbb\n")
+    _make_file(tmp_path, "b.txt", "xxx\nyyy\n")
+    diff = (
+        "--- a/a.txt\n"
+        "+++ b/a.txt\n"
+        "@@ -1,2 +1,2 @@\n"
+        "-aaa\n"
+        "+AAA\n"
+        " bbb\n"
+        "--- a/b.txt\n"
+        "+++ b/b.txt\n"
+        "@@ -1,2 +1,2 @@\n"
+        " xxx\n"
+        "-yyy\n"
+        "+YYY\n"
+    )
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert not result.is_error
+    assert "2 files" in result.output
+    assert (tmp_path / "a.txt").read_text(encoding="utf-8") == "AAA\nbbb\n"
+    assert (tmp_path / "b.txt").read_text(encoding="utf-8") == "xxx\nYYY\n"
+
+
+# ── Fuzzy context matching ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_fuzzy_matching(tmp_path: Path, tool: DiffApplyTool) -> None:
+    """Context lines are off by 2 positions — fuzzy should handle it."""
+    _make_file(
+        tmp_path,
+        "shift.txt",
+        "extra1\nextra2\nalpha\nbeta\ngamma\n",
+    )
+    # Hunk says old_start=1 but actual match starts at line 3
+    diff = "--- a/shift.txt\n+++ b/shift.txt\n@@ -1,3 +1,3 @@\n alpha\n-beta\n+BETA\n gamma\n"
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert not result.is_error
+    assert "fuzzy" in result.output
+    content = (tmp_path / "shift.txt").read_text(encoding="utf-8")
+    assert "BETA" in content
+    assert "beta" not in content
+
+
+# ── Reject on context mismatch ──────────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_context_mismatch_rejected(tmp_path: Path, tool: DiffApplyTool) -> None:
+    _make_file(tmp_path, "nope.txt", "aaa\nbbb\nccc\n")
+    diff = "--- a/nope.txt\n+++ b/nope.txt\n@@ -1,3 +1,3 @@\n xxx\n-yyy\n+zzz\n www\n"
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert result.is_error
+    assert "failed to match" in result.error.lower()
+
+
+# ── Empty diff → error ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_empty_diff(tmp_path: Path, tool: DiffApplyTool) -> None:
+    result = await tool.execute({"diff": ""}, _ctx(tmp_path))
+    assert result.is_error
+
+
+@pytest.mark.asyncio()
+async def test_whitespace_only_diff(tmp_path: Path, tool: DiffApplyTool) -> None:
+    result = await tool.execute({"diff": "   \n\n  "}, _ctx(tmp_path))
+    assert result.is_error
+
+
+# ── Path traversal blocked ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_path_traversal_blocked(tmp_path: Path, tool: DiffApplyTool) -> None:
+    diff = "--- a/../../../etc/passwd\n+++ b/../../../etc/passwd\n@@ -1,1 +1,2 @@\n root\n+hacked\n"
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert result.is_error
+    assert "access denied" in result.error.lower() or "outside" in result.error.lower()
+
+
+# ── New file creation (--- /dev/null) ────────────────────────────────
+
+
+@pytest.mark.asyncio()
+async def test_new_file_creation(tmp_path: Path, tool: DiffApplyTool) -> None:
+    diff = "--- /dev/null\n+++ b/newfile.txt\n@@ -0,0 +1,3 @@\n+hello\n+world\n+!\n"
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert not result.is_error
+    created = tmp_path / "newfile.txt"
+    assert created.exists()
+    content = created.read_text(encoding="utf-8")
+    assert "hello" in content
+    assert "world" in content
+    assert "!" in content
+
+
+@pytest.mark.asyncio()
+async def test_new_file_in_subdirectory(tmp_path: Path, tool: DiffApplyTool) -> None:
+    diff = (
+        "--- /dev/null\n+++ b/sub/dir/new.py\n@@ -0,0 +1,2 @@\n+print('hello')\n+print('world')\n"
+    )
+    result = await tool.execute({"diff": diff}, _ctx(tmp_path))
+    assert not result.is_error
+    created = tmp_path / "sub" / "dir" / "new.py"
+    assert created.exists()
+
+
+# ── Tool metadata ────────────────────────────────────────────────────
+
+
+def test_tool_name(tool: DiffApplyTool) -> None:
+    assert tool.name == "diff_apply"
+
+
+def test_tool_risk_level(tool: DiffApplyTool) -> None:
+    from godspeed.tools.base import RiskLevel
+
+    assert tool.risk_level == RiskLevel.LOW
+
+
+def test_tool_schema_has_diff(tool: DiffApplyTool) -> None:
+    schema = tool.get_schema()
+    assert "diff" in schema["properties"]
+    assert "diff" in schema["required"]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,221 @@
+"""Tests for agent loop event types."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import get_args
+
+import pytest
+
+from godspeed.agent.events import (
+    AgentEvent,
+    AssistantTextEvent,
+    BudgetExceededEvent,
+    ErrorEvent,
+    ParallelBatchCompleteEvent,
+    ParallelBatchStartEvent,
+    PermissionDeniedEvent,
+    PhaseChangeEvent,
+    TextChunkEvent,
+    ThinkingEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+)
+
+ALL_EVENT_CLASSES = [
+    ThinkingEvent,
+    TextChunkEvent,
+    AssistantTextEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    PermissionDeniedEvent,
+    ParallelBatchStartEvent,
+    ParallelBatchCompleteEvent,
+    BudgetExceededEvent,
+    ErrorEvent,
+    PhaseChangeEvent,
+]
+
+
+class TestEventInstantiation:
+    """Each event dataclass can be instantiated with correct fields."""
+
+    def test_thinking_event(self) -> None:
+        evt = ThinkingEvent(text="reasoning about the problem")
+        assert evt.text == "reasoning about the problem"
+
+    def test_text_chunk_event(self) -> None:
+        evt = TextChunkEvent(text="Hello")
+        assert evt.text == "Hello"
+
+    def test_assistant_text_event(self) -> None:
+        evt = AssistantTextEvent(text="Full response here.")
+        assert evt.text == "Full response here."
+
+    def test_tool_call_event(self) -> None:
+        evt = ToolCallEvent(
+            tool_name="read_file",
+            arguments={"path": "src/foo.py"},
+            call_id="call_123",
+        )
+        assert evt.tool_name == "read_file"
+        assert evt.arguments == {"path": "src/foo.py"}
+        assert evt.call_id == "call_123"
+
+    def test_tool_result_event(self) -> None:
+        evt = ToolResultEvent(
+            tool_name="read_file",
+            output="file contents",
+            is_error=False,
+            call_id="call_123",
+        )
+        assert evt.tool_name == "read_file"
+        assert evt.output == "file contents"
+        assert evt.is_error is False
+        assert evt.call_id == "call_123"
+
+    def test_tool_result_event_error(self) -> None:
+        evt = ToolResultEvent(
+            tool_name="bash",
+            output="command not found",
+            is_error=True,
+        )
+        assert evt.is_error is True
+
+    def test_permission_denied_event(self) -> None:
+        evt = PermissionDeniedEvent(tool_name="bash", reason="not in allowlist")
+        assert evt.tool_name == "bash"
+        assert evt.reason == "not in allowlist"
+
+    def test_parallel_batch_start_event(self) -> None:
+        tools = [("read_file", {"path": "/a"}), ("read_file", {"path": "/b"})]
+        evt = ParallelBatchStartEvent(tools=tools)
+        assert len(evt.tools) == 2
+        assert evt.tools[0] == ("read_file", {"path": "/a"})
+
+    def test_parallel_batch_complete_event(self) -> None:
+        results = [("read_file", "contents a", False), ("read_file", "contents b", False)]
+        evt = ParallelBatchCompleteEvent(results=results)
+        assert len(evt.results) == 2
+        assert evt.results[1][2] is False
+
+    def test_budget_exceeded_event(self) -> None:
+        evt = BudgetExceededEvent(spent=5.50, limit=5.00)
+        assert evt.spent == 5.50
+        assert evt.limit == 5.00
+
+    def test_error_event(self) -> None:
+        evt = ErrorEvent(message="something broke")
+        assert evt.message == "something broke"
+
+    def test_phase_change_event(self) -> None:
+        evt = PhaseChangeEvent(phase="plan", model="o3")
+        assert evt.phase == "plan"
+        assert evt.model == "o3"
+
+
+class TestFrozen:
+    """Events are frozen (immutable)."""
+
+    @pytest.mark.parametrize("cls", ALL_EVENT_CLASSES, ids=lambda c: c.__name__)
+    def test_frozen(self, cls: type) -> None:
+        assert dataclasses.fields(cls)  # has fields
+        evt = _make_instance(cls)
+        first_field = dataclasses.fields(cls)[0].name
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(evt, first_field, "mutated")
+
+
+class TestSlots:
+    """Events have slots (memory efficient)."""
+
+    @pytest.mark.parametrize("cls", ALL_EVENT_CLASSES, ids=lambda c: c.__name__)
+    def test_slots(self, cls: type) -> None:
+        assert hasattr(cls, "__slots__"), f"{cls.__name__} missing __slots__"
+        evt = _make_instance(cls)
+        assert not hasattr(evt, "__dict__"), f"{cls.__name__} should not have __dict__"
+
+
+class TestAgentEventUnion:
+    """AgentEvent union type accepts all event types."""
+
+    def test_all_classes_in_union(self) -> None:
+        union_members = set(get_args(AgentEvent))
+        for cls in ALL_EVENT_CLASSES:
+            assert cls in union_members, f"{cls.__name__} missing from AgentEvent union"
+
+    def test_union_has_no_extra_types(self) -> None:
+        union_members = set(get_args(AgentEvent))
+        expected = set(ALL_EVENT_CLASSES)
+        assert union_members == expected, f"Extra types in union: {union_members - expected}"
+
+    def test_isinstance_check_via_union(self) -> None:
+        evt = ThinkingEvent(text="hi")
+        assert isinstance(evt, get_args(AgentEvent))
+
+
+class TestDefaults:
+    """Default values work correctly."""
+
+    def test_tool_call_event_default_call_id(self) -> None:
+        evt = ToolCallEvent(tool_name="bash", arguments={"cmd": "ls"})
+        assert evt.call_id == ""
+
+    def test_tool_result_event_defaults(self) -> None:
+        evt = ToolResultEvent(tool_name="bash", output="ok")
+        assert evt.is_error is False
+        assert evt.call_id == ""
+
+
+class TestRepr:
+    """Events have reasonable repr/str."""
+
+    def test_thinking_event_repr(self) -> None:
+        evt = ThinkingEvent(text="deep thought")
+        r = repr(evt)
+        assert "ThinkingEvent" in r
+        assert "deep thought" in r
+
+    def test_tool_call_event_repr(self) -> None:
+        evt = ToolCallEvent(tool_name="bash", arguments={"cmd": "ls"}, call_id="c1")
+        r = repr(evt)
+        assert "ToolCallEvent" in r
+        assert "bash" in r
+        assert "c1" in r
+
+    def test_budget_exceeded_repr(self) -> None:
+        evt = BudgetExceededEvent(spent=3.14, limit=2.0)
+        r = repr(evt)
+        assert "3.14" in r
+        assert "2.0" in r
+
+    @pytest.mark.parametrize("cls", ALL_EVENT_CLASSES, ids=lambda c: c.__name__)
+    def test_str_does_not_raise(self, cls: type) -> None:
+        evt = _make_instance(cls)
+        result = str(evt)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FACTORY: dict[type, tuple[tuple, dict]] = {
+    ThinkingEvent: (("text",), {}),
+    TextChunkEvent: (("chunk",), {}),
+    AssistantTextEvent: (("full text",), {}),
+    ToolCallEvent: ((), {"tool_name": "t", "arguments": {}}),
+    ToolResultEvent: ((), {"tool_name": "t", "output": "o"}),
+    PermissionDeniedEvent: ((), {"tool_name": "t", "reason": "r"}),
+    ParallelBatchStartEvent: ((), {"tools": []}),
+    ParallelBatchCompleteEvent: ((), {"results": []}),
+    BudgetExceededEvent: ((), {"spent": 1.0, "limit": 2.0}),
+    ErrorEvent: (("err",), {}),
+    PhaseChangeEvent: ((), {"phase": "plan", "model": "m"}),
+}
+
+
+def _make_instance(cls: type) -> object:
+    args, kwargs = _FACTORY[cls]
+    return cls(*args, **kwargs)

--- a/tests/test_evolution/test_applier.py
+++ b/tests/test_evolution/test_applier.py
@@ -1,0 +1,191 @@
+"""Tests for the evolution applier — runtime hot-swap of evolved artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from godspeed.evolution.applier import EvolutionApplier
+from godspeed.evolution.fitness import FitnessScore
+from godspeed.evolution.mutator import MutationCandidate
+from godspeed.evolution.registry import EvolutionRegistry
+from godspeed.evolution.safety import SafetyVerdict
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(
+    artifact_id: str = "file_read",
+    artifact_type: str = "tool_description",
+) -> MutationCandidate:
+    return MutationCandidate(
+        artifact_type=artifact_type,
+        artifact_id=artifact_id,
+        original="Original description.",
+        mutated="Improved description.",
+        mutation_rationale="test",
+        model_used="ollama/test",
+    )
+
+
+def _make_score() -> FitnessScore:
+    return FitnessScore(
+        correctness=0.9,
+        procedure_following=0.8,
+        conciseness=0.7,
+        overall=0.8,
+        length_penalty=0.0,
+        confidence=1.0,
+    )
+
+
+def _make_verdict() -> SafetyVerdict:
+    return SafetyVerdict(passed=True, checks=(), requires_human_review=False)
+
+
+def _setup(tmp_path: Path) -> tuple[EvolutionRegistry, EvolutionApplier]:
+    registry = EvolutionRegistry(tmp_path)
+    applier = EvolutionApplier(registry)
+    return registry, applier
+
+
+# ---------------------------------------------------------------------------
+# Test: apply_tool_description
+# ---------------------------------------------------------------------------
+
+
+class TestApplyToolDescription:
+    def test_apply(self, tmp_path: Path) -> None:
+        registry, applier = _setup(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+
+        applier.apply_tool_description(record_id, "file_read", "Improved.", "Original.")
+        assert applier.description_overrides["file_read"] == "Improved."
+        assert registry.get_applied("file_read") is not None
+
+    def test_get_tool_description_with_override(self, tmp_path: Path) -> None:
+        registry, applier = _setup(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        applier.apply_tool_description(record_id, "file_read", "Improved.", "Original.")
+
+        assert applier.get_tool_description("file_read", "default") == "Improved."
+        assert applier.get_tool_description("bash", "default") == "default"
+
+
+# ---------------------------------------------------------------------------
+# Test: apply_prompt_section
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPromptSection:
+    def test_apply(self, tmp_path: Path) -> None:
+        registry, applier = _setup(tmp_path)
+        candidate = _make_candidate(artifact_id="core", artifact_type="prompt_section")
+        record_id = registry.register(candidate, _make_score(), _make_verdict())
+
+        applier.apply_prompt_section(record_id, "core", "Better prompt.", "Old prompt.")
+        assert applier.prompt_overrides["core"] == "Better prompt."
+
+    def test_get_prompt_section_with_override(self, tmp_path: Path) -> None:
+        registry, applier = _setup(tmp_path)
+        candidate = _make_candidate(artifact_id="core", artifact_type="prompt_section")
+        record_id = registry.register(candidate, _make_score(), _make_verdict())
+        applier.apply_prompt_section(record_id, "core", "Better.", "Old.")
+
+        assert applier.get_prompt_section("core", "default") == "Better."
+        assert applier.get_prompt_section("tools", "default") == "default"
+
+
+# ---------------------------------------------------------------------------
+# Test: apply_skill
+# ---------------------------------------------------------------------------
+
+
+class TestApplySkill:
+    def test_writes_skill_file(self, tmp_path: Path) -> None:
+        registry, applier = _setup(tmp_path)
+        candidate = _make_candidate(artifact_id="read-edit", artifact_type="skill")
+        record_id = registry.register(candidate, _make_score(), _make_verdict())
+
+        skills_dir = tmp_path / "skills"
+        applier.apply_skill(
+            record_id,
+            "read-edit",
+            "---\nname: read-edit\n---\nContent",
+            skills_dir,
+        )
+
+        skill_path = skills_dir / "read-edit.md"
+        assert skill_path.exists()
+        assert "read-edit" in skill_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Test: rollback
+# ---------------------------------------------------------------------------
+
+
+class TestRollback:
+    def test_rollback_tool_description(self, tmp_path: Path) -> None:
+        registry, applier = _setup(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        applier.apply_tool_description(record_id, "file_read", "New.", "Original.")
+
+        assert "file_read" in applier.description_overrides
+        result = applier.rollback(record_id)
+        assert result is True
+        assert "file_read" not in applier.description_overrides
+
+    def test_rollback_prompt_section(self, tmp_path: Path) -> None:
+        registry, applier = _setup(tmp_path)
+        candidate = _make_candidate(artifact_id="core", artifact_type="prompt_section")
+        record_id = registry.register(candidate, _make_score(), _make_verdict())
+        applier.apply_prompt_section(record_id, "core", "New.", "Old.")
+
+        result = applier.rollback(record_id)
+        assert result is True
+        assert "core" not in applier.prompt_overrides
+
+    def test_rollback_nonexistent(self, tmp_path: Path) -> None:
+        _, applier = _setup(tmp_path)
+        assert applier.rollback("nonexistent") is False
+
+    def test_rollback_unapplied(self, tmp_path: Path) -> None:
+        registry, applier = _setup(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        # Never applied
+        assert applier.rollback(record_id) is False
+
+
+# ---------------------------------------------------------------------------
+# Test: load_applied
+# ---------------------------------------------------------------------------
+
+
+class TestLoadApplied:
+    def test_loads_on_startup(self, tmp_path: Path) -> None:
+        # First session: apply a mutation
+        registry = EvolutionRegistry(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        registry.mark_applied(record_id, "Evolved description.")
+
+        # Also manually write the artifact_type to applied json
+        applied_path = tmp_path / "applied" / "file_read.json"
+        data = json.loads(applied_path.read_text(encoding="utf-8"))
+        data["artifact_type"] = "tool_description"
+        applied_path.write_text(json.dumps(data), encoding="utf-8")
+
+        # Second session: load from disk
+        registry2 = EvolutionRegistry(tmp_path)
+        applier2 = EvolutionApplier(registry2)
+        count = applier2.load_applied()
+
+        assert count == 1
+        assert applier2.description_overrides.get("file_read") == "Evolved description."
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        applier = EvolutionApplier(registry)
+        assert applier.load_applied() == 0

--- a/tests/test_evolution/test_cross_session.py
+++ b/tests/test_evolution/test_cross_session.py
@@ -1,0 +1,210 @@
+"""Tests for cross-session learning and regression detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from godspeed.evolution.cross_session import (
+    AggregateReport,
+    CrossSessionAnalyzer,
+    RegressionAlert,
+)
+from godspeed.evolution.trace_analyzer import SessionTrace, ToolCall
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _tc(tool: str = "file_read", is_error: bool = False, latency: float = 50.0) -> ToolCall:
+    return ToolCall(
+        tool_name=tool,
+        arguments={},
+        output_length=100,
+        is_error=is_error,
+        latency_ms=latency,
+        outcome="error" if is_error else "success",
+    )
+
+
+def _session(
+    session_id: str = "s1",
+    model: str = "ollama/gemma3:12b",
+    tool_calls: tuple[ToolCall, ...] = (),
+    latency: float = 100.0,
+) -> SessionTrace:
+    errors = tuple(tc for tc in tool_calls if tc.is_error)
+    return SessionTrace(
+        session_id=session_id,
+        tool_calls=tool_calls,
+        errors=errors,
+        permission_denials=(),
+        permission_grants=(),
+        total_latency_ms=latency,
+        model=model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: aggregate_sessions
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateSessions:
+    def test_basic_aggregation(self) -> None:
+        sessions = [
+            _session("s1", tool_calls=(_tc(), _tc(is_error=True))),
+            _session("s2", tool_calls=(_tc(), _tc())),
+        ]
+        analyzer = CrossSessionAnalyzer()
+        report = analyzer.aggregate_sessions(sessions)
+
+        assert report.total_sessions == 2
+        assert report.total_tool_calls == 4
+        assert report.total_errors == 1
+        assert report.error_rate == 0.25
+
+    def test_empty_sessions(self) -> None:
+        analyzer = CrossSessionAnalyzer()
+        report = analyzer.aggregate_sessions([])
+        assert report.total_sessions == 0
+        assert report.error_rate == 0.0
+
+    def test_model_distribution(self) -> None:
+        sessions = [
+            _session("s1", model="claude"),
+            _session("s2", model="claude"),
+            _session("s3", model="ollama/gemma3"),
+        ]
+        analyzer = CrossSessionAnalyzer()
+        report = analyzer.aggregate_sessions(sessions)
+        models = dict(report.model_distribution)
+        assert models["claude"] == 2
+        assert models["ollama/gemma3"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: model_specific_analysis
+# ---------------------------------------------------------------------------
+
+
+class TestModelSpecificAnalysis:
+    def test_filters_by_model(self) -> None:
+        sessions = [
+            _session("s1", model="claude", tool_calls=(_tc(is_error=True),)),
+            _session("s2", model="ollama", tool_calls=(_tc(),)),
+            _session("s3", model="claude", tool_calls=(_tc(),)),
+        ]
+        analyzer = CrossSessionAnalyzer()
+        report = analyzer.model_specific_analysis(sessions, "claude")
+
+        assert report.model == "claude"
+        assert report.sessions == 2
+
+    def test_no_matching_sessions(self) -> None:
+        sessions = [_session("s1", model="claude")]
+        analyzer = CrossSessionAnalyzer()
+        report = analyzer.model_specific_analysis(sessions, "gpt-4")
+        assert report.sessions == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: track_evolution_impact
+# ---------------------------------------------------------------------------
+
+
+class TestTrackEvolutionImpact:
+    def test_improvement_detected(self) -> None:
+        before = [_session("s1", tool_calls=(_tc("bash", is_error=True), _tc("bash")))]
+        after = [_session("s2", tool_calls=(_tc("bash"), _tc("bash")))]
+
+        analyzer = CrossSessionAnalyzer()
+        impact = analyzer.track_evolution_impact(before, after, "bash")
+
+        assert impact.before_error_rate == 0.5
+        assert impact.after_error_rate == 0.0
+        assert impact.delta < 0
+        assert impact.improved is True
+
+    def test_regression_detected(self) -> None:
+        before = [_session("s1", tool_calls=(_tc("bash"),))]
+        after = [_session("s2", tool_calls=(_tc("bash", is_error=True),))]
+
+        analyzer = CrossSessionAnalyzer()
+        impact = analyzer.track_evolution_impact(before, after, "bash")
+
+        assert impact.delta > 0
+        assert impact.improved is False
+
+
+# ---------------------------------------------------------------------------
+# Test: detect_regression
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRegression:
+    def test_regression_flagged(self) -> None:
+        before = [_session("s1", tool_calls=(_tc("bash"),) * 10)]
+        after = [
+            _session(
+                "s2",
+                tool_calls=tuple(_tc("bash", is_error=(i < 5)) for i in range(10)),
+            )
+        ]
+
+        analyzer = CrossSessionAnalyzer()
+        alerts = analyzer.detect_regression(before, after, threshold=0.1)
+
+        assert len(alerts) == 1
+        assert alerts[0].artifact_id == "bash"
+        assert alerts[0].delta > 0
+
+    def test_no_regression(self) -> None:
+        before = [_session("s1", tool_calls=(_tc("bash"),))]
+        after = [_session("s2", tool_calls=(_tc("bash"),))]
+
+        analyzer = CrossSessionAnalyzer()
+        alerts = analyzer.detect_regression(before, after, threshold=0.1)
+        assert alerts == []
+
+    def test_recommendation_severity(self) -> None:
+        # Create severe regression (100% error rate vs 0%)
+        before = [_session("s1", tool_calls=(_tc("bash"),) * 10)]
+        after = [_session("s2", tool_calls=(_tc("bash", is_error=True),) * 10)]
+
+        analyzer = CrossSessionAnalyzer()
+        alerts = analyzer.detect_regression(before, after, threshold=0.1)
+
+        assert alerts[0].recommendation == "rollback"
+
+
+# ---------------------------------------------------------------------------
+# Test: data structures frozen
+# ---------------------------------------------------------------------------
+
+
+class TestDataStructures:
+    def test_aggregate_report_frozen(self) -> None:
+        report = AggregateReport(
+            total_sessions=0,
+            total_tool_calls=0,
+            total_errors=0,
+            error_rate=0.0,
+            tool_error_rates=(),
+            model_distribution=(),
+            avg_session_latency_ms=0.0,
+        )
+        with pytest.raises(AttributeError):
+            report.total_sessions = 5  # type: ignore[misc]
+
+    def test_regression_alert_frozen(self) -> None:
+        alert = RegressionAlert(
+            artifact_id="bash",
+            record_id="",
+            before_error_rate=0.0,
+            after_error_rate=0.5,
+            delta=0.5,
+            recommendation="rollback",
+        )
+        with pytest.raises(AttributeError):
+            alert.recommendation = "monitor"  # type: ignore[misc]

--- a/tests/test_evolution/test_fitness.py
+++ b/tests/test_evolution/test_fitness.py
@@ -1,0 +1,300 @@
+"""Tests for the fitness evaluator — A/B testing with LLM-as-judge scoring."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from godspeed.evolution.fitness import (
+    FitnessEvaluator,
+    FitnessScore,
+    JudgeVerdict,
+)
+from godspeed.evolution.mutator import MutationCandidate
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(
+    original: str = "Short description.",
+    mutated: str = "Improved longer description with examples.",
+    artifact_type: str = "tool_description",
+    artifact_id: str = "bash",
+) -> MutationCandidate:
+    return MutationCandidate(
+        artifact_type=artifact_type,
+        artifact_id=artifact_id,
+        original=original,
+        mutated=mutated,
+        mutation_rationale="test",
+        model_used="ollama/test",
+    )
+
+
+GOOD_VERDICT_JSON = """{
+    "a_correctness": 6, "a_procedure": 5, "a_conciseness": 7,
+    "b_correctness": 9, "b_procedure": 8, "b_conciseness": 8,
+    "winner": "b"
+}"""
+
+TIE_VERDICT_JSON = """{
+    "a_correctness": 7, "a_procedure": 7, "a_conciseness": 7,
+    "b_correctness": 7, "b_procedure": 7, "b_conciseness": 7,
+    "winner": "tie"
+}"""
+
+
+# ---------------------------------------------------------------------------
+# Test: FitnessScore data structure
+# ---------------------------------------------------------------------------
+
+
+class TestFitnessScore:
+    def test_frozen(self) -> None:
+        score = FitnessScore(
+            correctness=0.9,
+            procedure_following=0.8,
+            conciseness=0.7,
+            overall=0.83,
+            length_penalty=0.0,
+            confidence=1.0,
+        )
+        with pytest.raises(AttributeError):
+            score.overall = 0.5  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        score = FitnessScore(
+            correctness=0.9,
+            procedure_following=0.8,
+            conciseness=0.7,
+            overall=0.83,
+            length_penalty=0.1,
+            confidence=0.5,
+        )
+        assert score.correctness == 0.9
+        assert score.confidence == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Test: JudgeVerdict data structure
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeVerdict:
+    def test_frozen(self) -> None:
+        v = JudgeVerdict(
+            a_correctness=7,
+            a_procedure=6,
+            a_conciseness=8,
+            b_correctness=9,
+            b_procedure=8,
+            b_conciseness=7,
+            winner="b",
+        )
+        with pytest.raises(AttributeError):
+            v.winner = "a"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Test: _parse_verdict
+# ---------------------------------------------------------------------------
+
+
+class TestParseVerdict:
+    def test_valid_json(self) -> None:
+        verdict = FitnessEvaluator._parse_verdict(GOOD_VERDICT_JSON)
+        assert verdict is not None
+        assert verdict.winner == "b"
+        assert verdict.b_correctness == 9
+
+    def test_json_in_code_block(self) -> None:
+        text = f"```json\n{GOOD_VERDICT_JSON}\n```"
+        verdict = FitnessEvaluator._parse_verdict(text)
+        assert verdict is not None
+        assert verdict.winner == "b"
+
+    def test_json_with_surrounding_text(self) -> None:
+        text = f"Here is my evaluation:\n{GOOD_VERDICT_JSON}\nThat's my verdict."
+        verdict = FitnessEvaluator._parse_verdict(text)
+        assert verdict is not None
+
+    def test_no_json(self) -> None:
+        verdict = FitnessEvaluator._parse_verdict("No JSON here at all")
+        assert verdict is None
+
+    def test_missing_keys(self) -> None:
+        verdict = FitnessEvaluator._parse_verdict('{"a_correctness": 5}')
+        assert verdict is None
+
+    def test_invalid_winner_defaults_to_tie(self) -> None:
+        j = (
+            '{"a_correctness": 5, "a_procedure": 5,'
+            ' "a_conciseness": 5, "b_correctness": 5,'
+            ' "b_procedure": 5, "b_conciseness": 5,'
+            ' "winner": "invalid"}'
+        )
+        verdict = FitnessEvaluator._parse_verdict(j)
+        assert verdict is not None
+        assert verdict.winner == "tie"
+
+    def test_scores_clamped(self) -> None:
+        j = (
+            '{"a_correctness": -5, "a_procedure": 15,'
+            ' "a_conciseness": 5, "b_correctness": 5,'
+            ' "b_procedure": 5, "b_conciseness": 5,'
+            ' "winner": "a"}'
+        )
+        verdict = FitnessEvaluator._parse_verdict(j)
+        assert verdict is not None
+        assert verdict.a_correctness == 0.0
+        assert verdict.a_procedure == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Test: evaluate
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    @pytest.mark.asyncio
+    async def test_successful_evaluation(self) -> None:
+        evaluator = FitnessEvaluator()
+        candidate = _make_candidate()
+
+        with patch.object(evaluator, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = GOOD_VERDICT_JSON
+
+            score = await evaluator.evaluate(candidate, test_cases=["Test task"])
+
+        assert isinstance(score, FitnessScore)
+        assert score.correctness == 0.9  # 9/10
+        assert score.procedure_following == 0.8  # 8/10
+        assert score.conciseness == 0.8  # 8/10
+        assert score.confidence == 1.0
+        assert score.overall > 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_test_cases(self) -> None:
+        evaluator = FitnessEvaluator()
+        candidate = _make_candidate()
+
+        with patch.object(evaluator, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = GOOD_VERDICT_JSON
+
+            score = await evaluator.evaluate(
+                candidate,
+                test_cases=["Task 1", "Task 2", "Task 3"],
+            )
+
+        assert score.confidence == 1.0
+        assert mock_llm.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_partial_failures_reduce_confidence(self) -> None:
+        evaluator = FitnessEvaluator()
+        candidate = _make_candidate()
+
+        call_count = 0
+
+        async def _alternating_response(prompt: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise RuntimeError("fail")
+            return GOOD_VERDICT_JSON
+
+        with patch.object(evaluator, "_call_llm", side_effect=_alternating_response):
+            score = await evaluator.evaluate(
+                candidate,
+                test_cases=["T1", "T2", "T3"],
+            )
+
+        # 2 out of 3 succeed (call 1 OK, call 2 fail, call 3 OK)
+        assert score.confidence == pytest.approx(2 / 3, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_all_failures_return_zero(self) -> None:
+        evaluator = FitnessEvaluator()
+        candidate = _make_candidate()
+
+        with patch.object(evaluator, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.side_effect = RuntimeError("fail")
+
+            score = await evaluator.evaluate(candidate, test_cases=["T1"])
+
+        assert score.overall == 0.0
+        assert score.confidence == 0.0
+
+    @pytest.mark.asyncio
+    async def test_default_test_case_used(self) -> None:
+        evaluator = FitnessEvaluator()
+        candidate = _make_candidate()
+
+        with patch.object(evaluator, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = GOOD_VERDICT_JSON
+
+            score = await evaluator.evaluate(candidate)  # No test_cases
+
+        assert score.confidence == 1.0
+        assert mock_llm.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: length penalty
+# ---------------------------------------------------------------------------
+
+
+class TestLengthPenalty:
+    @pytest.mark.asyncio
+    async def test_no_penalty_for_small_growth(self) -> None:
+        evaluator = FitnessEvaluator()
+        candidate = _make_candidate(
+            original="A tool description that is fairly long already.",
+            mutated="A tool description that is fairly long already, with a small addition.",
+        )
+
+        with patch.object(evaluator, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = GOOD_VERDICT_JSON
+
+            score = await evaluator.evaluate(candidate, test_cases=["T1"])
+
+        assert score.length_penalty == 0.0
+
+    @pytest.mark.asyncio
+    async def test_penalty_for_excessive_growth(self) -> None:
+        evaluator = FitnessEvaluator()
+        candidate = _make_candidate(
+            original="short",
+            mutated="x" * 1000,  # Way longer than 2x original
+        )
+
+        with patch.object(evaluator, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = GOOD_VERDICT_JSON
+
+            score = await evaluator.evaluate(candidate, test_cases=["T1"])
+
+        assert score.length_penalty > 0
+
+
+# ---------------------------------------------------------------------------
+# Test: model configuration
+# ---------------------------------------------------------------------------
+
+
+class TestModelConfig:
+    def test_default_model_auto_detects(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=14000):
+            e = FitnessEvaluator()
+            assert e.judge_model == "ollama/gemma3:12b"
+
+    def test_default_model_low_vram(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=4000):
+            e = FitnessEvaluator()
+            assert e.judge_model == "ollama/qwen2.5:3b"
+
+    def test_custom_model(self) -> None:
+        e = FitnessEvaluator(judge_model="anthropic/claude-sonnet-4-20250514")
+        assert e.judge_model == "anthropic/claude-sonnet-4-20250514"

--- a/tests/test_evolution/test_hardware.py
+++ b/tests/test_evolution/test_hardware.py
@@ -1,0 +1,166 @@
+"""Tests for hardware-aware model selection."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from godspeed.evolution.hardware import (
+    FALLBACK_MODEL,
+    detect_vram_mb,
+    is_low_memory,
+    recommended_max_eval_cases,
+    recommended_num_candidates,
+    select_evolution_model,
+)
+
+# ---------------------------------------------------------------------------
+# Test: detect_vram_mb
+# ---------------------------------------------------------------------------
+
+
+class TestDetectVram:
+    def test_nvidia_smi_available(self) -> None:
+        with (
+            patch("godspeed.evolution.hardware.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("godspeed.evolution.hardware.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "12000\n"
+            assert detect_vram_mb() == 12000
+
+    def test_nvidia_smi_not_found(self) -> None:
+        with (
+            patch("godspeed.evolution.hardware.shutil.which", return_value=None),
+            patch("godspeed.evolution.hardware._detect_jetson", return_value=None),
+        ):
+            assert detect_vram_mb() is None
+
+    def test_nvidia_smi_fails(self) -> None:
+        with (
+            patch("godspeed.evolution.hardware.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("godspeed.evolution.hardware.subprocess.run") as mock_run,
+            patch("godspeed.evolution.hardware._detect_jetson", return_value=None),
+        ):
+            mock_run.return_value.returncode = 1
+            assert detect_vram_mb() is None
+
+    def test_nvidia_smi_multi_gpu_uses_first(self) -> None:
+        with (
+            patch("godspeed.evolution.hardware.shutil.which", return_value="/usr/bin/nvidia-smi"),
+            patch("godspeed.evolution.hardware.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "16000\n8000\n"
+            assert detect_vram_mb() == 16000
+
+
+# ---------------------------------------------------------------------------
+# Test: select_evolution_model
+# ---------------------------------------------------------------------------
+
+
+class TestSelectModel:
+    def test_explicit_model_respected(self) -> None:
+        model = "anthropic/claude-sonnet-4-20250514"
+        assert select_evolution_model(model) == model
+
+    def test_high_vram_gets_12b(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=14000):
+            assert select_evolution_model() == "ollama/gemma3:12b"
+
+    def test_medium_vram_gets_4b(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=7000):
+            assert select_evolution_model() == "ollama/gemma3:4b"
+
+    def test_low_vram_gets_3b(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=4000):
+            assert select_evolution_model() == "ollama/qwen2.5:3b"
+
+    def test_very_low_vram_gets_1_5b(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=2000):
+            assert select_evolution_model() == "ollama/qwen2.5:1.5b"
+
+    def test_no_vram_detected_uses_fallback(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=None):
+            assert select_evolution_model() == FALLBACK_MODEL
+
+    def test_jetson_orin_nano_8gb(self) -> None:
+        """Jetson Orin Nano Super: 8GB shared, ~4.8GB available after 60% factor."""
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=4800):
+            model = select_evolution_model()
+            assert model == "ollama/qwen2.5:3b"
+
+    def test_empty_string_triggers_auto(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=14000):
+            assert select_evolution_model("") == "ollama/gemma3:12b"
+
+
+# ---------------------------------------------------------------------------
+# Test: recommended_num_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendedCandidates:
+    def test_high_vram(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=14000):
+            assert recommended_num_candidates() == 5
+
+    def test_medium_vram(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=7000):
+            assert recommended_num_candidates() == 3
+
+    def test_low_vram(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=4000):
+            assert recommended_num_candidates() == 2
+
+    def test_very_low_vram(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=1000):
+            assert recommended_num_candidates() == 1
+
+    def test_no_detection(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=None):
+            assert recommended_num_candidates() == 2
+
+    def test_api_model_no_constraint(self) -> None:
+        assert recommended_num_candidates("anthropic/claude-sonnet-4-20250514") == 5
+
+
+# ---------------------------------------------------------------------------
+# Test: recommended_max_eval_cases
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendedEvalCases:
+    def test_high_vram(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=14000):
+            assert recommended_max_eval_cases() == 5
+
+    def test_low_vram(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=4000):
+            assert recommended_max_eval_cases() == 2
+
+    def test_api_model(self) -> None:
+        assert recommended_max_eval_cases("anthropic/claude-sonnet-4-20250514") == 5
+
+
+# ---------------------------------------------------------------------------
+# Test: is_low_memory
+# ---------------------------------------------------------------------------
+
+
+class TestIsLowMemory:
+    def test_high_vram_not_low(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=14000):
+            assert is_low_memory() is False
+
+    def test_low_vram_is_low(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=4000):
+            assert is_low_memory() is True
+
+    def test_no_detection_assumes_low(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=None):
+            assert is_low_memory() is True
+
+    def test_boundary_6gb(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=6000):
+            assert is_low_memory() is False

--- a/tests/test_evolution/test_mutator.py
+++ b/tests/test_evolution/test_mutator.py
@@ -1,0 +1,380 @@
+"""Tests for the evolution engine — GEPA-style LLM-guided mutations."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from godspeed.evolution.mutator import (
+    EvolutionEngine,
+    MutationCandidate,
+    SkillCandidate,
+)
+from godspeed.evolution.trace_analyzer import (
+    EvolutionReport,
+    ToolCall,
+    ToolFailurePattern,
+    ToolSequence,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_failure(
+    tool_name: str = "bash",
+    category: str = "execution_error",
+    frequency: int = 5,
+) -> ToolFailurePattern:
+    return ToolFailurePattern(
+        tool_name=tool_name,
+        error_category=category,
+        frequency=frequency,
+        example_args=({"cmd": "ls -la"},),
+        suggested_fix=f"Tool '{tool_name}' description may need better examples",
+    )
+
+
+def _make_report(
+    error_rate: float = 0.2,
+    failures: tuple[ToolFailurePattern, ...] = (),
+) -> EvolutionReport:
+    return EvolutionReport(
+        sessions_analyzed=10,
+        tool_failures=failures,
+        latency_stats=(),
+        permission_insights=(),
+        tool_sequences=(),
+        most_used_tools=(("file_read", 50), ("bash", 30)),
+        error_rate=error_rate,
+    )
+
+
+def _make_tool_call(
+    tool_name: str = "file_read",
+    is_error: bool = False,
+) -> ToolCall:
+    return ToolCall(
+        tool_name=tool_name,
+        arguments={"path": "src/foo.py"},
+        output_length=200,
+        is_error=is_error,
+        latency_ms=45.0,
+        outcome="success" if not is_error else "error",
+    )
+
+
+def _make_sequence() -> ToolSequence:
+    return ToolSequence(
+        tools=("file_read", "file_edit"),
+        frequency=8,
+        avg_success_rate=0.9,
+        candidate_skill_name="file_read_and_file_edit",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: MutationCandidate data structure
+# ---------------------------------------------------------------------------
+
+
+class TestMutationCandidate:
+    def test_frozen(self) -> None:
+        mc = MutationCandidate(
+            artifact_type="tool_description",
+            artifact_id="bash",
+            original="old",
+            mutated="new",
+            mutation_rationale="fix errors",
+            model_used="ollama/gemma3:12b",
+        )
+        with pytest.raises(AttributeError):
+            mc.mutated = "changed"  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        mc = MutationCandidate(
+            artifact_type="prompt_section",
+            artifact_id="core",
+            original="a",
+            mutated="b",
+            mutation_rationale="r",
+            model_used="m",
+        )
+        assert mc.artifact_type == "prompt_section"
+        assert mc.artifact_id == "core"
+
+
+# ---------------------------------------------------------------------------
+# Test: mutate_tool_description
+# ---------------------------------------------------------------------------
+
+
+class TestMutateToolDescription:
+    @pytest.mark.asyncio
+    async def test_returns_candidates(self) -> None:
+        engine = EvolutionEngine(model="ollama/test")
+        failure = _make_failure()
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = "Improved description for bash tool with examples."
+
+            candidates = await engine.mutate_tool_description(
+                tool_name="bash",
+                current_desc="Run shell commands.",
+                failure_patterns=[failure],
+                num_candidates=2,
+            )
+
+        assert len(candidates) == 2
+        assert all(isinstance(c, MutationCandidate) for c in candidates)
+        assert candidates[0].artifact_type == "tool_description"
+        assert candidates[0].artifact_id == "bash"
+        assert candidates[0].original == "Run shell commands."
+        assert candidates[0].mutated == "Improved description for bash tool with examples."
+
+    @pytest.mark.asyncio
+    async def test_no_failures_returns_empty(self) -> None:
+        engine = EvolutionEngine()
+        candidates = await engine.mutate_tool_description(
+            tool_name="bash",
+            current_desc="Run shell commands.",
+            failure_patterns=[],
+        )
+        assert candidates == []
+
+    @pytest.mark.asyncio
+    async def test_identical_mutation_skipped(self) -> None:
+        engine = EvolutionEngine()
+        failure = _make_failure()
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            # Return identical text — should be skipped
+            mock_llm.return_value = "Run shell commands."
+
+            candidates = await engine.mutate_tool_description(
+                tool_name="bash",
+                current_desc="Run shell commands.",
+                failure_patterns=[failure],
+                num_candidates=2,
+            )
+
+        assert candidates == []
+
+    @pytest.mark.asyncio
+    async def test_llm_error_handled(self) -> None:
+        engine = EvolutionEngine()
+        failure = _make_failure()
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.side_effect = RuntimeError("LLM down")
+
+            candidates = await engine.mutate_tool_description(
+                tool_name="bash",
+                current_desc="Run shell commands.",
+                failure_patterns=[failure],
+                num_candidates=2,
+            )
+
+        assert candidates == []
+
+    @pytest.mark.asyncio
+    async def test_rationale_includes_failure_count(self) -> None:
+        engine = EvolutionEngine()
+        failures = [_make_failure(), _make_failure(category="timeout")]
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = "Better description."
+
+            candidates = await engine.mutate_tool_description(
+                tool_name="bash",
+                current_desc="old",
+                failure_patterns=failures,
+                num_candidates=1,
+            )
+
+        assert "2 failure pattern" in candidates[0].mutation_rationale
+
+
+# ---------------------------------------------------------------------------
+# Test: mutate_prompt_section
+# ---------------------------------------------------------------------------
+
+
+class TestMutatePromptSection:
+    @pytest.mark.asyncio
+    async def test_returns_candidates(self) -> None:
+        engine = EvolutionEngine()
+        report = _make_report(
+            error_rate=0.3,
+            failures=(_make_failure(),),
+        )
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = "Improved core prompt section."
+
+            candidates = await engine.mutate_prompt_section(
+                section_name="core",
+                current_text="You are a coding agent.",
+                report=report,
+                num_candidates=1,
+            )
+
+        assert len(candidates) == 1
+        assert candidates[0].artifact_type == "prompt_section"
+        assert "30.0%" in candidates[0].mutation_rationale
+
+    @pytest.mark.asyncio
+    async def test_llm_error_handled(self) -> None:
+        engine = EvolutionEngine()
+        report = _make_report()
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.side_effect = RuntimeError("fail")
+
+            candidates = await engine.mutate_prompt_section(
+                section_name="core",
+                current_text="prompt",
+                report=report,
+                num_candidates=1,
+            )
+
+        assert candidates == []
+
+
+# ---------------------------------------------------------------------------
+# Test: mutate_compaction_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestMutateCompactionPrompt:
+    @pytest.mark.asyncio
+    async def test_returns_candidates(self) -> None:
+        engine = EvolutionEngine()
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = "Better compaction prompt."
+
+            candidates = await engine.mutate_compaction_prompt(
+                current_prompt="Summarize the conversation.",
+                quality_scores=[0.6, 0.7, 0.5],
+                num_candidates=1,
+            )
+
+        assert len(candidates) == 1
+        assert candidates[0].artifact_type == "compaction_prompt"
+        assert "0.60" in candidates[0].mutation_rationale
+
+
+# ---------------------------------------------------------------------------
+# Test: generate_tool_examples
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateToolExamples:
+    @pytest.mark.asyncio
+    async def test_generates_examples(self) -> None:
+        engine = EvolutionEngine()
+        traces = [_make_tool_call(), _make_tool_call()]
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = (
+                '- Example: Read a Python file\n  Arguments: {"path": "src/main.py"}'
+            )
+
+            examples = await engine.generate_tool_examples("file_read", traces)
+
+        assert len(examples) >= 1
+        assert "Example" in examples[0]
+
+    @pytest.mark.asyncio
+    async def test_empty_traces_returns_empty(self) -> None:
+        engine = EvolutionEngine()
+        examples = await engine.generate_tool_examples("file_read", [])
+        assert examples == []
+
+
+# ---------------------------------------------------------------------------
+# Test: suggest_new_skill
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestNewSkill:
+    @pytest.mark.asyncio
+    async def test_generates_skill(self) -> None:
+        engine = EvolutionEngine()
+        sequence = _make_sequence()
+        traces = [[_make_tool_call("file_read"), _make_tool_call("file_edit")]]
+
+        skill_yaml = """---
+name: read-and-edit
+description: Read then edit a file
+trigger: read-edit
+---
+
+1. Read the file with file_read
+2. Edit the file with file_edit"""
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = skill_yaml
+
+            result = await engine.suggest_new_skill(sequence, traces)
+
+        assert result is not None
+        assert isinstance(result, SkillCandidate)
+        assert result.name == "read-and-edit"
+        assert result.trigger == "read-edit"
+        assert "file_read" in result.content
+
+    @pytest.mark.asyncio
+    async def test_malformed_output_returns_none(self) -> None:
+        engine = EvolutionEngine()
+        sequence = _make_sequence()
+
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = "No frontmatter here"
+
+            result = await engine.suggest_new_skill(sequence, [[]])
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: model configuration
+# ---------------------------------------------------------------------------
+
+
+class TestModelConfig:
+    def test_default_model_auto_detects(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=14000):
+            engine = EvolutionEngine()
+            assert engine.model == "ollama/gemma3:12b"
+
+    def test_default_model_low_vram(self) -> None:
+        with patch("godspeed.evolution.hardware.detect_vram_mb", return_value=4000):
+            engine = EvolutionEngine()
+            assert engine.model == "ollama/qwen2.5:3b"
+
+    def test_custom_model(self) -> None:
+        engine = EvolutionEngine(model="anthropic/claude-sonnet-4-20250514")
+        assert engine.model == "anthropic/claude-sonnet-4-20250514"
+
+
+# ---------------------------------------------------------------------------
+# Test: _format_failures helper
+# ---------------------------------------------------------------------------
+
+
+class TestFormatFailures:
+    def test_formats_correctly(self) -> None:
+        failures = [_make_failure(), _make_failure(category="timeout", frequency=3)]
+        result = EvolutionEngine._format_failures(failures)
+        assert "execution_error" in result
+        assert "timeout" in result
+        assert "5x" in result
+        assert "3x" in result
+
+    def test_empty_list(self) -> None:
+        result = EvolutionEngine._format_failures([])
+        assert result == ""

--- a/tests/test_evolution/test_permissions.py
+++ b/tests/test_evolution/test_permissions.py
@@ -1,0 +1,171 @@
+"""Tests for permission pattern learning."""
+
+from __future__ import annotations
+
+import pytest
+
+from godspeed.evolution.permissions import PermissionAdvisor, PermissionSuggestion
+from godspeed.evolution.trace_analyzer import SessionTrace
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _session(
+    denials: tuple[tuple[str, str], ...] = (),
+    grants: tuple[str, ...] = (),
+) -> SessionTrace:
+    return SessionTrace(
+        session_id="s1",
+        tool_calls=(),
+        errors=(),
+        permission_denials=denials,
+        permission_grants=grants,
+        total_latency_ms=0.0,
+        model="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: analyze_denials
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeDenials:
+    def test_frequent_denials_flagged(self) -> None:
+        sessions = [
+            _session(denials=tuple(("bash", "not allowed") for _ in range(6))),
+        ]
+        advisor = PermissionAdvisor(denial_threshold=5)
+        suggestions = advisor.analyze_denials(sessions)
+
+        assert len(suggestions) == 1
+        assert suggestions[0].tool_name == "bash"
+        assert suggestions[0].action == "add_to_allowlist"
+        assert suggestions[0].denial_count == 6
+
+    def test_below_threshold_excluded(self) -> None:
+        sessions = [
+            _session(denials=(("bash", "not allowed"), ("bash", "not allowed"))),
+        ]
+        advisor = PermissionAdvisor(denial_threshold=5)
+        suggestions = advisor.analyze_denials(sessions)
+        assert suggestions == []
+
+    def test_rationale_includes_reasons(self) -> None:
+        sessions = [
+            _session(denials=tuple(("bash", "blocked by policy") for _ in range(5))),
+        ]
+        advisor = PermissionAdvisor(denial_threshold=5)
+        suggestions = advisor.analyze_denials(sessions)
+        assert "blocked by policy" in suggestions[0].rationale
+
+
+# ---------------------------------------------------------------------------
+# Test: analyze_approvals
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeApprovals:
+    def test_frequent_grants_suggest_pre_approve(self) -> None:
+        sessions = [
+            _session(grants=tuple("file_read" for _ in range(6))),
+        ]
+        advisor = PermissionAdvisor(grant_threshold=5)
+        suggestions = advisor.analyze_approvals(sessions)
+
+        assert len(suggestions) == 1
+        assert suggestions[0].tool_name == "file_read"
+        assert suggestions[0].action == "pre_approve"
+
+    def test_mixed_grant_denial_excluded(self) -> None:
+        sessions = [
+            _session(
+                grants=tuple("bash" for _ in range(6)),
+                denials=(("bash", "denied once"),),
+            ),
+        ]
+        advisor = PermissionAdvisor(grant_threshold=5)
+        suggestions = advisor.analyze_approvals(sessions)
+        assert suggestions == []
+
+    def test_below_threshold_excluded(self) -> None:
+        sessions = [_session(grants=("file_read",))]
+        advisor = PermissionAdvisor(grant_threshold=5)
+        assert advisor.analyze_approvals(sessions) == []
+
+
+# ---------------------------------------------------------------------------
+# Test: generate_permission_config
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratePermissionConfig:
+    def test_generates_config(self) -> None:
+        suggestions = [
+            PermissionSuggestion(
+                tool_name="file_read",
+                action="pre_approve",
+                denial_count=0,
+                grant_count=10,
+                rationale="safe",
+            ),
+            PermissionSuggestion(
+                tool_name="bash",
+                action="add_to_allowlist",
+                denial_count=8,
+                grant_count=0,
+                rationale="frequent",
+            ),
+        ]
+        advisor = PermissionAdvisor()
+        config = advisor.generate_permission_config(suggestions)
+
+        assert "permissions" in config
+        assert "bash" in config["permissions"]["allow"]
+        assert "file_read" in config["permissions"]["allow"]
+
+    def test_empty_suggestions(self) -> None:
+        advisor = PermissionAdvisor()
+        config = advisor.generate_permission_config([])
+        assert config["permissions"]["allow"] == []
+
+
+# ---------------------------------------------------------------------------
+# Test: get_all_suggestions
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllSuggestions:
+    def test_combines_denials_and_approvals(self) -> None:
+        sessions = [
+            _session(
+                denials=tuple(("bash", "blocked") for _ in range(6)),
+                grants=tuple("file_read" for _ in range(6)),
+            ),
+        ]
+        advisor = PermissionAdvisor(denial_threshold=5, grant_threshold=5)
+        all_suggestions = advisor.get_all_suggestions(sessions)
+
+        tools = {s.tool_name for s in all_suggestions}
+        assert "bash" in tools
+        assert "file_read" in tools
+
+
+# ---------------------------------------------------------------------------
+# Test: data structures
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionSuggestion:
+    def test_frozen(self) -> None:
+        s = PermissionSuggestion(
+            tool_name="bash",
+            action="add_to_allowlist",
+            denial_count=5,
+            grant_count=0,
+            rationale="test",
+        )
+        with pytest.raises(AttributeError):
+            s.action = "changed"  # type: ignore[misc]

--- a/tests/test_evolution/test_registry.py
+++ b/tests/test_evolution/test_registry.py
@@ -1,0 +1,271 @@
+"""Tests for the evolution registry — versioned history of evolved artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from godspeed.evolution.fitness import FitnessScore
+from godspeed.evolution.mutator import MutationCandidate
+from godspeed.evolution.registry import EvolutionRecord, EvolutionRegistry
+from godspeed.evolution.safety import SafetyVerdict
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(artifact_id: str = "file_read") -> MutationCandidate:
+    return MutationCandidate(
+        artifact_type="tool_description",
+        artifact_id=artifact_id,
+        original="Read files.",
+        mutated="Read files with path validation.",
+        mutation_rationale="improve clarity",
+        model_used="ollama/test",
+    )
+
+
+def _make_score(overall: float = 0.8) -> FitnessScore:
+    return FitnessScore(
+        correctness=0.9,
+        procedure_following=0.8,
+        conciseness=0.7,
+        overall=overall,
+        length_penalty=0.0,
+        confidence=1.0,
+    )
+
+
+def _make_verdict(passed: bool = True) -> SafetyVerdict:
+    return SafetyVerdict(
+        passed=passed,
+        checks=(("size_limit", True, "ok"), ("fitness_threshold", passed, "ok")),
+        requires_human_review=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: register
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_register_returns_id(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        assert isinstance(record_id, str)
+        assert len(record_id) > 0
+
+    def test_creates_registry_file(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        registry.register(_make_candidate(), _make_score(), _make_verdict())
+        assert (tmp_path / "registry.jsonl").exists()
+
+    def test_creates_candidate_file(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        assert (tmp_path / "candidates" / f"{record_id}.json").exists()
+
+    def test_multiple_registrations(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        id1 = registry.register(_make_candidate("tool_a"), _make_score(), _make_verdict())
+        id2 = registry.register(_make_candidate("tool_b"), _make_score(), _make_verdict())
+        assert id1 != id2
+
+        records = registry.get_history("tool_a")
+        assert len(records) == 1
+        assert records[0].artifact_id == "tool_a"
+
+
+# ---------------------------------------------------------------------------
+# Test: mark_applied / mark_reverted
+# ---------------------------------------------------------------------------
+
+
+class TestApplyRevert:
+    def test_mark_applied(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+
+        registry.mark_applied(record_id, "mutated text")
+        record = registry.get_record(record_id)
+
+        assert record is not None
+        assert record.applied_at != ""
+        assert (tmp_path / "applied" / "file_read.json").exists()
+
+    def test_mark_reverted(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        registry.mark_applied(record_id, "mutated text")
+        registry.mark_reverted(record_id)
+
+        record = registry.get_record(record_id)
+        assert record is not None
+        assert record.reverted_at != ""
+        assert not (tmp_path / "applied" / "file_read.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Test: originals backup
+# ---------------------------------------------------------------------------
+
+
+class TestOriginals:
+    def test_save_and_retrieve(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        registry.save_original("file_read", "Original description.")
+        result = registry.get_original("file_read")
+        assert result == "Original description."
+
+    def test_only_saves_first(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        registry.save_original("file_read", "First original.")
+        registry.save_original("file_read", "Second original.")  # Should not overwrite
+        result = registry.get_original("file_read")
+        assert result == "First original."
+
+    def test_missing_original(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        assert registry.get_original("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Test: get_applied / list_applied
+# ---------------------------------------------------------------------------
+
+
+class TestAppliedQueries:
+    def test_get_applied(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        registry.mark_applied(record_id, "mutated text")
+
+        applied = registry.get_applied("file_read")
+        assert applied is not None
+        assert applied["record_id"] == record_id
+        assert applied["mutated_text"] == "mutated text"
+
+    def test_get_applied_missing(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        assert registry.get_applied("nonexistent") is None
+
+    def test_list_applied(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        id1 = registry.register(_make_candidate("tool_a"), _make_score(), _make_verdict())
+        id2 = registry.register(_make_candidate("tool_b"), _make_score(), _make_verdict())
+        registry.mark_applied(id1, "text_a")
+        registry.mark_applied(id2, "text_b")
+
+        applied = registry.list_applied()
+        assert len(applied) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: get_candidate
+# ---------------------------------------------------------------------------
+
+
+class TestGetCandidate:
+    def test_retrieves_candidate(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+
+        candidate = registry.get_candidate(record_id)
+        assert candidate is not None
+        assert candidate["artifact_id"] == "file_read"
+        assert candidate["original"] == "Read files."
+        assert candidate["mutated"] == "Read files with path validation."
+
+    def test_missing_candidate(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        assert registry.get_candidate("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# Test: leaderboard
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderboard:
+    def test_returns_top_applied(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+
+        # Register and apply 3 mutations with different fitness
+        for i, score_val in enumerate([0.6, 0.9, 0.7]):
+            record_id = registry.register(
+                _make_candidate(f"tool_{i}"),
+                _make_score(overall=score_val),
+                _make_verdict(),
+            )
+            registry.mark_applied(record_id, f"text_{i}")
+
+        leaders = registry.leaderboard(top_n=2)
+        assert len(leaders) == 2
+        assert leaders[0].fitness_overall == 0.9
+        assert leaders[1].fitness_overall == 0.7
+
+    def test_excludes_reverted(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        record_id = registry.register(_make_candidate(), _make_score(), _make_verdict())
+        registry.mark_applied(record_id, "text")
+        registry.mark_reverted(record_id)
+
+        leaders = registry.leaderboard()
+        assert len(leaders) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: stats
+# ---------------------------------------------------------------------------
+
+
+class TestStats:
+    def test_empty_registry(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        s = registry.stats()
+        assert s["total_mutations"] == 0
+        assert s["avg_fitness"] == 0.0
+
+    def test_populated_registry(self, tmp_path: Path) -> None:
+        registry = EvolutionRegistry(tmp_path)
+        id1 = registry.register(_make_candidate("a"), _make_score(0.8), _make_verdict(True))
+        registry.register(_make_candidate("b"), _make_score(0.4), _make_verdict(False))
+        registry.mark_applied(id1, "text")
+
+        s = registry.stats()
+        assert s["total_mutations"] == 2
+        assert s["applied"] == 1
+        assert s["safety_passed"] == 1
+        assert s["safety_failed"] == 1
+        assert s["avg_fitness"] == pytest.approx(0.6, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Test: EvolutionRecord
+# ---------------------------------------------------------------------------
+
+
+class TestEvolutionRecord:
+    def test_to_dict_from_dict_roundtrip(self) -> None:
+        rec = EvolutionRecord(
+            record_id="test-123",
+            artifact_type="tool_description",
+            artifact_id="bash",
+            original_hash="abc123",
+            mutated_hash="def456",
+            fitness_overall=0.85,
+            fitness_confidence=1.0,
+            safety_passed=True,
+            requires_review=False,
+            model_used="ollama/test",
+            created_at="2026-04-13T00:00:00+00:00",
+            applied_at="",
+            reverted_at="",
+        )
+        d = rec.to_dict()
+        rec2 = EvolutionRecord.from_dict(d)
+        assert rec.record_id == rec2.record_id
+        assert rec.fitness_overall == rec2.fitness_overall

--- a/tests/test_evolution/test_safety.py
+++ b/tests/test_evolution/test_safety.py
@@ -1,0 +1,219 @@
+"""Tests for the safety gate — preventing regressions from evolved artifacts."""
+
+from __future__ import annotations
+
+import pytest
+
+from godspeed.evolution.fitness import FitnessScore
+from godspeed.evolution.mutator import MutationCandidate
+from godspeed.evolution.safety import SafetyGate, SafetyVerdict
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_candidate(
+    original: str = "Read files from disk with path validation and traversal protection.",
+    mutated: str = "Read files from the local filesystem with path validation and examples.",
+    artifact_type: str = "tool_description",
+    artifact_id: str = "file_read",
+) -> MutationCandidate:
+    return MutationCandidate(
+        artifact_type=artifact_type,
+        artifact_id=artifact_id,
+        original=original,
+        mutated=mutated,
+        mutation_rationale="test",
+        model_used="ollama/test",
+    )
+
+
+def _make_score(
+    overall: float = 0.8,
+    confidence: float = 1.0,
+) -> FitnessScore:
+    return FitnessScore(
+        correctness=0.9,
+        procedure_following=0.8,
+        conciseness=0.7,
+        overall=overall,
+        length_penalty=0.0,
+        confidence=confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: SafetyVerdict data structure
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyVerdict:
+    def test_frozen(self) -> None:
+        v = SafetyVerdict(
+            passed=True,
+            checks=(("size_limit", True, "ok"),),
+            requires_human_review=False,
+        )
+        with pytest.raises(AttributeError):
+            v.passed = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Test: check_size_limit
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSizeLimit:
+    def test_within_limit(self) -> None:
+        gate = SafetyGate(max_growth=2.0)
+        candidate = _make_candidate(original="short text", mutated="slightly longer text")
+        ok, _msg = gate.check_size_limit(candidate)
+        assert ok is True
+
+    def test_exceeds_limit(self) -> None:
+        gate = SafetyGate(max_growth=2.0)
+        candidate = _make_candidate(original="short", mutated="x" * 1000)
+        ok, msg = gate.check_size_limit(candidate)
+        assert ok is False
+        assert "ratio" in msg
+
+    def test_empty_original(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate(original="", mutated="something")
+        ok, _msg = gate.check_size_limit(candidate)
+        assert ok is True  # No check on empty original
+
+
+# ---------------------------------------------------------------------------
+# Test: check_semantic_drift
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSemanticDrift:
+    def test_similar_text_passes(self) -> None:
+        gate = SafetyGate(min_similarity=0.3)
+        candidate = _make_candidate(
+            original="Read files from disk with validation.",
+            mutated="Read files from the local disk with path validation and examples.",
+        )
+        ok, _msg = gate.check_semantic_drift(candidate)
+        assert ok is True
+
+    def test_completely_different_fails(self) -> None:
+        gate = SafetyGate(min_similarity=0.3)
+        candidate = _make_candidate(
+            original="Read files from disk.",
+            mutated="Execute shell commands in a sandbox container.",
+        )
+        ok, _msg = gate.check_semantic_drift(candidate)
+        assert ok is False
+
+    def test_both_empty(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate(original="", mutated="")
+        ok, _ = gate.check_semantic_drift(candidate)
+        assert ok is True
+
+    def test_one_empty(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate(original="content", mutated="")
+        ok, _ = gate.check_semantic_drift(candidate)
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Test: check_fitness_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFitnessThreshold:
+    def test_above_threshold(self) -> None:
+        gate = SafetyGate(min_fitness=0.6)
+        score = _make_score(overall=0.8)
+        ok, _msg = gate.check_fitness_threshold(score)
+        assert ok is True
+
+    def test_below_threshold(self) -> None:
+        gate = SafetyGate(min_fitness=0.6)
+        score = _make_score(overall=0.4)
+        ok, _msg = gate.check_fitness_threshold(score)
+        assert ok is False
+
+    def test_exact_threshold(self) -> None:
+        gate = SafetyGate(min_fitness=0.6)
+        score = _make_score(overall=0.6)
+        ok, _ = gate.check_fitness_threshold(score)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Test: requires_human_review
+# ---------------------------------------------------------------------------
+
+
+class TestRequiresHumanReview:
+    def test_prompt_section_needs_review(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate(artifact_type="prompt_section", artifact_id="tools")
+        assert gate.requires_human_review(candidate) is True
+
+    def test_core_artifact_needs_review(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate(artifact_type="tool_description", artifact_id="core")
+        assert gate.requires_human_review(candidate) is True
+
+    def test_security_artifact_needs_review(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate(artifact_id="security")
+        assert gate.requires_human_review(candidate) is True
+
+    def test_regular_tool_no_review(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate(artifact_type="tool_description", artifact_id="file_read")
+        assert gate.requires_human_review(candidate) is False
+
+
+# ---------------------------------------------------------------------------
+# Test: gate (full check)
+# ---------------------------------------------------------------------------
+
+
+class TestGate:
+    def test_all_checks_pass(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate()
+        score = _make_score(overall=0.8, confidence=1.0)
+        verdict = gate.gate(candidate, score)
+
+        assert verdict.passed is True
+        assert all(ok for _, ok, _ in verdict.checks)
+        assert verdict.requires_human_review is False
+
+    def test_size_limit_fails(self) -> None:
+        gate = SafetyGate(max_growth=1.5)
+        candidate = _make_candidate(original="a", mutated="a" * 100)
+        score = _make_score()
+        verdict = gate.gate(candidate, score)
+
+        assert verdict.passed is False
+        size_check = next(c for c in verdict.checks if c[0] == "size_limit")
+        assert size_check[1] is False
+
+    def test_low_confidence_fails(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate()
+        score = _make_score(confidence=0.3)
+        verdict = gate.gate(candidate, score)
+
+        assert verdict.passed is False
+        conf_check = next(c for c in verdict.checks if c[0] == "confidence")
+        assert conf_check[1] is False
+
+    def test_prompt_section_flagged_for_review(self) -> None:
+        gate = SafetyGate()
+        candidate = _make_candidate(artifact_type="prompt_section")
+        score = _make_score()
+        verdict = gate.gate(candidate, score)
+
+        assert verdict.requires_human_review is True

--- a/tests/test_evolution/test_skill_gen.py
+++ b/tests/test_evolution/test_skill_gen.py
@@ -1,0 +1,161 @@
+"""Tests for skill auto-generation from repeated tool patterns."""
+
+from __future__ import annotations
+
+from godspeed.evolution.skill_gen import GeneratedSkill, SkillGenerator
+from godspeed.evolution.trace_analyzer import SessionTrace, ToolCall, ToolSequence
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _sequence(
+    tools: tuple[str, ...] = ("file_read", "file_edit"),
+    frequency: int = 5,
+) -> ToolSequence:
+    return ToolSequence(
+        tools=tools,
+        frequency=frequency,
+        avg_success_rate=0.9,
+        candidate_skill_name="_and_".join(tools),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: generate_skill_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSkillMarkdown:
+    def test_generates_valid_markdown(self) -> None:
+        gen = SkillGenerator()
+        seq = _sequence()
+        markdown = gen.generate_skill_markdown(seq)
+
+        assert "---" in markdown
+        assert "file_read" in markdown
+        assert "file_edit" in markdown
+
+    def test_validates_own_output(self) -> None:
+        gen = SkillGenerator()
+        seq = _sequence()
+        markdown = gen.generate_skill_markdown(seq)
+        assert gen.validate_skill(markdown) is True
+
+    def test_custom_description(self) -> None:
+        gen = SkillGenerator()
+        seq = _sequence()
+        markdown = gen.generate_skill_markdown(seq, description="Custom desc")
+        assert "Custom desc" in markdown
+
+
+# ---------------------------------------------------------------------------
+# Test: generate (full GeneratedSkill)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_returns_generated_skill(self) -> None:
+        gen = SkillGenerator()
+        seq = _sequence()
+        skill = gen.generate(seq)
+
+        assert isinstance(skill, GeneratedSkill)
+        assert skill.source_tools == ("file_read", "file_edit")
+        assert skill.frequency == 5
+        assert len(skill.content) > 0
+
+    def test_name_is_kebab_case(self) -> None:
+        gen = SkillGenerator()
+        seq = _sequence(tools=("file_read", "file_edit"))
+        skill = gen.generate(seq)
+        assert "-" in skill.name
+        assert "_" not in skill.name
+
+
+# ---------------------------------------------------------------------------
+# Test: validate_skill
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSkill:
+    def test_valid_skill(self) -> None:
+        gen = SkillGenerator()
+        valid = "---\nname: test\ndescription: A test\ntrigger: test\n---\n\n1. Do something"
+        assert gen.validate_skill(valid) is True
+
+    def test_missing_frontmatter(self) -> None:
+        gen = SkillGenerator()
+        assert gen.validate_skill("No frontmatter here") is False
+
+    def test_missing_required_field(self) -> None:
+        gen = SkillGenerator()
+        invalid = "---\nname: test\n---\n\nContent"
+        assert gen.validate_skill(invalid) is False
+
+    def test_empty_body(self) -> None:
+        gen = SkillGenerator()
+        invalid = "---\nname: test\ndescription: d\ntrigger: t\n---\n"
+        assert gen.validate_skill(invalid) is False
+
+
+# ---------------------------------------------------------------------------
+# Test: detect_patterns (delegates to TraceAnalyzer)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPatterns:
+    def test_delegates_to_analyzer(self) -> None:
+        gen = SkillGenerator()
+        # Create sessions with repeated patterns
+        tc_read = ToolCall(
+            tool_name="file_read",
+            arguments={},
+            output_length=100,
+            is_error=False,
+            latency_ms=50.0,
+            outcome="success",
+        )
+        tc_edit = ToolCall(
+            tool_name="file_edit",
+            arguments={},
+            output_length=100,
+            is_error=False,
+            latency_ms=50.0,
+            outcome="success",
+        )
+
+        sessions = [
+            SessionTrace(
+                session_id=f"s{i}",
+                tool_calls=(tc_read, tc_edit),
+                errors=(),
+                permission_denials=(),
+                permission_grants=(),
+                total_latency_ms=100.0,
+                model="",
+            )
+            for i in range(5)
+        ]
+
+        patterns = gen.detect_patterns(sessions, min_frequency=3)
+        assert len(patterns) > 0
+        pair = next((p for p in patterns if p.tools == ("file_read", "file_edit")), None)
+        assert pair is not None
+
+
+# ---------------------------------------------------------------------------
+# Test: _make_name helper
+# ---------------------------------------------------------------------------
+
+
+class TestMakeName:
+    def test_deduplicates_consecutive(self) -> None:
+        name = SkillGenerator._make_name(("file_read", "file_read", "file_edit"))
+        assert name == "file-read-and-file-edit"
+
+    def test_caps_length(self) -> None:
+        long_tools = tuple(f"tool_{i}" for i in range(20))
+        name = SkillGenerator._make_name(long_tools)
+        assert len(name) <= 50

--- a/tests/test_evolution/test_trace_analyzer.py
+++ b/tests/test_evolution/test_trace_analyzer.py
@@ -1,0 +1,530 @@
+"""Tests for the trace analyzer — parsing audit JSONL into actionable insights."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import pytest
+
+from godspeed.audit.events import AuditEventType, AuditRecord
+from godspeed.evolution.trace_analyzer import (
+    EvolutionReport,
+    SessionTrace,
+    ToolCall,
+    TraceAnalyzer,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_record(
+    session_id: str = "sess-1",
+    action_type: AuditEventType = AuditEventType.TOOL_CALL,
+    detail: dict | None = None,
+    outcome: str = "success",
+    sequence: int = 0,
+) -> str:
+    """Create an audit record JSON line."""
+    rec = AuditRecord(
+        session_id=session_id,
+        sequence=sequence,
+        action_type=action_type,
+        action_detail=detail or {},
+        outcome=outcome,
+    )
+    return rec.model_dump_json()
+
+
+def _write_session(
+    tmp_path: Path,
+    session_id: str,
+    records: list[str],
+    compressed: bool = False,
+) -> Path:
+    """Write a session audit file from record JSON strings."""
+    content = "\n".join(records) + "\n"
+    if compressed:
+        path = tmp_path / f"{session_id}.audit.jsonl.gz"
+        with gzip.open(path, "wt", encoding="utf-8") as f:
+            f.write(content)
+    else:
+        path = tmp_path / f"{session_id}.audit.jsonl"
+        path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _make_tool_call_response_pair(
+    session_id: str = "sess-1",
+    tool_name: str = "file_read",
+    arguments: dict | None = None,
+    outcome: str = "success",
+    latency_ms: float = 50.0,
+    output_length: int = 100,
+    seq_start: int = 0,
+) -> list[str]:
+    """Create a TOOL_CALL + TOOL_RESPONSE pair."""
+    call = _make_record(
+        session_id=session_id,
+        action_type=AuditEventType.TOOL_CALL,
+        detail={"tool_name": tool_name, "arguments": arguments or {"path": "src/foo.py"}},
+        sequence=seq_start,
+    )
+    response = _make_record(
+        session_id=session_id,
+        action_type=AuditEventType.TOOL_RESPONSE,
+        detail={
+            "tool_name": tool_name,
+            "latency_ms": latency_ms,
+            "output_length": output_length,
+        },
+        outcome=outcome,
+        sequence=seq_start + 1,
+    )
+    return [call, response]
+
+
+# ---------------------------------------------------------------------------
+# Test: load_sessions
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSessions:
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        assert sessions == []
+
+    def test_nonexistent_dir(self, tmp_path: Path) -> None:
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path / "nope")
+        assert sessions == []
+
+    def test_single_session(self, tmp_path: Path) -> None:
+        records = _make_tool_call_response_pair()
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        assert len(sessions) == 1
+        assert sessions[0].session_id == "sess-1"
+        assert len(sessions[0].tool_calls) == 1
+        assert sessions[0].tool_calls[0].tool_name == "file_read"
+
+    def test_compressed_session(self, tmp_path: Path) -> None:
+        records = _make_tool_call_response_pair(session_id="sess-gz")
+        _write_session(tmp_path, "sess-gz", records, compressed=True)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        assert len(sessions) == 1
+        assert sessions[0].session_id == "sess-gz"
+
+    def test_last_n_filter(self, tmp_path: Path) -> None:
+        import time
+
+        for i in range(5):
+            records = _make_tool_call_response_pair(session_id=f"sess-{i}")
+            _write_session(tmp_path, f"sess-{i}", records)
+            # Touch with increasing mtime
+            time.sleep(0.01)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path, last_n=2)
+        assert len(sessions) == 2
+
+    def test_malformed_records_skipped(self, tmp_path: Path) -> None:
+        records = [
+            "not valid json",
+            *_make_tool_call_response_pair(),
+        ]
+        _write_session(tmp_path, "sess-bad", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        assert len(sessions) == 1
+        assert len(sessions[0].tool_calls) == 1
+
+    def test_empty_file_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "empty.audit.jsonl").write_text("", encoding="utf-8")
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        assert sessions == []
+
+
+# ---------------------------------------------------------------------------
+# Test: analyze_tool_failures
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeToolFailures:
+    def test_no_errors(self, tmp_path: Path) -> None:
+        records = _make_tool_call_response_pair(outcome="success")
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        failures = analyzer.analyze_tool_failures(sessions)
+        assert failures == []
+
+    def test_groups_by_tool_and_category(self, tmp_path: Path) -> None:
+        records = [
+            *_make_tool_call_response_pair(tool_name="bash", outcome="error", seq_start=0),
+            *_make_tool_call_response_pair(tool_name="bash", outcome="error", seq_start=2),
+            *_make_tool_call_response_pair(tool_name="file_read", outcome="timeout", seq_start=4),
+        ]
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        failures = analyzer.analyze_tool_failures(sessions)
+
+        assert len(failures) == 2
+        # Sorted by frequency descending
+        assert failures[0].tool_name == "bash"
+        assert failures[0].frequency == 2
+        assert failures[1].tool_name == "file_read"
+        assert failures[1].error_category == "timeout"
+
+    def test_example_args_capped_at_5(self, tmp_path: Path) -> None:
+        records = []
+        for i in range(10):
+            records.extend(
+                _make_tool_call_response_pair(
+                    tool_name="bash",
+                    arguments={"cmd": f"cmd-{i}"},
+                    outcome="error",
+                    seq_start=i * 2,
+                )
+            )
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        failures = analyzer.analyze_tool_failures(sessions)
+
+        assert failures[0].frequency == 10
+        assert len(failures[0].example_args) == 5
+
+    def test_suggested_fix_present(self, tmp_path: Path) -> None:
+        records = _make_tool_call_response_pair(tool_name="bash", outcome="timeout")
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        failures = analyzer.analyze_tool_failures(sessions)
+        fix = failures[0].suggested_fix.lower()
+        assert "timeout" in fix or "background" in fix
+
+
+# ---------------------------------------------------------------------------
+# Test: analyze_tool_latency
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeToolLatency:
+    def test_basic_latency_stats(self, tmp_path: Path) -> None:
+        records = []
+        for i, latency in enumerate([10.0, 20.0, 30.0, 40.0, 50.0]):
+            records.extend(
+                _make_tool_call_response_pair(
+                    tool_name="file_read",
+                    latency_ms=latency,
+                    seq_start=i * 2,
+                )
+            )
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        stats = analyzer.analyze_tool_latency(sessions)
+
+        assert len(stats) == 1
+        assert stats[0].tool_name == "file_read"
+        assert stats[0].count == 5
+        assert stats[0].mean_ms == 30.0
+        assert stats[0].p50_ms == 30.0
+
+    def test_multiple_tools(self, tmp_path: Path) -> None:
+        records = [
+            *_make_tool_call_response_pair(tool_name="file_read", latency_ms=100.0, seq_start=0),
+            *_make_tool_call_response_pair(tool_name="bash", latency_ms=500.0, seq_start=2),
+        ]
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        stats = analyzer.analyze_tool_latency(sessions)
+
+        assert len(stats) == 2
+        # Sorted by p95 descending
+        assert stats[0].tool_name == "bash"
+
+    def test_zero_latency_excluded(self, tmp_path: Path) -> None:
+        records = _make_tool_call_response_pair(tool_name="file_read", latency_ms=0.0)
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        stats = analyzer.analyze_tool_latency(sessions)
+        assert stats == []
+
+
+# ---------------------------------------------------------------------------
+# Test: analyze_permission_patterns
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePermissionPatterns:
+    def test_frequent_denials_flagged(self, tmp_path: Path) -> None:
+        records = []
+        for i in range(6):
+            records.append(
+                _make_record(
+                    action_type=AuditEventType.PERMISSION_CHECK,
+                    detail={"tool_name": "bash", "reason": "not in allowlist"},
+                    outcome="denied",
+                    sequence=i,
+                )
+            )
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        insights = analyzer.analyze_permission_patterns(sessions)
+
+        assert len(insights) == 1
+        assert insights[0].tool_name == "bash"
+        assert insights[0].denial_count == 6
+        assert insights[0].suggestion == "review_needed"
+
+    def test_frequent_grants_suggest_pre_approve(self, tmp_path: Path) -> None:
+        records = []
+        for i in range(6):
+            records.append(
+                _make_record(
+                    action_type=AuditEventType.PERMISSION_GRANT,
+                    detail={"tool_name": "file_read"},
+                    sequence=i,
+                )
+            )
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        insights = analyzer.analyze_permission_patterns(sessions)
+
+        assert len(insights) == 1
+        assert insights[0].suggestion == "pre_approve"
+
+    def test_low_signal_excluded(self, tmp_path: Path) -> None:
+        records = [
+            _make_record(
+                action_type=AuditEventType.PERMISSION_CHECK,
+                detail={"tool_name": "bash"},
+                outcome="denied",
+                sequence=0,
+            ),
+        ]
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        insights = analyzer.analyze_permission_patterns(sessions)
+        assert insights == []
+
+
+# ---------------------------------------------------------------------------
+# Test: analyze_multi_tool_sequences
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeMultiToolSequences:
+    def test_detects_repeated_pair(self, tmp_path: Path) -> None:
+        # Create 3 sessions each with file_read -> file_edit sequence
+        for s in range(3):
+            records = [
+                *_make_tool_call_response_pair(
+                    session_id=f"sess-{s}", tool_name="file_read", seq_start=0
+                ),
+                *_make_tool_call_response_pair(
+                    session_id=f"sess-{s}", tool_name="file_edit", seq_start=2
+                ),
+            ]
+            _write_session(tmp_path, f"sess-{s}", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        sequences = analyzer.analyze_multi_tool_sequences(sessions, min_frequency=3)
+
+        tool_pairs = [s.tools for s in sequences]
+        assert ("file_read", "file_edit") in tool_pairs
+
+    def test_min_frequency_filter(self, tmp_path: Path) -> None:
+        # Only 2 sessions — below threshold of 3
+        for s in range(2):
+            records = [
+                *_make_tool_call_response_pair(
+                    session_id=f"sess-{s}", tool_name="file_read", seq_start=0
+                ),
+                *_make_tool_call_response_pair(
+                    session_id=f"sess-{s}", tool_name="file_edit", seq_start=2
+                ),
+            ]
+            _write_session(tmp_path, f"sess-{s}", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        sequences = analyzer.analyze_multi_tool_sequences(sessions, min_frequency=3)
+        assert sequences == []
+
+    def test_skill_name_generated(self, tmp_path: Path) -> None:
+        for s in range(3):
+            records = [
+                *_make_tool_call_response_pair(
+                    session_id=f"sess-{s}", tool_name="file_read", seq_start=0
+                ),
+                *_make_tool_call_response_pair(
+                    session_id=f"sess-{s}", tool_name="bash", seq_start=2
+                ),
+            ]
+            _write_session(tmp_path, f"sess-{s}", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        sequences = analyzer.analyze_multi_tool_sequences(sessions, min_frequency=3)
+
+        pair = next(s for s in sequences if s.tools == ("file_read", "bash"))
+        assert "file_read" in pair.candidate_skill_name
+        assert "bash" in pair.candidate_skill_name
+
+
+# ---------------------------------------------------------------------------
+# Test: generate_report
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReport:
+    def test_full_report(self, tmp_path: Path) -> None:
+        records = [
+            *_make_tool_call_response_pair(tool_name="file_read", seq_start=0),
+            *_make_tool_call_response_pair(tool_name="bash", outcome="error", seq_start=2),
+        ]
+        _write_session(tmp_path, "sess-1", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        report = analyzer.generate_report(sessions)
+
+        assert isinstance(report, EvolutionReport)
+        assert report.sessions_analyzed == 1
+        assert report.error_rate == 0.5  # 1 error out of 2 calls
+        assert len(report.most_used_tools) == 2
+
+    def test_empty_sessions(self) -> None:
+        analyzer = TraceAnalyzer()
+        report = analyzer.generate_report([])
+
+        assert report.sessions_analyzed == 0
+        assert report.error_rate == 0.0
+        assert report.tool_failures == ()
+
+
+# ---------------------------------------------------------------------------
+# Test: data structures
+# ---------------------------------------------------------------------------
+
+
+class TestDataStructures:
+    def test_tool_call_frozen(self) -> None:
+        tc = ToolCall(
+            tool_name="bash",
+            arguments={"cmd": "ls"},
+            output_length=10,
+            is_error=False,
+            latency_ms=5.0,
+            outcome="success",
+        )
+        with pytest.raises(AttributeError):
+            tc.tool_name = "modified"  # type: ignore[misc]
+
+    def test_session_trace_frozen(self) -> None:
+        trace = SessionTrace(
+            session_id="s1",
+            tool_calls=(),
+            errors=(),
+            permission_denials=(),
+            permission_grants=(),
+            total_latency_ms=0.0,
+            model="",
+        )
+        with pytest.raises(AttributeError):
+            trace.session_id = "modified"  # type: ignore[misc]
+
+    def test_evolution_report_frozen(self) -> None:
+        report = EvolutionReport(
+            sessions_analyzed=0,
+            tool_failures=(),
+            latency_stats=(),
+            permission_insights=(),
+            tool_sequences=(),
+            most_used_tools=(),
+            error_rate=0.0,
+        )
+        with pytest.raises(AttributeError):
+            report.sessions_analyzed = 5  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Test: edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_session_with_only_llm_records(self, tmp_path: Path) -> None:
+        records = [
+            _make_record(
+                action_type=AuditEventType.LLM_REQUEST,
+                detail={"model": "claude-sonnet-4-20250514"},
+            ),
+            _make_record(
+                action_type=AuditEventType.LLM_RESPONSE,
+                detail={"tokens": 500},
+            ),
+        ]
+        _write_session(tmp_path, "sess-llm", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        assert len(sessions) == 1
+        assert sessions[0].model == "claude-sonnet-4-20250514"
+        assert sessions[0].tool_calls == ()
+
+    def test_model_extracted_from_llm_request(self, tmp_path: Path) -> None:
+        records = [
+            _make_record(
+                action_type=AuditEventType.LLM_REQUEST,
+                detail={"model": "ollama/gemma3:12b"},
+            ),
+            *_make_tool_call_response_pair(seq_start=1),
+        ]
+        _write_session(tmp_path, "sess-model", records)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        assert sessions[0].model == "ollama/gemma3:12b"
+
+    def test_mixed_compressed_and_plain(self, tmp_path: Path) -> None:
+        records1 = _make_tool_call_response_pair(session_id="s-plain")
+        records2 = _make_tool_call_response_pair(session_id="s-gz")
+        _write_session(tmp_path, "s-plain", records1, compressed=False)
+        _write_session(tmp_path, "s-gz", records2, compressed=True)
+
+        analyzer = TraceAnalyzer()
+        sessions = analyzer.load_sessions(tmp_path)
+        assert len(sessions) == 2
+        ids = {s.session_id for s in sessions}
+        assert ids == {"s-plain", "s-gz"}

--- a/tests/test_github_tool.py
+++ b/tests/test_github_tool.py
@@ -1,0 +1,464 @@
+"""Tests for the GitHub PR/issue workflow tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from godspeed.tools.base import RiskLevel, ToolContext
+from godspeed.tools.github import GithubTool
+
+
+@pytest.fixture
+def tool() -> GithubTool:
+    return GithubTool()
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(cwd=tmp_path, session_id="test-session")
+
+
+def _make_process(
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> AsyncMock:
+    """Build a mock asyncio subprocess that returns the given outputs."""
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(return_value=(stdout.encode(), stderr.encode()))
+    proc.returncode = returncode
+    proc.kill = MagicMock()
+    return proc
+
+
+# ------------------------------------------------------------------
+# Tool metadata
+# ------------------------------------------------------------------
+
+
+def test_name_and_risk(tool: GithubTool) -> None:
+    assert tool.name == "github"
+    assert tool.risk_level == RiskLevel.HIGH
+
+
+def test_schema_has_required_action(tool: GithubTool) -> None:
+    schema = tool.get_schema()
+    assert schema["required"] == ["action"]
+    assert "action" in schema["properties"]
+    actions = schema["properties"]["action"]["enum"]
+    assert "create_pr" in actions
+    assert "list_issues" in actions
+
+
+# ------------------------------------------------------------------
+# gh not installed
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value=None)
+async def test_gh_not_installed(
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    result = await tool.execute({"action": "list_prs"}, ctx)
+    assert result.is_error
+    assert "gh CLI is not installed" in (result.error or "")
+
+
+# ------------------------------------------------------------------
+# Invalid action
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+async def test_invalid_action(
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    result = await tool.execute({"action": "nope"}, ctx)
+    assert result.is_error
+    assert "Invalid action" in (result.error or "")
+
+
+# ------------------------------------------------------------------
+# create_pr
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_create_pr_success(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    mock_exec.return_value = _make_process(stdout="https://github.com/owner/repo/pull/42")
+    result = await tool.execute(
+        {"action": "create_pr", "title": "feat: add widget", "body": "Adds widget support"},
+        ctx,
+    )
+    assert not result.is_error
+    assert "pull/42" in result.output
+
+    # Verify the gh args
+    call_args = mock_exec.call_args
+    positional = call_args[0]
+    assert positional[0] == "gh"
+    assert "pr" in positional
+    assert "create" in positional
+    assert "--title" in positional
+    assert "feat: add widget" in positional
+    assert "--base" in positional
+    assert "main" in positional
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+async def test_create_pr_missing_title(
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    result = await tool.execute({"action": "create_pr"}, ctx)
+    assert result.is_error
+    assert "title is required" in (result.error or "")
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_create_pr_custom_base(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    mock_exec.return_value = _make_process(stdout="https://github.com/o/r/pull/1")
+    result = await tool.execute(
+        {"action": "create_pr", "title": "fix: bug", "base": "develop"},
+        ctx,
+    )
+    assert not result.is_error
+    positional = mock_exec.call_args[0]
+    assert "develop" in positional
+
+
+# ------------------------------------------------------------------
+# list_prs
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_list_prs(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    payload = [
+        {"number": 1, "title": "PR one", "state": "OPEN", "author": {"login": "dev"}},
+        {"number": 2, "title": "PR two", "state": "OPEN", "author": {"login": "dev"}},
+    ]
+    mock_exec.return_value = _make_process(stdout=json.dumps(payload))
+    result = await tool.execute({"action": "list_prs"}, ctx)
+    assert not result.is_error
+    data = json.loads(result.output)
+    assert len(data) == 2
+    assert data[0]["number"] == 1
+
+
+# ------------------------------------------------------------------
+# get_pr
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_get_pr(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    payload = {
+        "number": 5,
+        "title": "feat: stuff",
+        "state": "OPEN",
+        "body": "desc",
+        "additions": 10,
+        "deletions": 3,
+        "files": [{"path": "a.py"}],
+    }
+    mock_exec.return_value = _make_process(stdout=json.dumps(payload))
+    result = await tool.execute({"action": "get_pr", "number": 5}, ctx)
+    assert not result.is_error
+    data = json.loads(result.output)
+    assert data["number"] == 5
+    assert data["additions"] == 10
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+async def test_get_pr_missing_number(
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    result = await tool.execute({"action": "get_pr"}, ctx)
+    assert result.is_error
+    assert "number is required" in (result.error or "")
+
+
+# ------------------------------------------------------------------
+# list_issues
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_list_issues(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    payload = [
+        {"number": 10, "title": "Bug report", "state": "OPEN", "labels": []},
+    ]
+    mock_exec.return_value = _make_process(stdout=json.dumps(payload))
+    result = await tool.execute({"action": "list_issues", "state": "open"}, ctx)
+    assert not result.is_error
+    data = json.loads(result.output)
+    assert data[0]["number"] == 10
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_list_issues_with_labels(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    mock_exec.return_value = _make_process(stdout="[]")
+    result = await tool.execute(
+        {"action": "list_issues", "labels": "bug,priority"},
+        ctx,
+    )
+    assert not result.is_error
+    positional = mock_exec.call_args[0]
+    assert "--label" in positional
+    assert "bug,priority" in positional
+
+
+# ------------------------------------------------------------------
+# get_issue
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_get_issue(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    payload = {
+        "number": 7,
+        "title": "Feature request",
+        "state": "OPEN",
+        "body": "Please add X",
+        "labels": [{"name": "enhancement"}],
+        "comments": [],
+    }
+    mock_exec.return_value = _make_process(stdout=json.dumps(payload))
+    result = await tool.execute({"action": "get_issue", "number": 7}, ctx)
+    assert not result.is_error
+    data = json.loads(result.output)
+    assert data["number"] == 7
+    assert data["labels"][0]["name"] == "enhancement"
+
+
+# ------------------------------------------------------------------
+# create_issue
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_create_issue(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    mock_exec.return_value = _make_process(stdout="https://github.com/owner/repo/issues/15")
+    result = await tool.execute(
+        {"action": "create_issue", "title": "New bug", "body": "It breaks"},
+        ctx,
+    )
+    assert not result.is_error
+    assert "issues/15" in result.output
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+async def test_create_issue_missing_title(
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    result = await tool.execute({"action": "create_issue"}, ctx)
+    assert result.is_error
+    assert "title is required" in (result.error or "")
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_create_issue_with_labels(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    mock_exec.return_value = _make_process(stdout="https://github.com/o/r/issues/20")
+    result = await tool.execute(
+        {"action": "create_issue", "title": "Bug", "labels": "bug,urgent"},
+        ctx,
+    )
+    assert not result.is_error
+    positional = mock_exec.call_args[0]
+    assert "--label" in positional
+    assert "bug,urgent" in positional
+
+
+# ------------------------------------------------------------------
+# comment_issue
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_comment_issue(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    mock_exec.return_value = _make_process(stdout="")
+    result = await tool.execute(
+        {"action": "comment_issue", "number": 3, "body": "LGTM"},
+        ctx,
+    )
+    assert not result.is_error
+    assert "Commented on issue #3" in result.output
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+async def test_comment_issue_missing_body(
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    result = await tool.execute({"action": "comment_issue", "number": 3}, ctx)
+    assert result.is_error
+    assert "body is required" in (result.error or "")
+
+
+# ------------------------------------------------------------------
+# comment_pr
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_comment_pr(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    mock_exec.return_value = _make_process(stdout="")
+    result = await tool.execute(
+        {"action": "comment_pr", "number": 9, "body": "Looks good"},
+        ctx,
+    )
+    assert not result.is_error
+    assert "Commented on PR #9" in result.output
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+async def test_comment_pr_missing_number(
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    result = await tool.execute({"action": "comment_pr", "body": "hi"}, ctx)
+    assert result.is_error
+    assert "number is required" in (result.error or "")
+
+
+# ------------------------------------------------------------------
+# gh CLI failure (nonzero exit)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_gh_cli_failure(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    mock_exec.return_value = _make_process(returncode=1, stderr="not authenticated")
+    result = await tool.execute({"action": "list_prs"}, ctx)
+    assert result.is_error
+    assert "not authenticated" in (result.error or "")
+
+
+# ------------------------------------------------------------------
+# Timeout
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh")
+@patch("godspeed.tools.github.asyncio.create_subprocess_exec")
+async def test_timeout(
+    mock_exec: AsyncMock,
+    _mock_which: MagicMock,
+    tool: GithubTool,
+    ctx: ToolContext,
+) -> None:
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(side_effect=TimeoutError)
+    proc.kill = MagicMock()
+    mock_exec.return_value = proc
+    result = await tool.execute({"action": "list_prs"}, ctx)
+    assert result.is_error
+    assert "timed out" in (result.error or "")

--- a/tests/test_image_read.py
+++ b/tests/test_image_read.py
@@ -1,0 +1,202 @@
+"""Tests for the image_read tool."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+from godspeed.tools.image_read import ImageReadTool
+
+# Minimal valid PNG: 1x1 pixel, RGB
+MINIMAL_PNG = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde"
+    b"\x00\x00\x00\x0cIDATx"
+    b"\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+# Minimal JPEG (SOI + APP0 marker + EOI)
+MINIMAL_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 100 + b"\xff\xd9"
+
+
+def _make_context(tmp_path: Path) -> ToolContext:
+    return ToolContext(cwd=tmp_path, session_id="test")
+
+
+@pytest.fixture
+def tool() -> ImageReadTool:
+    return ImageReadTool()
+
+
+@pytest.mark.asyncio
+async def test_read_valid_png(tool: ImageReadTool, tmp_path: Path) -> None:
+    img = tmp_path / "test.png"
+    img.write_bytes(MINIMAL_PNG)
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "test.png"}, ctx)
+
+    assert not result.is_error
+    assert result.output.startswith("[Image: test.png] (image/png,")
+    assert "data:image/png;base64," in result.output
+    # Verify round-trip decoding
+    b64_part = result.output.split("data:image/png;base64,", 1)[1]
+    assert base64.b64decode(b64_part) == MINIMAL_PNG
+
+
+@pytest.mark.asyncio
+async def test_read_valid_jpg(tool: ImageReadTool, tmp_path: Path) -> None:
+    img = tmp_path / "photo.jpg"
+    img.write_bytes(MINIMAL_JPEG)
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "photo.jpg"}, ctx)
+
+    assert not result.is_error
+    assert "[Image: photo.jpg] (image/jpeg," in result.output
+    assert "data:image/jpeg;base64," in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_jpeg_uppercase_ext(tool: ImageReadTool, tmp_path: Path) -> None:
+    img = tmp_path / "photo.JPEG"
+    img.write_bytes(MINIMAL_JPEG)
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "photo.JPEG"}, ctx)
+
+    assert not result.is_error
+    assert "image/jpeg" in result.output
+
+
+@pytest.mark.asyncio
+async def test_reject_unsupported_format_txt(tool: ImageReadTool, tmp_path: Path) -> None:
+    txt = tmp_path / "notes.txt"
+    txt.write_text("not an image")
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "notes.txt"}, ctx)
+
+    assert result.is_error
+    assert "Unsupported image format" in result.error
+    assert ".txt" in result.error
+
+
+@pytest.mark.asyncio
+async def test_reject_unsupported_format_bmp(tool: ImageReadTool, tmp_path: Path) -> None:
+    bmp = tmp_path / "image.bmp"
+    bmp.write_bytes(b"\x42\x4d" + b"\x00" * 100)
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "image.bmp"}, ctx)
+
+    assert result.is_error
+    assert "Unsupported image format" in result.error
+    assert ".bmp" in result.error
+
+
+@pytest.mark.asyncio
+async def test_file_not_found(tool: ImageReadTool, tmp_path: Path) -> None:
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "nonexistent.png"}, ctx)
+
+    assert result.is_error
+    assert "File not found" in result.error
+
+
+@pytest.mark.asyncio
+async def test_reject_file_over_20mb(tool: ImageReadTool, tmp_path: Path) -> None:
+    img = tmp_path / "huge.png"
+    img.write_bytes(MINIMAL_PNG)
+    ctx = _make_context(tmp_path)
+
+    fake_size = 21 * 1024 * 1024
+    real_stat = img.stat()
+
+    class FakeStat:
+        st_mode = real_stat.st_mode
+        st_size = fake_size
+
+    with patch("pathlib.Path.stat", return_value=FakeStat()):
+        result = await tool.execute({"file_path": "huge.png"}, ctx)
+
+    assert result.is_error
+    assert "too large" in result.error
+    assert "20MB" in result.error
+
+
+@pytest.mark.asyncio
+async def test_warn_file_over_5mb(tool: ImageReadTool, tmp_path: Path) -> None:
+    img = tmp_path / "big.png"
+    # Create a file just over 5MB
+    data = MINIMAL_PNG + b"\x00" * (5 * 1024 * 1024 + 1)
+    img.write_bytes(data)
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "big.png"}, ctx)
+
+    assert not result.is_error
+    assert "WARNING" in result.output
+    assert "[Image: big.png]" in result.output
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_blocked(tool: ImageReadTool, tmp_path: Path) -> None:
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "../../etc/passwd"}, ctx)
+
+    assert result.is_error
+    assert "Access denied" in result.error
+
+
+@pytest.mark.asyncio
+async def test_directory_rejected(tool: ImageReadTool, tmp_path: Path) -> None:
+    subdir = tmp_path / "images"
+    subdir.mkdir()
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "images"}, ctx)
+
+    assert result.is_error
+    assert "Not a file" in result.error
+
+
+@pytest.mark.asyncio
+async def test_empty_file_path(tool: ImageReadTool, tmp_path: Path) -> None:
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": ""}, ctx)
+
+    assert result.is_error
+    assert "non-empty string" in result.error
+
+
+@pytest.mark.asyncio
+async def test_missing_file_path(tool: ImageReadTool, tmp_path: Path) -> None:
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({}, ctx)
+
+    assert result.is_error
+    assert "non-empty string" in result.error
+
+
+@pytest.mark.asyncio
+async def test_output_contains_size_kb(tool: ImageReadTool, tmp_path: Path) -> None:
+    img = tmp_path / "sized.png"
+    img.write_bytes(MINIMAL_PNG)
+    ctx = _make_context(tmp_path)
+
+    result = await tool.execute({"file_path": "sized.png"}, ctx)
+
+    assert not result.is_error
+    # Output should contain size in KB format like "0.1KB"
+    assert "KB)" in result.output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,14 +2,18 @@
 
 Tests the complete pipeline: LLM (mocked) → tool call → permission check →
 tool execution → audit recording → result fed back to conversation.
+
+v2.0 additions: parallel tool dispatch, multimodal @-mentions,
+auto-commit after threshold, and lint-fix-retry loops.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -18,11 +22,13 @@ from godspeed.agent.loop import agent_loop
 from godspeed.audit.trail import AuditTrail
 from godspeed.llm.client import ChatResponse, LLMClient
 from godspeed.security.permissions import PermissionEngine
-from godspeed.tools.base import RiskLevel, ToolContext
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
 from godspeed.tools.file_read import FileReadTool
 from godspeed.tools.file_write import FileWriteTool
 from godspeed.tools.registry import ToolRegistry
 from godspeed.tools.shell import ShellTool
+from godspeed.tui.mentions import parse_mentions, resolve_mentions
+from tests.conftest import MockTool
 
 
 def _text(content: str) -> ChatResponse:
@@ -297,3 +303,380 @@ class TestIntegrationConversationFlow:
 
         result = await agent_loop("Loop forever", conv, client, registry, ctx)
         assert "maximum iterations" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# v2.0 Integration Tests
+# ---------------------------------------------------------------------------
+
+
+class _TrackedTool(Tool):
+    """Tool that records invocations with timestamps for concurrency assertions."""
+
+    def __init__(
+        self,
+        name: str,
+        delay: float = 0.05,
+        result: ToolResult | None = None,
+    ) -> None:
+        self._name = name
+        self._delay = delay
+        self._result = result or ToolResult.success(f"{name}_output")
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"Tracked test tool: {self._name}"
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"input": {"type": "string"}},
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        await asyncio.sleep(self._delay)
+        end = loop.time()
+        self.calls.append({"args": arguments, "start": start, "end": end})
+        return self._result
+
+
+class TestParallelToolsEndToEnd:
+    """LLM returns 3 tool calls, all execute concurrently, conversation has correct results."""
+
+    @pytest.mark.asyncio
+    async def test_parallel_tools_end_to_end(self, tool_context: ToolContext) -> None:
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+
+        tool_a = _TrackedTool("tool_a", delay=0.15)
+        tool_b = _TrackedTool("tool_b", delay=0.15)
+        tool_c = _TrackedTool("tool_c", delay=0.15)
+        registry.register(tool_a)
+        registry.register(tool_b)
+        registry.register(tool_c)
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _multi_tool_call(
+                    [
+                        ("tool_a", {"input": "alpha"}),
+                        ("tool_b", {"input": "beta"}),
+                        ("tool_c", {"input": "gamma"}),
+                    ]
+                ),
+                _text("All three complete."),
+            ]
+        )
+
+        result = await agent_loop(
+            "Run all three tools",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            parallel_tool_calls=True,
+        )
+
+        # Final text returned correctly
+        assert result == "All three complete."
+
+        # Each tool invoked exactly once with correct args
+        assert len(tool_a.calls) == 1
+        assert tool_a.calls[0]["args"] == {"input": "alpha"}
+        assert len(tool_b.calls) == 1
+        assert tool_b.calls[0]["args"] == {"input": "beta"}
+        assert len(tool_c.calls) == 1
+        assert tool_c.calls[0]["args"] == {"input": "gamma"}
+
+        # Concurrency: all three started before any finished
+        all_starts = [t.calls[0]["start"] for t in (tool_a, tool_b, tool_c)]
+        all_ends = [t.calls[0]["end"] for t in (tool_a, tool_b, tool_c)]
+        latest_start = max(all_starts)
+        earliest_end = min(all_ends)
+        assert latest_start < earliest_end, "Tools did not overlap — not truly parallel"
+
+        # Conversation contains results in call order (a, b, c)
+        tool_msgs = [
+            msg["content"]
+            for msg in conversation.messages
+            if msg.get("role") == "tool" and msg.get("content", "").endswith("_output")
+        ]
+        assert tool_msgs == ["tool_a_output", "tool_b_output", "tool_c_output"]
+
+
+class TestMultimodalWithFileMention:
+    """@file:test.py flows through parse_mentions -> resolve_mentions -> content blocks."""
+
+    @pytest.mark.asyncio
+    async def test_multimodal_with_file_mention(self, tool_context: ToolContext) -> None:
+        # Create a real file in the temp project directory
+        test_file = tool_context.cwd / "test.py"
+        test_file.write_text("print('hello world')\n", encoding="utf-8")
+
+        # Step 1: parse_mentions extracts the mention and cleans text
+        raw_input = "Review this @file:test.py and explain it"
+        cleaned, mentions = parse_mentions(raw_input)
+
+        assert cleaned == "Review this and explain it"
+        assert len(mentions) == 1
+        assert mentions[0].type == "file"
+        assert mentions[0].target == "test.py"
+
+        # Step 2: resolve_mentions reads the file into content blocks
+        blocks = await resolve_mentions(mentions, tool_context.cwd)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert "print('hello world')" in blocks[0]["text"]
+        assert "[Content of test.py]" in blocks[0]["text"]
+
+        # Step 3: Build multimodal message and add to conversation
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        content_blocks: list[dict[str, Any]] = [
+            {"type": "text", "text": cleaned},
+            *blocks,
+        ]
+        conversation.add_user_message(content_blocks)
+
+        # Verify the conversation has the multimodal content
+        user_msgs = [m for m in conversation.messages if m["role"] == "user"]
+        assert len(user_msgs) == 1
+        assert isinstance(user_msgs[0]["content"], list)
+        assert len(user_msgs[0]["content"]) == 2
+        assert user_msgs[0]["content"][0]["text"] == "Review this and explain it"
+        assert "print('hello world')" in user_msgs[0]["content"][1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_file_mention_missing_file_produces_error_block(
+        self, tool_context: ToolContext
+    ) -> None:
+        """Referencing a nonexistent file produces an error content block."""
+        _cleaned, mentions = parse_mentions("Look at @file:nonexistent.py")
+        blocks = await resolve_mentions(mentions, tool_context.cwd)
+
+        assert len(blocks) == 1
+        assert "Error resolving" in blocks[0]["text"]
+
+
+class TestAutoCommitAfterThreshold:
+    """N successful edits triggers auto-commit (mock git and LLM)."""
+
+    @pytest.mark.asyncio
+    async def test_auto_commit_after_threshold(self, tool_context: ToolContext) -> None:
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+
+        # Register a file_edit tool that always succeeds
+        edit_tool = MockTool(
+            name="file_edit",
+            result=ToolResult.success("Edit applied"),
+        )
+        registry.register(edit_tool)
+
+        # 3 sequential single-edit calls + final text.
+        # auto_commit_threshold=3 so commit triggers after 3rd edit.
+        threshold = 3
+        side_effects: list[ChatResponse] = []
+        for i in range(threshold):
+            side_effects.append(
+                _multi_tool_call(
+                    [
+                        ("file_edit", {"file_path": f"src/mod_{i}.py", "content": f"v{i}"}),
+                    ]
+                )
+            )
+        side_effects.append(_text("All edits done."))
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(side_effect=side_effects)
+
+        # Mock the auto_commit module so no real git operations happen
+        mock_commit_msg = "feat(src): update modules"
+        with (
+            patch(
+                "godspeed.agent.auto_commit.generate_commit_message",
+                new_callable=AsyncMock,
+                return_value=mock_commit_msg,
+            ) as mock_gen_msg,
+            patch(
+                "godspeed.agent.auto_commit.auto_commit",
+                new_callable=AsyncMock,
+                return_value=ToolResult.success(f"Auto-committed: abc12345 {mock_commit_msg}"),
+            ) as mock_commit,
+        ):
+            result = await agent_loop(
+                "Edit three files",
+                conversation,
+                client,
+                registry,
+                tool_context,
+                parallel_tool_calls=False,
+                auto_commit=True,
+                auto_commit_threshold=threshold,
+            )
+
+        assert result == "All edits done."
+
+        # auto_commit was called exactly once (after reaching threshold)
+        mock_gen_msg.assert_awaited_once()
+        mock_commit.assert_awaited_once()
+
+        # The commit message was generated from the change descriptions
+        descriptions_arg = mock_gen_msg.call_args[0][0]
+        assert len(descriptions_arg) == threshold
+        assert all("file_edit" in d for d in descriptions_arg)
+
+        # Conversation contains the auto-commit result
+        tool_msgs = [m["content"] for m in conversation.messages if m.get("role") == "tool"]
+        assert any("Auto-commit" in msg for msg in tool_msgs)
+
+    @pytest.mark.asyncio
+    async def test_no_auto_commit_below_threshold(self, tool_context: ToolContext) -> None:
+        """Fewer edits than threshold should not trigger auto-commit."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="file_edit", result=ToolResult.success("ok")))
+
+        # Only 2 edits, threshold is 5
+        side_effects = [
+            _multi_tool_call([("file_edit", {"file_path": "a.py", "content": "x"})]),
+            _multi_tool_call([("file_edit", {"file_path": "b.py", "content": "y"})]),
+            _text("Done."),
+        ]
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(side_effect=side_effects)
+
+        with patch(
+            "godspeed.agent.auto_commit.auto_commit",
+            new_callable=AsyncMock,
+        ) as mock_commit:
+            await agent_loop(
+                "Edit two files",
+                conversation,
+                client,
+                registry,
+                tool_context,
+                parallel_tool_calls=False,
+                auto_commit=True,
+                auto_commit_threshold=5,
+            )
+
+        mock_commit.assert_not_awaited()
+
+
+class TestLintFixRetryInLoop:
+    """Edit -> auto-verify with retry -> re-verify passes."""
+
+    @pytest.mark.asyncio
+    async def test_lint_fix_retry_in_loop(self, tool_context: ToolContext) -> None:
+        """file_edit on a .py file triggers _auto_verify_file with retry loop.
+
+        Mock the verify internals: first check fails, fix runs, re-check passes.
+        """
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+
+        # Register file_edit and verify tools
+        edit_tool = MockTool(name="file_edit", result=ToolResult.success("File written"))
+        verify_tool = MockTool(name="verify", result=ToolResult.success("Verification passed"))
+        registry.register(edit_tool)
+        registry.register(verify_tool)
+
+        # Create the target file so path resolution works
+        target = tool_context.cwd / "app.py"
+        target.write_text("x=1\n", encoding="utf-8")
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _multi_tool_call(
+                    [
+                        ("file_edit", {"file_path": "app.py", "content": "x = 1\n"}),
+                    ]
+                ),
+                _text("Edit verified and clean."),
+            ]
+        )
+
+        with patch(
+            "godspeed.agent.loop._auto_verify_file",
+            new_callable=AsyncMock,
+        ) as mock_auto_verify:
+            # Simulate: the retry loop ran one fix round and then passed
+            mock_auto_verify.return_value = ToolResult.success(
+                "Auto-fixed 1 round(s) of issues, 0 remaining: app.py"
+            )
+
+            result = await agent_loop(
+                "Fix app.py",
+                conversation,
+                client,
+                registry,
+                tool_context,
+                parallel_tool_calls=False,
+                auto_fix_retries=3,
+            )
+
+        assert result == "Edit verified and clean."
+
+        # _auto_verify_file was called for the .py file edit
+        mock_auto_verify.assert_awaited_once()
+        call_args = mock_auto_verify.call_args
+        assert call_args[0][0] == "app.py"  # file_path
+        assert call_args[0][4] == 3  # auto_fix_retries
+
+        # Conversation contains the verify result showing auto-fix worked
+        tool_msgs = [m["content"] for m in conversation.messages if m.get("role") == "tool"]
+        assert any("Auto-fixed" in msg for msg in tool_msgs)
+        assert any("0 remaining" in msg for msg in tool_msgs)
+
+    @pytest.mark.asyncio
+    async def test_verify_skipped_for_non_verifiable_extension(
+        self, tool_context: ToolContext
+    ) -> None:
+        """file_edit on a non-verifiable extension (.txt) should skip auto-verify."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="file_edit", result=ToolResult.success("ok")))
+        registry.register(MockTool(name="verify", result=ToolResult.success("pass")))
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _multi_tool_call(
+                    [
+                        ("file_edit", {"file_path": "notes.txt", "content": "hello"}),
+                    ]
+                ),
+                _text("Done."),
+            ]
+        )
+
+        with patch(
+            "godspeed.agent.loop._auto_verify_file",
+            new_callable=AsyncMock,
+        ) as mock_auto_verify:
+            await agent_loop(
+                "Edit notes",
+                conversation,
+                client,
+                registry,
+                tool_context,
+                parallel_tool_calls=False,
+            )
+
+        # .txt is not in VERIFIABLE_EXTENSIONS, so verify should not be called
+        mock_auto_verify.assert_not_awaited()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,341 @@
+"""Tests for LLM client — ChatResponse, ModelRouter, LLMClient, BudgetExceededError."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from godspeed.llm.client import (
+    BudgetExceededError,
+    ChatResponse,
+    LLMClient,
+    ModelRouter,
+)
+
+# ---------------------------------------------------------------------------
+# Test: ChatResponse
+# ---------------------------------------------------------------------------
+
+
+class TestChatResponse:
+    def test_has_tool_calls_true(self) -> None:
+        r = ChatResponse(tool_calls=[{"id": "1", "function": {"name": "x"}}])
+        assert r.has_tool_calls is True
+
+    def test_has_tool_calls_false(self) -> None:
+        r = ChatResponse(content="hello")
+        assert r.has_tool_calls is False
+
+    def test_defaults(self) -> None:
+        r = ChatResponse()
+        assert r.content == ""
+        assert r.tool_calls == []
+        assert r.thinking == ""
+
+
+# ---------------------------------------------------------------------------
+# Test: BudgetExceededError
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetExceededError:
+    def test_attributes(self) -> None:
+        err = BudgetExceededError(spent=1.50, limit=1.00)
+        assert err.spent == 1.50
+        assert err.limit == 1.00
+        assert "$1.5" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Test: ModelRouter
+# ---------------------------------------------------------------------------
+
+
+class TestModelRouter:
+    def test_no_routing(self) -> None:
+        router = ModelRouter()
+        assert router.route("ollama/qwen3:4b") == "ollama/qwen3:4b"
+        assert router.has_routing is False
+
+    def test_with_routing(self) -> None:
+        router = ModelRouter({"plan": "claude-sonnet", "edit": "gpt-4o"})
+        assert router.route("default", "plan") == "claude-sonnet"
+        assert router.route("default", "edit") == "gpt-4o"
+        assert router.route("default", "chat") == "default"
+        assert router.has_routing is True
+        assert router.routes == {"plan": "claude-sonnet", "edit": "gpt-4o"}
+
+    def test_unknown_task_type_uses_default(self) -> None:
+        router = ModelRouter({"plan": "claude"})
+        assert router.route("fallback", "unknown") == "fallback"
+
+    def test_none_task_type(self) -> None:
+        router = ModelRouter({"plan": "claude"})
+        assert router.route("default", None) == "default"
+
+
+# ---------------------------------------------------------------------------
+# Test: LLMClient helpers (no LLM calls)
+# ---------------------------------------------------------------------------
+
+
+class TestLLMClientHelpers:
+    def test_supports_tool_calling_ollama_qwen(self) -> None:
+        client = LLMClient(model="ollama/qwen3:4b")
+        assert client._supports_tool_calling() is True
+
+    def test_supports_tool_calling_ollama_unknown(self) -> None:
+        client = LLMClient(model="ollama/phi4:latest")
+        assert client._supports_tool_calling() is False
+
+    def test_supports_tool_calling_api_model(self) -> None:
+        client = LLMClient(model="claude-sonnet-4-20250514")
+        assert client._supports_tool_calling() is True
+
+    def test_effective_model_upgrades_ollama(self) -> None:
+        client = LLMClient(model="ollama/qwen3:4b")
+        assert client._effective_model() == "ollama_chat/qwen3:4b"
+
+    def test_effective_model_no_upgrade_unsupported(self) -> None:
+        client = LLMClient(model="ollama/phi4:latest")
+        assert client._effective_model() == "ollama/phi4:latest"
+
+    def test_effective_model_api_unchanged(self) -> None:
+        client = LLMClient(model="claude-sonnet-4-20250514")
+        assert client._effective_model() == "claude-sonnet-4-20250514"
+
+    def test_is_connection_error(self) -> None:
+        assert LLMClient._is_connection_error(ConnectionError("Connection refused"))
+        assert not LLMClient._is_connection_error(ValueError("bad input"))
+
+    def test_is_anthropic_model(self) -> None:
+        client = LLMClient(model="claude-sonnet-4-20250514")
+        assert client._is_anthropic_model() is True
+        assert client._is_anthropic_model("anthropic/claude-haiku") is True
+        client2 = LLMClient(model="gpt-4o")
+        assert client2._is_anthropic_model() is False
+
+    def test_check_budget_no_limit(self) -> None:
+        client = LLMClient(model="test", max_cost_usd=0.0)
+        client.total_cost_usd = 100.0
+        client._check_budget()  # Should not raise
+
+    def test_check_budget_exceeded(self) -> None:
+        client = LLMClient(model="test", max_cost_usd=1.0)
+        client.total_cost_usd = 1.50
+        with pytest.raises(BudgetExceededError):
+            client._check_budget()
+
+    def test_check_budget_within_limit(self) -> None:
+        client = LLMClient(model="test", max_cost_usd=2.0)
+        client.total_cost_usd = 1.50
+        client._check_budget()  # Should not raise
+
+    def test_build_failure_error_ollama(self) -> None:
+        client = LLMClient(model="ollama/qwen3:4b")
+        err = client._build_failure_error(ConnectionError("Connection refused"))
+        assert "ollama serve" in str(err).lower()
+
+    def test_build_failure_error_generic(self) -> None:
+        client = LLMClient(model="gpt-4o")
+        err = client._build_failure_error(RuntimeError("timeout"))
+        assert "All models failed" in str(err)
+
+    def test_apply_prompt_caching_claude(self) -> None:
+        messages = [{"role": "system", "content": "You are helpful."}]
+        result = LLMClient._apply_prompt_caching("claude-sonnet", messages)
+        assert result[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_apply_prompt_caching_ollama_noop(self) -> None:
+        messages = [{"role": "system", "content": "You are helpful."}]
+        result = LLMClient._apply_prompt_caching("ollama/qwen3", messages)
+        assert result == messages
+
+
+# ---------------------------------------------------------------------------
+# Test: LLMClient.chat (mocked LiteLLM)
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(
+    content: str = "Hello",
+    tool_calls: list | None = None,
+    finish_reason: str = "stop",
+    input_tokens: int = 10,
+    output_tokens: int = 20,
+) -> MagicMock:
+    """Build a mock litellm response."""
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls or [],
+        thinking=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    usage = SimpleNamespace(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+    )
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+class TestLLMClientChat:
+    @pytest.mark.asyncio
+    async def test_basic_chat(self) -> None:
+        client = LLMClient(model="ollama/qwen3:4b")
+        mock_resp = _mock_response(content="Hi there")
+
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_resp)
+            response = await client.chat([{"role": "user", "content": "hello"}])
+
+        assert response.content == "Hi there"
+        assert response.finish_reason == "stop"
+        assert client.total_input_tokens == 10
+        assert client.total_output_tokens == 20
+
+    @pytest.mark.asyncio
+    async def test_chat_with_tool_calls(self) -> None:
+        tc = SimpleNamespace(
+            id="tc_1",
+            function=SimpleNamespace(name="file_read", arguments='{"path": "foo.py"}'),
+        )
+        mock_resp = _mock_response(content="", tool_calls=[tc])
+
+        client = LLMClient(model="ollama/qwen3:4b")
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_resp)
+            response = await client.chat([{"role": "user", "content": "read foo"}])
+
+        assert response.has_tool_calls
+        assert response.tool_calls[0]["function"]["name"] == "file_read"
+
+    @pytest.mark.asyncio
+    async def test_chat_with_thinking(self) -> None:
+        msg = SimpleNamespace(
+            content="Result",
+            tool_calls=[],
+            thinking="I need to think about this...",
+        )
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        usage = SimpleNamespace(prompt_tokens=10, completion_tokens=20)
+        mock_resp = SimpleNamespace(choices=[choice], usage=usage)
+
+        client = LLMClient(model="claude-sonnet-4-20250514", thinking_budget=1000)
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_resp)
+            response = await client.chat([{"role": "user", "content": "think"}])
+
+        assert response.thinking == "I need to think about this..."
+        # Verify thinking param was passed
+        call_kwargs = mock_litellm.return_value.acompletion.call_args[1]
+        assert call_kwargs["thinking"]["budget_tokens"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_chat_content_blocks(self) -> None:
+        """Handle responses where content is a list of blocks."""
+        msg = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "Part 1. "},
+                {"type": "text", "text": "Part 2."},
+            ],
+            tool_calls=[],
+            thinking=None,
+        )
+        choice = SimpleNamespace(message=msg, finish_reason="stop")
+        usage = SimpleNamespace(prompt_tokens=5, completion_tokens=10)
+        mock_resp = SimpleNamespace(choices=[choice], usage=usage)
+
+        client = LLMClient(model="claude-sonnet-4-20250514")
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_resp)
+            response = await client.chat([{"role": "user", "content": "test"}])
+
+        assert response.content == "Part 1. Part 2."
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_failure(self) -> None:
+        client = LLMClient(
+            model="ollama/qwen3:4b",
+            fallback_models=["ollama/gemma3:4b"],
+        )
+
+        call_count = 0
+
+        async def _failing_then_success(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:  # Primary + retry both fail
+                raise RuntimeError("model down")
+            return _mock_response(content="from fallback")
+
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(side_effect=_failing_then_success)
+            response = await client.chat([{"role": "user", "content": "test"}])
+
+        assert response.content == "from fallback"
+        assert call_count == 3  # primary + retry + fallback
+
+    @pytest.mark.asyncio
+    async def test_all_models_fail_raises(self) -> None:
+        client = LLMClient(model="ollama/qwen3:4b")
+
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(side_effect=RuntimeError("down"))
+            with pytest.raises(RuntimeError, match="All models failed"):
+                await client.chat([{"role": "user", "content": "test"}])
+
+    @pytest.mark.asyncio
+    async def test_budget_exceeded_during_chat(self) -> None:
+        client = LLMClient(model="claude-sonnet-4-20250514", max_cost_usd=0.001)
+        mock_resp = _mock_response(input_tokens=100_000, output_tokens=50_000)
+
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_resp)
+            # BudgetExceededError is caught by fallback loop, surfaced as RuntimeError
+            with pytest.raises(RuntimeError, match="Budget exceeded"):
+                await client.chat([{"role": "user", "content": "expensive"}])
+
+    @pytest.mark.asyncio
+    async def test_model_routing(self) -> None:
+        router = ModelRouter({"plan": "claude-sonnet-4-20250514"})
+        client = LLMClient(model="ollama/qwen3:4b", router=router)
+        mock_resp = _mock_response()
+
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_resp)
+            await client.chat(
+                [{"role": "user", "content": "plan this"}],
+                task_type="plan",
+            )
+
+        call_kwargs = mock_litellm.return_value.acompletion.call_args[1]
+        assert call_kwargs["model"] == "claude-sonnet-4-20250514"
+        # Model should be restored after call
+        assert client.model == "ollama/qwen3:4b"
+
+    @pytest.mark.asyncio
+    async def test_connection_refused_skips_retry(self) -> None:
+        """Connection-refused errors skip the retry and go straight to fallback."""
+        client = LLMClient(
+            model="ollama/qwen3:4b",
+            fallback_models=["ollama/gemma3:4b"],
+        )
+
+        call_count = 0
+
+        async def _conn_refused_then_ok(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if kwargs["model"].startswith("ollama_chat/qwen"):
+                raise ConnectionError("Connection refused")
+            return _mock_response(content="ok")
+
+        with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+            mock_litellm.return_value.acompletion = AsyncMock(side_effect=_conn_refused_then_ok)
+            response = await client.chat([{"role": "user", "content": "test"}])
+
+        assert response.content == "ok"
+        # Should be: primary (fail, conn refused) + fallback (ok) = 2 calls
+        assert call_count == 2

--- a/tests/test_llm_cost.py
+++ b/tests/test_llm_cost.py
@@ -1,0 +1,71 @@
+"""Tests for LLM cost estimation and model selection."""
+
+from __future__ import annotations
+
+from godspeed.llm.cost import estimate_cost, format_cost, get_cheapest_model
+
+
+class TestEstimateCost:
+    def test_ollama_free(self) -> None:
+        assert estimate_cost("ollama/qwen3:4b", 100_000, 50_000) == 0.0
+
+    def test_ollama_chat_free(self) -> None:
+        assert estimate_cost("ollama_chat/qwen3:4b", 100_000, 50_000) == 0.0
+
+    def test_claude_sonnet(self) -> None:
+        cost = estimate_cost("claude-sonnet-4-20250514", 1_000_000, 1_000_000)
+        # $3/M input + $15/M output = $18
+        assert cost == 18.0
+
+    def test_gpt_4o(self) -> None:
+        cost = estimate_cost("gpt-4o-2024-08-06", 1_000_000, 1_000_000)
+        # $2.50/M input + $10/M output = $12.50
+        assert cost == 12.5
+
+    def test_unknown_model_free(self) -> None:
+        assert estimate_cost("some-unknown-model", 100_000, 50_000) == 0.0
+
+    def test_with_provider_prefix(self) -> None:
+        cost = estimate_cost("anthropic/claude-sonnet-4-20250514", 1_000_000, 0)
+        assert cost == 3.0  # $3/M input
+
+    def test_zero_tokens(self) -> None:
+        assert estimate_cost("claude-sonnet", 0, 0) == 0.0
+
+    def test_small_token_count(self) -> None:
+        cost = estimate_cost("claude-sonnet", 1000, 500)
+        assert cost > 0
+        assert cost < 0.02  # ~$0.0105 for 1K input + 500 output
+
+
+class TestGetCheapestModel:
+    def test_empty_list(self) -> None:
+        assert get_cheapest_model([]) == ""
+
+    def test_ollama_is_cheapest(self) -> None:
+        models = ["claude-sonnet-4-20250514", "ollama/qwen3:4b", "gpt-4o"]
+        assert get_cheapest_model(models) == "ollama/qwen3:4b"
+
+    def test_all_api_models(self) -> None:
+        models = ["claude-opus-4-20250514", "claude-haiku-3.5", "gpt-4o"]
+        result = get_cheapest_model(models)
+        assert result == "claude-haiku-3.5"  # Cheapest API model
+
+    def test_single_model(self) -> None:
+        assert get_cheapest_model(["gpt-4o"]) == "gpt-4o"
+
+    def test_all_ollama(self) -> None:
+        models = ["ollama/qwen3:4b", "ollama/gemma3:12b"]
+        # First free model wins
+        assert get_cheapest_model(models) == "ollama/qwen3:4b"
+
+
+class TestFormatCost:
+    def test_free(self) -> None:
+        assert format_cost(0.0) == "free"
+
+    def test_small_cost(self) -> None:
+        assert format_cost(0.0042) == "$0.0042"
+
+    def test_normal_cost(self) -> None:
+        assert format_cost(1.50) == "$1.50"

--- a/tests/test_mcp/test_client.py
+++ b/tests/test_mcp/test_client.py
@@ -26,6 +26,28 @@ class TestMCPServerConfig:
         assert config.args == ["-y", "@modelcontextprotocol/server-github"]
         assert config.env == {"GITHUB_TOKEN": "test"}
 
+    def test_sse_config(self) -> None:
+        """SSE transport config stores url and headers."""
+        config = MCPServerConfig(
+            name="remote",
+            transport="sse",
+            url="http://localhost:3001",
+            headers={"Authorization": "Bearer tok123"},
+        )
+        assert config.transport == "sse"
+        assert config.url == "http://localhost:3001"
+        assert config.headers == {"Authorization": "Bearer tok123"}
+        # stdio fields get defaults
+        assert config.command == ""
+        assert config.args == []
+
+    def test_transport_defaults_to_stdio(self) -> None:
+        """Omitting transport field defaults to stdio (backward compat)."""
+        config = MCPServerConfig(name="legacy", command="/usr/bin/server")
+        assert config.transport == "stdio"
+        assert config.url is None
+        assert config.headers is None
+
 
 class TestMCPToolDefinition:
     """Test tool definition data class."""
@@ -46,10 +68,11 @@ class TestMCPClient:
     """Test MCP client behavior."""
 
     def test_availability_check(self) -> None:
-        """Client reports availability based on mcp package."""
+        """Client reports availability based on installed transport backends."""
         client = MCPClient()
-        # Should be True or False depending on whether mcp is installed
+        # available is True when at least one backend (stdio or sse) is usable
         assert isinstance(client.available, bool)
+        assert isinstance(client.stdio_available, bool)
 
     def test_disconnect_all(self) -> None:
         """Disconnect clears connections without error."""

--- a/tests/test_mcp/test_sse_transport.py
+++ b/tests/test_mcp/test_sse_transport.py
@@ -1,0 +1,295 @@
+"""Tests for MCP SSE/HTTP transport."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from godspeed.mcp.client import MCPClient, MCPServerConfig
+from godspeed.mcp.sse_transport import MCPSSEClient
+
+
+def _make_response(
+    json_data: dict | list | None = None,
+    status_code: int = 200,
+    content_length: int | None = None,
+) -> httpx.Response:
+    """Build a mock httpx.Response."""
+    import json as _json
+
+    body = _json.dumps(json_data or {}).encode()
+    headers = {"content-type": "application/json"}
+    if content_length is not None:
+        headers["content-length"] = str(content_length)
+    resp = httpx.Response(
+        status_code=status_code,
+        content=body,
+        headers=headers,
+        request=httpx.Request("POST", "http://test"),
+    )
+    return resp
+
+
+class TestMCPSSETransport:
+    """Tests for MCPSSEClient."""
+
+    @pytest.mark.asyncio
+    async def test_sse_client_connect(self) -> None:
+        """Mock httpx, verify POST to /initialize is made."""
+        client = MCPSSEClient(base_url="http://localhost:8080")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(return_value=_make_response({}))
+
+        with patch("godspeed.mcp.sse_transport.httpx.AsyncClient", return_value=mock_http):
+            await client.connect()
+
+        mock_http.post.assert_called_once_with("/initialize", json={})
+
+    @pytest.mark.asyncio
+    async def test_sse_client_list_tools(self) -> None:
+        """Mock response with tool definitions, verify parsing."""
+        tools_payload = {
+            "tools": [
+                {
+                    "name": "search",
+                    "description": "Search the web",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                    },
+                },
+                {
+                    "name": "fetch",
+                    "description": "Fetch a URL",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"url": {"type": "string"}},
+                    },
+                },
+            ]
+        }
+
+        client = MCPSSEClient(base_url="http://localhost:8080")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(
+            side_effect=[
+                _make_response({}),  # /initialize
+                _make_response(tools_payload),  # /tools/list
+            ]
+        )
+
+        with patch("godspeed.mcp.sse_transport.httpx.AsyncClient", return_value=mock_http):
+            await client.connect()
+            tools = await client.list_tools()
+
+        assert len(tools) == 2
+        assert tools[0]["name"] == "search"
+        assert tools[1]["name"] == "fetch"
+        assert "query" in tools[0]["inputSchema"]["properties"]
+
+    @pytest.mark.asyncio
+    async def test_sse_client_call_tool(self) -> None:
+        """Mock POST, verify result extraction from content array."""
+        call_response = {
+            "content": [
+                {"type": "text", "text": "Result line 1"},
+                {"type": "text", "text": "Result line 2"},
+            ]
+        }
+
+        client = MCPSSEClient(base_url="http://localhost:8080")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(
+            side_effect=[
+                _make_response({}),  # /initialize
+                _make_response(call_response),  # /tools/call
+            ]
+        )
+
+        with patch("godspeed.mcp.sse_transport.httpx.AsyncClient", return_value=mock_http):
+            await client.connect()
+            result = await client.call_tool("search", {"query": "test"})
+
+        assert result == "Result line 1\nResult line 2"
+        # Verify the call payload
+        call_args = mock_http.post.call_args_list[1]
+        assert call_args.kwargs["json"] == {"name": "search", "arguments": {"query": "test"}}
+
+    @pytest.mark.asyncio
+    async def test_sse_connection_error_graceful(self) -> None:
+        """Server unreachable — list_tools returns empty list."""
+        client = MCPSSEClient(base_url="http://localhost:9999")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(
+            side_effect=[
+                _make_response({}),  # /initialize succeeds
+                httpx.ConnectError("Connection refused"),  # /tools/list fails
+            ]
+        )
+
+        with patch("godspeed.mcp.sse_transport.httpx.AsyncClient", return_value=mock_http):
+            await client.connect()
+            tools = await client.list_tools()
+
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_sse_timeout(self) -> None:
+        """Mock slow response, verify timeout handling."""
+        client = MCPSSEClient(base_url="http://localhost:8080")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(
+            side_effect=[
+                _make_response({}),  # /initialize succeeds
+                httpx.TimeoutException("Read timed out"),  # /tools/call times out
+            ]
+        )
+
+        with patch("godspeed.mcp.sse_transport.httpx.AsyncClient", return_value=mock_http):
+            await client.connect()
+            result = await client.call_tool("slow_tool", {"x": 1})
+
+        assert "Error" in result
+        assert "timed out" in result
+
+    @pytest.mark.asyncio
+    async def test_sse_disconnect(self) -> None:
+        """Disconnect closes the HTTP client."""
+        client = MCPSSEClient(base_url="http://localhost:8080")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        mock_http.post = AsyncMock(return_value=_make_response({}))
+        mock_http.aclose = AsyncMock()
+
+        with patch("godspeed.mcp.sse_transport.httpx.AsyncClient", return_value=mock_http):
+            await client.connect()
+            await client.disconnect()
+
+        mock_http.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sse_call_tool_not_connected(self) -> None:
+        """Call tool before connecting returns error string."""
+        client = MCPSSEClient(base_url="http://localhost:8080")
+        result = await client.call_tool("anything", {})
+        assert "Error" in result
+        assert "not connected" in result
+
+    @pytest.mark.asyncio
+    async def test_sse_list_tools_not_connected(self) -> None:
+        """List tools before connecting returns empty list."""
+        client = MCPSSEClient(base_url="http://localhost:8080")
+        tools = await client.list_tools()
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_sse_response_size_validation(self) -> None:
+        """Oversized response is rejected."""
+        client = MCPSSEClient(base_url="http://localhost:8080")
+        mock_http = AsyncMock(spec=httpx.AsyncClient)
+        oversized_resp = _make_response({}, content_length=2_000_000)
+        mock_http.post = AsyncMock(
+            side_effect=[
+                _make_response({}),  # /initialize
+                oversized_resp,  # /tools/list — too large
+            ]
+        )
+
+        with patch("godspeed.mcp.sse_transport.httpx.AsyncClient", return_value=mock_http):
+            await client.connect()
+            tools = await client.list_tools()
+
+        assert tools == []
+
+
+class TestMCPTransportSelection:
+    """Tests for transport selection in MCPClient."""
+
+    def test_transport_selection_stdio(self) -> None:
+        """Config with transport=stdio uses existing client path."""
+        config = MCPServerConfig(name="local", command="echo", transport="stdio")
+        assert config.transport == "stdio"
+        assert config.url is None
+
+    def test_transport_selection_sse(self) -> None:
+        """Config with transport=sse populates url and headers."""
+        config = MCPServerConfig(
+            name="remote",
+            transport="sse",
+            url="http://localhost:8080",
+            headers={"Authorization": "Bearer tok"},
+        )
+        assert config.transport == "sse"
+        assert config.url == "http://localhost:8080"
+        assert config.headers == {"Authorization": "Bearer tok"}
+
+    def test_config_backward_compat(self) -> None:
+        """Config without transport field defaults to stdio."""
+        config = MCPServerConfig(name="legacy", command="node")
+        assert config.transport == "stdio"
+        assert config.url is None
+        assert config.headers is None
+
+    @pytest.mark.asyncio
+    async def test_connect_routes_to_sse(self) -> None:
+        """MCPClient.connect dispatches to SSE path for transport=sse."""
+        client = MCPClient()
+        config = MCPServerConfig(
+            name="remote",
+            transport="sse",
+            url="http://localhost:8080",
+        )
+
+        mock_sse = AsyncMock()
+        mock_sse.connect = AsyncMock()
+        mock_sse.list_tools = AsyncMock(
+            return_value=[
+                {
+                    "name": "ping",
+                    "description": "Ping test",
+                    "inputSchema": {},
+                }
+            ]
+        )
+
+        with patch("godspeed.mcp.sse_transport.MCPSSEClient", return_value=mock_sse):
+            tools = await client.connect(config)
+
+        assert len(tools) == 1
+        assert tools[0].name == "mcp_remote_ping"
+        mock_sse.connect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_sse_missing_url(self) -> None:
+        """SSE transport without url returns empty list."""
+        client = MCPClient()
+        config = MCPServerConfig(name="broken", transport="sse")
+        tools = await client.connect(config)
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_call_tool_routes_to_sse(self) -> None:
+        """MCPClient.call_tool dispatches to SSE client when available."""
+        client = MCPClient()
+        mock_sse = AsyncMock()
+        mock_sse.call_tool = AsyncMock(return_value="pong")
+        client._sse_clients["remote"] = mock_sse
+
+        result = await client.call_tool("remote", "ping", {})
+        assert result == "pong"
+        mock_sse.call_tool.assert_called_once_with("ping", {})
+
+    @pytest.mark.asyncio
+    async def test_disconnect_all_closes_sse(self) -> None:
+        """disconnect_all closes SSE clients."""
+        client = MCPClient()
+        mock_sse = AsyncMock()
+        mock_sse.disconnect = AsyncMock()
+        client._sse_clients["remote"] = mock_sse
+
+        await client.disconnect_all()
+
+        mock_sse.disconnect.assert_called_once()
+        assert len(client._sse_clients) == 0
+        assert len(client._connections) == 0

--- a/tests/test_mention_integration.py
+++ b/tests/test_mention_integration.py
@@ -1,0 +1,244 @@
+"""Integration tests for @-mention wiring: completion → parsing → resolution → conversation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from prompt_toolkit.completion import CompleteEvent
+from prompt_toolkit.document import Document
+
+from godspeed.agent.conversation import Conversation
+from godspeed.tui.completions import MENTION_TYPES, GodspeedCompleter
+from godspeed.tui.mentions import parse_mentions, resolve_mentions
+
+# ---------------------------------------------------------------------------
+# Tab completion
+# ---------------------------------------------------------------------------
+
+
+class TestMentionTabCompletion:
+    """Tab completion for @-mentions in the TUI."""
+
+    def test_bare_at_shows_three_mention_types(self) -> None:
+        """Typing bare `@` should suggest file, folder, and web."""
+        completer = GodspeedCompleter(cwd=Path("."))
+        doc = Document("@", cursor_position=1)
+        completions = list(completer.get_completions(doc, CompleteEvent()))
+
+        labels = [c.text for c in completions]
+        assert len(labels) == len(MENTION_TYPES)
+        assert "@file:" in labels
+        assert "@folder:" in labels
+        assert "@web:" in labels
+
+    def test_file_mention_completes_paths(self, tmp_path: Path) -> None:
+        """@file:src/ should return child paths under that directory."""
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "main.py").write_text("# main", encoding="utf-8")
+        (src_dir / "utils.py").write_text("# utils", encoding="utf-8")
+        (src_dir / "subpkg").mkdir()
+
+        completer = GodspeedCompleter(cwd=tmp_path)
+        doc = Document("@file:src/", cursor_position=len("@file:src/"))
+        completions = list(completer.get_completions(doc, CompleteEvent()))
+
+        texts = [c.text for c in completions]
+        assert any("main.py" in t for t in texts)
+        assert any("utils.py" in t for t in texts)
+        assert any("subpkg" in t for t in texts)
+
+    def test_folder_mention_completes_paths(self, tmp_path: Path) -> None:
+        """@folder: should also yield directory path completions."""
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "tests").mkdir()
+
+        completer = GodspeedCompleter(cwd=tmp_path)
+        doc = Document("@folder:", cursor_position=len("@folder:"))
+        completions = list(completer.get_completions(doc, CompleteEvent()))
+
+        texts = [c.text for c in completions]
+        assert any("docs" in t for t in texts)
+        assert any("tests" in t for t in texts)
+
+    def test_partial_type_filters(self) -> None:
+        """@fi should narrow completions to @file: only."""
+        completer = GodspeedCompleter(cwd=Path("."))
+        doc = Document("@fi", cursor_position=3)
+        completions = list(completer.get_completions(doc, CompleteEvent()))
+
+        assert len(completions) == 1
+        assert completions[0].text == "@file:"
+
+
+# ---------------------------------------------------------------------------
+# skip_user_message prevents double-add
+# ---------------------------------------------------------------------------
+
+
+class TestSkipUserMessage:
+    """Verify that skip_user_message=True prevents duplicate user messages."""
+
+    @pytest.mark.asyncio
+    async def test_skip_user_message_does_not_add(self) -> None:
+        """When skip_user_message=True, user_input must NOT be added again."""
+        conversation = Conversation(system_prompt="test", model="gpt-4")
+        # Pre-add the user message (simulating TUI pre-adding with content blocks)
+        conversation.add_user_message("Hello with @file:test.py context")
+
+        assert len(conversation._messages) == 1
+
+        llm_client = AsyncMock()
+        llm_client.chat.return_value = MagicMock(text="response", tool_calls=[], refusal=None)
+
+        tool_registry = MagicMock()
+        tool_registry.get_schemas.return_value = []
+        tool_context = MagicMock()
+
+        from godspeed.agent.loop import agent_loop
+
+        await agent_loop(
+            user_input="Hello with @file:test.py context",
+            conversation=conversation,
+            llm_client=llm_client,
+            tool_registry=tool_registry,
+            tool_context=tool_context,
+            skip_user_message=True,
+            max_iterations=1,
+        )
+
+        # Should still be 1 user message, not 2
+        user_msgs = [m for m in conversation._messages if m["role"] == "user"]
+        assert len(user_msgs) == 1
+
+    @pytest.mark.asyncio
+    async def test_without_skip_adds_user_message(self) -> None:
+        """Default (skip_user_message=False) adds the user message normally."""
+        conversation = Conversation(system_prompt="test", model="gpt-4")
+
+        llm_client = AsyncMock()
+        llm_client.chat.return_value = MagicMock(text="ok", tool_calls=[], refusal=None)
+
+        tool_registry = MagicMock()
+        tool_registry.get_schemas.return_value = []
+        tool_context = MagicMock()
+
+        from godspeed.agent.loop import agent_loop
+
+        await agent_loop(
+            user_input="plain message",
+            conversation=conversation,
+            llm_client=llm_client,
+            tool_registry=tool_registry,
+            tool_context=tool_context,
+            skip_user_message=False,
+            max_iterations=1,
+        )
+
+        user_msgs = [m for m in conversation._messages if m["role"] == "user"]
+        assert len(user_msgs) == 1
+        assert user_msgs[0]["content"] == "plain message"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: parse → resolve → content block in conversation
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndMentionFlow:
+    """Full pipeline: user input with mention → parsed → resolved → conversation."""
+
+    @pytest.mark.asyncio
+    async def test_file_mention_to_content_block(self, tmp_path: Path) -> None:
+        """A file mention should be parsed, resolved, and added as a content block."""
+        # Setup: create a real file
+        test_file = tmp_path / "config.yaml"
+        test_file.write_text("key: value\nport: 8080", encoding="utf-8")
+
+        # Step 1: Parse
+        user_text = "Explain @file:config.yaml please"
+        cleaned, mentions = parse_mentions(user_text)
+
+        assert cleaned == "Explain please"
+        assert len(mentions) == 1
+        assert mentions[0].type == "file"
+        assert mentions[0].target == "config.yaml"
+
+        # Step 2: Resolve
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert "key: value" in blocks[0]["text"]
+        assert "port: 8080" in blocks[0]["text"]
+
+        # Step 3: Build multimodal content and add to conversation
+        content_parts: list[dict[str, str]] = [{"type": "text", "text": cleaned}]
+        content_parts.extend(blocks)
+
+        conversation = Conversation(system_prompt="You are a helper.", model="gpt-4")
+        conversation.add_user_message(content_parts)
+
+        msgs = conversation.messages
+        # messages[0] = system, messages[1] = user
+        assert len(msgs) == 2
+        user_content = msgs[1]["content"]
+
+        assert isinstance(user_content, list)
+        assert len(user_content) == 2
+        assert user_content[0]["text"] == "Explain please"
+        assert "config.yaml" in user_content[1]["text"]
+        assert "key: value" in user_content[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_mentions_end_to_end(self, tmp_path: Path) -> None:
+        """Multiple mentions resolve to multiple content blocks."""
+        (tmp_path / "a.py").write_text("def hello(): ...", encoding="utf-8")
+        (tmp_path / "subdir").mkdir()
+        (tmp_path / "subdir" / "b.txt").touch()
+
+        user_text = "Compare @file:a.py and @folder:subdir"
+        cleaned, mentions = parse_mentions(user_text)
+
+        assert len(mentions) == 2
+
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 2
+        assert "def hello()" in blocks[0]["text"]
+        assert "b.txt" in blocks[1]["text"]
+
+        # Wire into conversation
+        content_parts: list[dict[str, str]] = [{"type": "text", "text": cleaned}]
+        content_parts.extend(blocks)
+
+        conversation = Conversation(system_prompt="sys", model="gpt-4")
+        conversation.add_user_message(content_parts)
+
+        user_content = conversation.messages[1]["content"]
+        assert isinstance(user_content, list)
+        assert len(user_content) == 3  # cleaned text + 2 resolved blocks
+
+    @pytest.mark.asyncio
+    async def test_failed_mention_still_produces_error_block(self, tmp_path: Path) -> None:
+        """A mention pointing to a missing file still adds an error block."""
+        user_text = "Read @file:nonexistent.py"
+        cleaned, mentions = parse_mentions(user_text)
+
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 1
+        assert "Error" in blocks[0]["text"]
+
+        # Error block still gets wired into conversation
+        content_parts: list[dict[str, str]] = [{"type": "text", "text": cleaned}]
+        content_parts.extend(blocks)
+
+        conversation = Conversation(system_prompt="sys", model="gpt-4")
+        conversation.add_user_message(content_parts)
+
+        user_content = conversation.messages[1]["content"]
+        assert isinstance(user_content, list)
+        assert any("Error" in block["text"] for block in user_content if "text" in block)

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,155 @@
+"""Tests for @-mention parsing and resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from godspeed.tui.mentions import Mention, parse_mentions, resolve_mentions
+
+
+class TestParseMentions:
+    """Test mention extraction from user input."""
+
+    def test_parse_file_mention(self) -> None:
+        cleaned, mentions = parse_mentions("Read @file:src/main.py please")
+        assert cleaned == "Read please"
+        assert len(mentions) == 1
+        assert mentions[0].type == "file"
+        assert mentions[0].target == "src/main.py"
+        assert mentions[0].raw == "@file:src/main.py"
+
+    def test_parse_folder_mention(self) -> None:
+        cleaned, mentions = parse_mentions("List @folder:src/")
+        assert cleaned == "List"
+        assert len(mentions) == 1
+        assert mentions[0].type == "folder"
+        assert mentions[0].target == "src/"
+
+    def test_parse_web_mention(self) -> None:
+        cleaned, mentions = parse_mentions("Check @web:https://example.com/docs")
+        assert cleaned == "Check"
+        assert len(mentions) == 1
+        assert mentions[0].type == "web"
+        assert mentions[0].target == "https://example.com/docs"
+
+    def test_multiple_mentions(self) -> None:
+        text = "Compare @file:a.py with @file:b.py and @folder:tests/"
+        cleaned, mentions = parse_mentions(text)
+        assert cleaned == "Compare with and"
+        assert len(mentions) == 3
+        assert mentions[0].target == "a.py"
+        assert mentions[1].target == "b.py"
+        assert mentions[2].target == "tests/"
+
+    def test_no_mentions_passthrough(self) -> None:
+        cleaned, mentions = parse_mentions("Just a normal message")
+        assert cleaned == "Just a normal message"
+        assert mentions == []
+
+    def test_empty_string(self) -> None:
+        cleaned, mentions = parse_mentions("")
+        assert cleaned == ""
+        assert mentions == []
+
+    def test_mention_at_start(self) -> None:
+        cleaned, mentions = parse_mentions("@file:test.py what is this?")
+        assert cleaned == "what is this?"
+        assert len(mentions) == 1
+
+    def test_mention_at_end(self) -> None:
+        cleaned, mentions = parse_mentions("Read this @file:main.py")
+        assert cleaned == "Read this"
+        assert len(mentions) == 1
+
+    def test_invalid_mention_type_ignored(self) -> None:
+        """@unknown:foo should not be parsed as a mention."""
+        cleaned, mentions = parse_mentions("Try @unknown:foo bar")
+        assert cleaned == "Try @unknown:foo bar"
+        assert mentions == []
+
+
+class TestResolveMentions:
+    """Test mention resolution to content blocks."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_file_mention(self, tmp_path: Path) -> None:
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('hello')", encoding="utf-8")
+
+        mentions = [Mention(type="file", raw="@file:test.py", target="test.py")]
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert "print('hello')" in blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_folder_mention(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").touch()
+        (tmp_path / "b.py").touch()
+        (tmp_path / "subdir").mkdir()
+
+        mentions = [Mention(type="folder", raw="@folder:.", target=".")]
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 1
+        assert "a.py" in blocks[0]["text"]
+        assert "b.py" in blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_web_https_only(self, tmp_path: Path) -> None:
+        """HTTP URLs should be rejected."""
+        mentions = [Mention(type="web", raw="@web:http://evil.com", target="http://evil.com")]
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 1
+        assert "Error" in blocks[0]["text"]
+        assert "HTTPS" in blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_blocked(self, tmp_path: Path) -> None:
+        """Paths that escape the project directory should be blocked."""
+        mentions = [
+            Mention(
+                type="file",
+                raw="@file:../../etc/passwd",
+                target="../../etc/passwd",
+            )
+        ]
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 1
+        assert "Error" in blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_file(self, tmp_path: Path) -> None:
+        mentions = [Mention(type="file", raw="@file:missing.py", target="missing.py")]
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 1
+        assert "Error" in blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_folder(self, tmp_path: Path) -> None:
+        mentions = [Mention(type="folder", raw="@folder:missing/", target="missing/")]
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 1
+        assert "Error" in blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_mentions_resolved(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("file_a", encoding="utf-8")
+        (tmp_path / "b.py").write_text("file_b", encoding="utf-8")
+
+        mentions = [
+            Mention(type="file", raw="@file:a.py", target="a.py"),
+            Mention(type="file", raw="@file:b.py", target="b.py"),
+        ]
+        blocks = await resolve_mentions(mentions, tmp_path)
+
+        assert len(blocks) == 2
+        assert "file_a" in blocks[0]["text"]
+        assert "file_b" in blocks[1]["text"]

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -1,0 +1,142 @@
+"""Tests for multimodal message support."""
+
+from __future__ import annotations
+
+import pytest
+
+from godspeed.agent.conversation import (
+    Conversation,
+    build_image_content_block,
+    build_multimodal_message,
+)
+from godspeed.llm.token_counter import IMAGE_BLOCK_TOKEN_ESTIMATE, count_message_tokens
+
+
+class TestMultimodalMessages:
+    """Test multimodal content block support in Conversation."""
+
+    def test_add_user_message_string_unchanged(self) -> None:
+        """Plain string messages work exactly as before."""
+        conv = Conversation("System prompt")
+        conv.add_user_message("Hello world")
+        msg = conv.messages[-1]
+        assert msg["role"] == "user"
+        assert msg["content"] == "Hello world"
+
+    def test_add_user_message_content_blocks(self) -> None:
+        """Content block lists are stored as-is."""
+        conv = Conversation("System prompt")
+        blocks = [
+            {"type": "text", "text": "Look at this image"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+        ]
+        conv.add_user_message(blocks)
+        msg = conv.messages[-1]
+        assert msg["role"] == "user"
+        assert isinstance(msg["content"], list)
+        assert len(msg["content"]) == 2
+        assert msg["content"][0]["type"] == "text"
+        assert msg["content"][1]["type"] == "image_url"
+
+
+class TestBuildImageContentBlock:
+    """Test image content block builder."""
+
+    def test_https_url(self) -> None:
+        block = build_image_content_block("https://example.com/image.png")
+        assert block["type"] == "image_url"
+        assert block["image_url"]["url"] == "https://example.com/image.png"
+
+    def test_http_url(self) -> None:
+        block = build_image_content_block("http://localhost:8080/img.jpg")
+        assert block["type"] == "image_url"
+        assert block["image_url"]["url"] == "http://localhost:8080/img.jpg"
+
+    def test_base64_data_uri(self) -> None:
+        uri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
+        block = build_image_content_block(uri)
+        assert block["type"] == "image_url"
+        assert block["image_url"]["url"] == uri
+
+    def test_empty_url_raises(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            build_image_content_block("")
+
+    def test_invalid_url_format_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid image URL format"):
+            build_image_content_block("/local/path/image.png")
+
+    def test_ftp_url_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid image URL format"):
+            build_image_content_block("ftp://example.com/image.png")
+
+
+class TestBuildMultimodalMessage:
+    """Test multimodal message builder."""
+
+    def test_text_only(self) -> None:
+        blocks = build_multimodal_message("Hello")
+        assert len(blocks) == 1
+        assert blocks[0] == {"type": "text", "text": "Hello"}
+
+    def test_text_and_images(self) -> None:
+        blocks = build_multimodal_message(
+            "Check these images",
+            images=["https://example.com/a.png", "https://example.com/b.png"],
+        )
+        assert len(blocks) == 3
+        assert blocks[0]["type"] == "text"
+        assert blocks[1]["type"] == "image_url"
+        assert blocks[2]["type"] == "image_url"
+
+    def test_images_only(self) -> None:
+        blocks = build_multimodal_message("", images=["https://example.com/a.png"])
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "image_url"
+
+    def test_no_images_param(self) -> None:
+        blocks = build_multimodal_message("Hello", images=None)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+
+    def test_empty_images_list(self) -> None:
+        blocks = build_multimodal_message("Hello", images=[])
+        assert len(blocks) == 1
+
+
+class TestTokenCountWithImages:
+    """Test that image content blocks are counted with flat estimate."""
+
+    def test_image_block_counted(self) -> None:
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+                ],
+            }
+        ]
+        count = count_message_tokens(msgs)
+        # Should include: 4 (msg overhead) + text tokens + IMAGE_BLOCK_TOKEN_ESTIMATE + 2 (priming)
+        assert count >= IMAGE_BLOCK_TOKEN_ESTIMATE
+
+    def test_multiple_images_counted(self) -> None:
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "https://a.com/1.png"}},
+                    {"type": "image_url", "image_url": {"url": "https://a.com/2.png"}},
+                ],
+            }
+        ]
+        count = count_message_tokens(msgs)
+        assert count >= IMAGE_BLOCK_TOKEN_ESTIMATE * 2
+
+    def test_no_images_unchanged(self) -> None:
+        """Messages without images should count the same as before."""
+        msgs = [{"role": "user", "content": "Hello world"}]
+        count = count_message_tokens(msgs)
+        # Should be small — just text tokens + overhead
+        assert 0 < count < IMAGE_BLOCK_TOKEN_ESTIMATE

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,0 +1,380 @@
+"""Tests for notebook (.ipynb) read/edit support (Unit 2)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+
+
+def _make_notebook(cells: list[dict] | None = None) -> dict:
+    """Create a minimal valid notebook structure."""
+    return {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python"}},
+        "cells": cells or [],
+    }
+
+
+def _code_cell(source: str, outputs: list | None = None) -> dict:
+    return {
+        "cell_type": "code",
+        "source": source.splitlines(keepends=True),
+        "metadata": {},
+        "execution_count": 1,
+        "outputs": outputs or [],
+    }
+
+
+def _markdown_cell(source: str) -> dict:
+    return {
+        "cell_type": "markdown",
+        "source": source.splitlines(keepends=True),
+        "metadata": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# FileReadTool: notebook rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_notebook_code_cells(tmp_path):
+    """Reading a .ipynb renders code cells with [Cell N: code] headers."""
+    from godspeed.tools.file_read import FileReadTool
+
+    nb = _make_notebook(
+        [
+            _code_cell("print('hello')"),
+            _code_cell("x = 42"),
+        ]
+    )
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    tool = FileReadTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute({"file_path": "test.ipynb"}, ctx)
+
+    assert not result.is_error
+    assert "[Cell 0: code]" in result.output
+    assert "print('hello')" in result.output
+    assert "[Cell 1: code]" in result.output
+    assert "x = 42" in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_notebook_markdown_cells(tmp_path):
+    """Reading a .ipynb renders markdown cells."""
+    nb = _make_notebook([_markdown_cell("# Hello World")])
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    from godspeed.tools.file_read import FileReadTool
+
+    tool = FileReadTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute({"file_path": "test.ipynb"}, ctx)
+
+    assert "[Cell 0: markdown]" in result.output
+    assert "# Hello World" in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_notebook_with_outputs(tmp_path):
+    """Reading a .ipynb renders cell outputs."""
+    nb = _make_notebook(
+        [
+            _code_cell(
+                "print('hello')",
+                outputs=[
+                    {"output_type": "stream", "name": "stdout", "text": ["hello\n"]},
+                ],
+            ),
+        ]
+    )
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    from godspeed.tools.file_read import FileReadTool
+
+    tool = FileReadTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute({"file_path": "test.ipynb"}, ctx)
+
+    assert "[Output: stream]" in result.output
+    assert "hello" in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_notebook_with_error_output(tmp_path):
+    """Reading a .ipynb renders error outputs."""
+    nb = _make_notebook(
+        [
+            _code_cell(
+                "1/0",
+                outputs=[
+                    {
+                        "output_type": "error",
+                        "ename": "ZeroDivisionError",
+                        "evalue": "division by zero",
+                        "traceback": [],
+                    },
+                ],
+            ),
+        ]
+    )
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    from godspeed.tools.file_read import FileReadTool
+
+    tool = FileReadTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute({"file_path": "test.ipynb"}, ctx)
+
+    assert "ZeroDivisionError" in result.output
+
+
+@pytest.mark.asyncio
+async def test_read_empty_notebook(tmp_path):
+    """Reading an empty notebook returns informative message."""
+    nb = _make_notebook([])
+    path = tmp_path / "empty.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    from godspeed.tools.file_read import FileReadTool
+
+    tool = FileReadTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute({"file_path": "empty.ipynb"}, ctx)
+
+    assert "empty notebook" in result.output.lower()
+
+
+@pytest.mark.asyncio
+async def test_read_malformed_notebook(tmp_path):
+    """Reading a malformed .ipynb returns error."""
+    path = tmp_path / "bad.ipynb"
+    path.write_text("{invalid json", encoding="utf-8")
+
+    from godspeed.tools.file_read import FileReadTool
+
+    tool = FileReadTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute({"file_path": "bad.ipynb"}, ctx)
+
+    assert result.is_error
+    assert "parse" in result.error.lower() or "Failed" in result.error
+
+
+# ---------------------------------------------------------------------------
+# NotebookEditTool: cell operations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_cell(tmp_path):
+    """edit_cell updates cell source."""
+    from godspeed.tools.notebook import NotebookEditTool
+
+    nb = _make_notebook([_code_cell("old code")])
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    tool = NotebookEditTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute(
+        {
+            "file_path": "test.ipynb",
+            "action": "edit_cell",
+            "cell_index": 0,
+            "content": "new code",
+        },
+        ctx,
+    )
+
+    assert not result.is_error
+    assert "Updated cell 0" in result.output
+
+    # Verify file was updated
+    updated = json.loads(path.read_text(encoding="utf-8"))
+    assert "".join(updated["cells"][0]["source"]) == "new code"
+
+
+@pytest.mark.asyncio
+async def test_add_cell(tmp_path):
+    """add_cell inserts a new cell."""
+    from godspeed.tools.notebook import NotebookEditTool
+
+    nb = _make_notebook([_code_cell("first")])
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    tool = NotebookEditTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute(
+        {
+            "file_path": "test.ipynb",
+            "action": "add_cell",
+            "cell_index": 0,
+            "content": "# Header",
+            "cell_type": "markdown",
+        },
+        ctx,
+    )
+
+    assert not result.is_error
+    updated = json.loads(path.read_text(encoding="utf-8"))
+    assert len(updated["cells"]) == 2
+    assert updated["cells"][0]["cell_type"] == "markdown"
+
+
+@pytest.mark.asyncio
+async def test_add_cell_append(tmp_path):
+    """add_cell without index appends to end."""
+    from godspeed.tools.notebook import NotebookEditTool
+
+    nb = _make_notebook([_code_cell("first")])
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    tool = NotebookEditTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute(
+        {
+            "file_path": "test.ipynb",
+            "action": "add_cell",
+            "content": "second",
+        },
+        ctx,
+    )
+
+    assert not result.is_error
+    updated = json.loads(path.read_text(encoding="utf-8"))
+    assert len(updated["cells"]) == 2
+    assert "".join(updated["cells"][1]["source"]) == "second"
+
+
+@pytest.mark.asyncio
+async def test_delete_cell(tmp_path):
+    """delete_cell removes the specified cell."""
+    from godspeed.tools.notebook import NotebookEditTool
+
+    nb = _make_notebook([_code_cell("keep"), _code_cell("delete")])
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    tool = NotebookEditTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute(
+        {
+            "file_path": "test.ipynb",
+            "action": "delete_cell",
+            "cell_index": 1,
+        },
+        ctx,
+    )
+
+    assert not result.is_error
+    updated = json.loads(path.read_text(encoding="utf-8"))
+    assert len(updated["cells"]) == 1
+    assert "".join(updated["cells"][0]["source"]) == "keep"
+
+
+@pytest.mark.asyncio
+async def test_move_cell(tmp_path):
+    """move_cell repositions a cell."""
+    from godspeed.tools.notebook import NotebookEditTool
+
+    nb = _make_notebook([_code_cell("a"), _code_cell("b"), _code_cell("c")])
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    tool = NotebookEditTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute(
+        {
+            "file_path": "test.ipynb",
+            "action": "move_cell",
+            "cell_index": 2,
+            "target_index": 0,
+        },
+        ctx,
+    )
+
+    assert not result.is_error
+    updated = json.loads(path.read_text(encoding="utf-8"))
+    sources = ["".join(c["source"]) for c in updated["cells"]]
+    assert sources == ["c", "a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_edit_cell_out_of_range(tmp_path):
+    """edit_cell with invalid index returns error."""
+    from godspeed.tools.notebook import NotebookEditTool
+
+    nb = _make_notebook([_code_cell("only")])
+    path = tmp_path / "test.ipynb"
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+    tool = NotebookEditTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute(
+        {
+            "file_path": "test.ipynb",
+            "action": "edit_cell",
+            "cell_index": 5,
+            "content": "nope",
+        },
+        ctx,
+    )
+
+    assert result.is_error
+    assert "out of range" in result.error
+
+
+@pytest.mark.asyncio
+async def test_notebook_edit_non_ipynb(tmp_path):
+    """NotebookEditTool rejects non-.ipynb files."""
+    from godspeed.tools.notebook import NotebookEditTool
+
+    (tmp_path / "test.py").write_text("x = 1")
+
+    tool = NotebookEditTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute(
+        {
+            "file_path": "test.py",
+            "action": "edit_cell",
+            "cell_index": 0,
+        },
+        ctx,
+    )
+
+    assert result.is_error
+    assert ".ipynb" in result.error
+
+
+@pytest.mark.asyncio
+async def test_notebook_edit_not_found(tmp_path):
+    """NotebookEditTool returns error for missing file."""
+    from godspeed.tools.notebook import NotebookEditTool
+
+    tool = NotebookEditTool()
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    result = await tool.execute(
+        {
+            "file_path": "missing.ipynb",
+            "action": "edit_cell",
+            "cell_index": 0,
+        },
+        ctx,
+    )
+
+    assert result.is_error
+    assert "not found" in result.error.lower()

--- a/tests/test_parallel_tools.py
+++ b/tests/test_parallel_tools.py
@@ -1,0 +1,430 @@
+"""Tests for parallel tool execution in the agent loop."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from godspeed.agent.conversation import Conversation
+from godspeed.agent.loop import agent_loop
+from godspeed.llm.client import ChatResponse, LLMClient
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+from godspeed.tools.registry import ToolRegistry
+from tests.conftest import MockTool
+
+
+def _make_text_response(text: str) -> ChatResponse:
+    return ChatResponse(content=text, tool_calls=[], finish_reason="stop")
+
+
+def _make_multi_tool_response(
+    tools: list[tuple[str, dict[str, Any]]],
+) -> ChatResponse:
+    """Create an LLM response with multiple tool calls."""
+    tool_calls = []
+    for i, (name, args) in enumerate(tools):
+        tool_calls.append(
+            {
+                "id": f"call_{i:03d}",
+                "function": {
+                    "name": name,
+                    "arguments": json.dumps(args),
+                },
+            }
+        )
+    return ChatResponse(
+        content="",
+        tool_calls=tool_calls,
+        finish_reason="tool_calls",
+    )
+
+
+class SlowTool(Tool):
+    """A tool that takes a configurable amount of time to execute."""
+
+    def __init__(
+        self,
+        name: str = "slow_tool",
+        delay: float = 0.1,
+        result: ToolResult | None = None,
+    ) -> None:
+        self._name = name
+        self._delay = delay
+        self._result = result or ToolResult.success(f"{name} output")
+        self.call_count = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"A slow tool ({self._delay}s)"
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"input": {"type": "string"}},
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        self.call_count += 1
+        await asyncio.sleep(self._delay)
+        return self._result
+
+
+class TestParallelToolExecution:
+    """Test parallel tool dispatch via asyncio.gather."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_tools_execute_concurrently(self, tool_context) -> None:
+        """Two slow tools should complete faster than their combined delay."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+
+        tool_a = SlowTool(name="tool_a", delay=0.5)
+        tool_b = SlowTool(name="tool_b", delay=0.5)
+        registry.register(tool_a)
+        registry.register(tool_b)
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _make_multi_tool_response(
+                    [
+                        ("tool_a", {"input": "a"}),
+                        ("tool_b", {"input": "b"}),
+                    ]
+                ),
+                _make_text_response("Done"),
+            ]
+        )
+
+        t0 = time.monotonic()
+        result = await agent_loop(
+            "Run both",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            parallel_tool_calls=True,
+        )
+        elapsed = time.monotonic() - t0
+
+        assert result == "Done"
+        assert tool_a.call_count == 1
+        assert tool_b.call_count == 1
+        # Parallel: both 0.5s tools should overlap. Sequential would be ~1.0s+.
+        # With overhead, parallel should still be well under 0.9s.
+        assert elapsed < 0.9, f"Expected parallel execution, took {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_results_feed_back_in_order(self, tool_context) -> None:
+        """Tool results must appear in conversation in the same order as calls."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+
+        # Tool B is faster than A, but results should be ordered A, B, C
+        registry.register(SlowTool(name="tool_a", delay=0.1, result=ToolResult.success("result_a")))
+        registry.register(
+            SlowTool(name="tool_b", delay=0.01, result=ToolResult.success("result_b"))
+        )
+        registry.register(
+            SlowTool(name="tool_c", delay=0.05, result=ToolResult.success("result_c"))
+        )
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _make_multi_tool_response(
+                    [
+                        ("tool_a", {}),
+                        ("tool_b", {}),
+                        ("tool_c", {}),
+                    ]
+                ),
+                _make_text_response("All done"),
+            ]
+        )
+
+        await agent_loop(
+            "Run all three",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            parallel_tool_calls=True,
+        )
+
+        # Extract tool results from conversation in order
+        tool_results = [
+            msg["content"]
+            for msg in conversation.messages
+            if msg.get("role") == "tool" and msg.get("content", "").startswith("result_")
+        ]
+        assert tool_results == ["result_a", "result_b", "result_c"]
+
+    @pytest.mark.asyncio
+    async def test_permission_denied_skips_without_blocking_others(self, tool_context) -> None:
+        """One denied tool should not prevent others from executing."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="tool_a", result=ToolResult.success("a_ok")))
+        registry.register(MockTool(name="tool_b", result=ToolResult.success("b_ok")))
+
+        # Set up permissions to deny tool_b
+        class DenyBPermissions:
+            def evaluate(self, tool_call):
+                if tool_call.tool_name == "tool_b":
+                    return "deny"
+                return "allow"
+
+        tool_context_with_perms = ToolContext(
+            cwd=tool_context.cwd,
+            session_id=tool_context.session_id,
+            permissions=DenyBPermissions(),
+        )
+
+        denied_tools = []
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _make_multi_tool_response(
+                    [
+                        ("tool_a", {}),
+                        ("tool_b", {}),
+                    ]
+                ),
+                _make_text_response("Done with A only"),
+            ]
+        )
+
+        result = await agent_loop(
+            "Run both",
+            conversation,
+            client,
+            registry,
+            tool_context_with_perms,
+            on_permission_denied=lambda name, reason: denied_tools.append(name),
+            parallel_tool_calls=True,
+        )
+
+        assert result == "Done with A only"
+        assert "tool_b" in denied_tools
+
+        # tool_a should have executed, tool_b should be denied
+        tool_msgs = [msg for msg in conversation.messages if msg.get("role") == "tool"]
+        contents = [m["content"] for m in tool_msgs]
+        assert any("a_ok" in c for c in contents)
+        assert any("DENIED" in c for c in contents)
+
+    @pytest.mark.asyncio
+    async def test_sequential_fallback_when_disabled(self, tool_context) -> None:
+        """With parallel_tool_calls=False, tools execute sequentially."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+
+        execution_order: list[str] = []
+
+        class OrderTrackingTool(Tool):
+            def __init__(self, tool_name: str, delay: float) -> None:
+                self._name = tool_name
+                self._delay = delay
+
+            @property
+            def name(self) -> str:
+                return self._name
+
+            @property
+            def description(self) -> str:
+                return "Tracks execution order"
+
+            @property
+            def risk_level(self) -> RiskLevel:
+                return RiskLevel.READ_ONLY
+
+            def get_schema(self) -> dict[str, Any]:
+                return {"type": "object", "properties": {}, "required": []}
+
+            async def execute(self, arguments, context) -> ToolResult:
+                execution_order.append(self._name)
+                await asyncio.sleep(self._delay)
+                return ToolResult.success(f"{self._name} done")
+
+        registry.register(OrderTrackingTool("first", 0.05))
+        registry.register(OrderTrackingTool("second", 0.05))
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _make_multi_tool_response([("first", {}), ("second", {})]),
+                _make_text_response("Done"),
+            ]
+        )
+
+        t0 = time.monotonic()
+        await agent_loop(
+            "Run both",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            parallel_tool_calls=False,
+        )
+        elapsed = time.monotonic() - t0
+
+        assert execution_order == ["first", "second"]
+        # Sequential: should take >= 0.10s (two 0.05s delays)
+        assert elapsed >= 0.09, f"Expected sequential execution, took {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_single_tool_call_unchanged(self, tool_context) -> None:
+        """A single tool call should work identically regardless of parallel flag."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        tool = MockTool(name="file_read", result=ToolResult.success("file contents"))
+        registry.register(tool)
+
+        client = LLMClient(model="test")
+
+        single_response = ChatResponse(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_001",
+                    "function": {
+                        "name": "file_read",
+                        "arguments": json.dumps({"file_path": "test.py"}),
+                    },
+                }
+            ],
+            finish_reason="tool_calls",
+        )
+        client.chat = AsyncMock(side_effect=[single_response, _make_text_response("Read it")])
+
+        result = await agent_loop(
+            "Read test.py",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            parallel_tool_calls=True,
+        )
+        assert result == "Read it"
+        assert tool.last_arguments == {"file_path": "test.py"}
+
+    @pytest.mark.asyncio
+    async def test_callbacks_called_for_all_parallel_tools(self, tool_context) -> None:
+        """on_tool_call and on_tool_result should fire for every tool in a parallel batch."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="tool_a", result=ToolResult.success("a_out")))
+        registry.register(MockTool(name="tool_b", result=ToolResult.success("b_out")))
+
+        tool_call_names: list[str] = []
+        tool_result_names: list[str] = []
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _make_multi_tool_response([("tool_a", {}), ("tool_b", {})]),
+                _make_text_response("Done"),
+            ]
+        )
+
+        await agent_loop(
+            "Run both",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            on_tool_call=lambda name, args: tool_call_names.append(name),
+            on_tool_result=lambda name, result: tool_result_names.append(name),
+            parallel_tool_calls=True,
+        )
+
+        assert set(tool_call_names) == {"tool_a", "tool_b"}
+        assert set(tool_result_names) == {"tool_a", "tool_b"}
+
+    @pytest.mark.asyncio
+    async def test_parallel_with_one_error_tool(self, tool_context) -> None:
+        """One failing tool in a parallel batch should not prevent others from succeeding."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="good_tool", result=ToolResult.success("ok")))
+        registry.register(MockTool(name="bad_tool", result=ToolResult.failure("boom")))
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _make_multi_tool_response(
+                    [
+                        ("good_tool", {}),
+                        ("bad_tool", {}),
+                    ]
+                ),
+                _make_text_response("Handled the error"),
+            ]
+        )
+
+        result = await agent_loop(
+            "Run both",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            parallel_tool_calls=True,
+        )
+
+        assert result == "Handled the error"
+
+        # Both results should be in conversation
+        tool_msgs = [msg["content"] for msg in conversation.messages if msg.get("role") == "tool"]
+        assert any("ok" in c for c in tool_msgs)
+        assert any("boom" in c for c in tool_msgs)
+
+    @pytest.mark.asyncio
+    async def test_all_denied_continues_to_next_llm_turn(self, tool_context) -> None:
+        """If all tool calls are denied, the loop should continue to the next LLM turn."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="tool_a"))
+
+        class DenyAllPermissions:
+            def evaluate(self, tool_call):
+                return "deny"
+
+        tool_context_deny = ToolContext(
+            cwd=tool_context.cwd,
+            session_id=tool_context.session_id,
+            permissions=DenyAllPermissions(),
+        )
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _make_multi_tool_response([("tool_a", {})]),
+                _make_text_response("Everything was denied, giving up."),
+            ]
+        )
+
+        result = await agent_loop(
+            "Try it",
+            conversation,
+            client,
+            registry,
+            tool_context_deny,
+            parallel_tool_calls=True,
+        )
+        assert "denied" in result.lower() or "giving up" in result.lower()

--- a/tests/test_pdf_read.py
+++ b/tests/test_pdf_read.py
@@ -1,0 +1,286 @@
+"""Tests for PDF read tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+from godspeed.tools.pdf_read import MAX_PAGES_PER_REQUEST, PdfReadTool, parse_page_range
+
+
+@pytest.fixture()
+def tool() -> PdfReadTool:
+    return PdfReadTool()
+
+
+@pytest.fixture()
+def ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(cwd=tmp_path, session_id="test")
+
+
+def _make_mock_doc(page_texts: list[str]) -> MagicMock:
+    """Create a mock pymupdf document with given page texts."""
+    doc = MagicMock()
+    doc.__len__ = lambda self: len(page_texts)
+
+    pages = []
+    for text in page_texts:
+        page = MagicMock()
+        page.get_text.return_value = text
+        pages.append(page)
+
+    doc.__getitem__ = lambda self, idx: pages[idx]
+    return doc
+
+
+class TestParsePageRange:
+    """Unit tests for parse_page_range."""
+
+    def test_single_page(self) -> None:
+        indices, error = parse_page_range("3", 10)
+        assert error is None
+        assert indices == [2]
+
+    def test_page_range(self) -> None:
+        indices, error = parse_page_range("1-5", 10)
+        assert error is None
+        assert indices == [0, 1, 2, 3, 4]
+
+    def test_page_range_clamped_to_total(self) -> None:
+        indices, error = parse_page_range("8-15", 10)
+        assert error is None
+        assert indices == [7, 8, 9]
+
+    def test_single_page_out_of_range(self) -> None:
+        _indices, error = parse_page_range("11", 10)
+        assert error is not None
+        assert "exceeds" in error
+
+    def test_start_page_out_of_range(self) -> None:
+        _indices, error = parse_page_range("15-20", 10)
+        assert error is not None
+        assert "exceeds" in error
+
+    def test_end_less_than_start(self) -> None:
+        _indices, error = parse_page_range("5-3", 10)
+        assert error is not None
+        assert "end" in error.lower() or "Invalid" in error
+
+    def test_invalid_format(self) -> None:
+        _indices, error = parse_page_range("abc", 10)
+        assert error is not None
+        assert "Invalid" in error
+
+    def test_invalid_range_format(self) -> None:
+        _indices, error = parse_page_range("a-b", 10)
+        assert error is not None
+        assert "Invalid" in error
+
+    def test_empty_string(self) -> None:
+        _indices, error = parse_page_range("", 10)
+        assert error is not None
+
+    def test_page_zero(self) -> None:
+        _indices, error = parse_page_range("0", 10)
+        assert error is not None
+        assert ">= 1" in error
+
+    def test_negative_page(self) -> None:
+        _indices, error = parse_page_range("-1", 10)
+        assert error is not None
+
+    def test_max_pages_exceeded(self) -> None:
+        _indices, error = parse_page_range("1-25", 100)
+        assert error is not None
+        assert str(MAX_PAGES_PER_REQUEST) in error
+
+
+class TestPdfReadToolProperties:
+    """Test tool metadata."""
+
+    def test_name(self, tool: PdfReadTool) -> None:
+        assert tool.name == "pdf_read"
+
+    def test_risk_level(self, tool: PdfReadTool) -> None:
+        from godspeed.tools.base import RiskLevel
+
+        assert tool.risk_level == RiskLevel.READ_ONLY
+
+    def test_schema_has_required_file_path(self, tool: PdfReadTool) -> None:
+        schema = tool.get_schema()
+        assert "file_path" in schema["properties"]
+        assert "pages" in schema["properties"]
+        assert schema["required"] == ["file_path"]
+
+
+class TestPdfReadToolExecute:
+    """Test tool execution with mocked pymupdf."""
+
+    @pytest.mark.asyncio()
+    async def test_pymupdf_not_installed(
+        self, tool: PdfReadTool, ctx: ToolContext, tmp_path: Path
+    ) -> None:
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.touch()
+
+        with patch.dict("sys.modules", {"pymupdf": None}):
+            result = await tool.execute({"file_path": "test.pdf"}, ctx)
+
+        assert result.is_error
+        assert "pymupdf" in result.error
+        assert "pip install pymupdf" in result.error
+
+    @pytest.mark.asyncio()
+    async def test_file_not_found(self, tool: PdfReadTool, ctx: ToolContext) -> None:
+        mock_pymupdf = MagicMock()
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "nonexistent.pdf"}, ctx)
+
+        assert result.is_error
+        assert "File not found" in result.error
+
+    @pytest.mark.asyncio()
+    async def test_path_traversal_blocked(self, tool: PdfReadTool, ctx: ToolContext) -> None:
+        mock_pymupdf = MagicMock()
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "../../etc/passwd"}, ctx)
+
+        assert result.is_error
+        assert "Access denied" in result.error
+
+    @pytest.mark.asyncio()
+    async def test_empty_file_path(self, tool: PdfReadTool, ctx: ToolContext) -> None:
+        mock_pymupdf = MagicMock()
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": ""}, ctx)
+
+        assert result.is_error
+        assert "non-empty string" in result.error
+
+    @pytest.mark.asyncio()
+    async def test_valid_pdf_read_all_pages(
+        self, tool: PdfReadTool, ctx: ToolContext, tmp_path: Path
+    ) -> None:
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.touch()
+
+        mock_doc = _make_mock_doc(["Page one text.", "Page two text.", "Page three text."])
+        mock_pymupdf = MagicMock()
+        mock_pymupdf.open.return_value = mock_doc
+
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "test.pdf"}, ctx)
+
+        assert not result.is_error
+        assert "[Page 1]:" in result.output
+        assert "Page one text." in result.output
+        assert "[Page 2]:" in result.output
+        assert "Page two text." in result.output
+        assert "[Page 3]:" in result.output
+        assert "Page three text." in result.output
+
+    @pytest.mark.asyncio()
+    async def test_single_page_read(
+        self, tool: PdfReadTool, ctx: ToolContext, tmp_path: Path
+    ) -> None:
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.touch()
+
+        mock_doc = _make_mock_doc(["First.", "Second.", "Third."])
+        mock_pymupdf = MagicMock()
+        mock_pymupdf.open.return_value = mock_doc
+
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "test.pdf", "pages": "2"}, ctx)
+
+        assert not result.is_error
+        assert "[Page 2]:" in result.output
+        assert "Second." in result.output
+        assert "[Page 1]:" not in result.output
+        assert "[Page 3]:" not in result.output
+
+    @pytest.mark.asyncio()
+    async def test_page_range_read(
+        self, tool: PdfReadTool, ctx: ToolContext, tmp_path: Path
+    ) -> None:
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.touch()
+
+        texts = [f"Content of page {i + 1}." for i in range(10)]
+        mock_doc = _make_mock_doc(texts)
+        mock_pymupdf = MagicMock()
+        mock_pymupdf.open.return_value = mock_doc
+
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "test.pdf", "pages": "1-5"}, ctx)
+
+        assert not result.is_error
+        for i in range(1, 6):
+            assert f"[Page {i}]:" in result.output
+            assert f"Content of page {i}." in result.output
+        assert "[Page 6]:" not in result.output
+
+    @pytest.mark.asyncio()
+    async def test_max_pages_limit_enforced(
+        self, tool: PdfReadTool, ctx: ToolContext, tmp_path: Path
+    ) -> None:
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.touch()
+
+        texts = [f"Page {i}" for i in range(50)]
+        mock_doc = _make_mock_doc(texts)
+        mock_pymupdf = MagicMock()
+        mock_pymupdf.open.return_value = mock_doc
+
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "test.pdf", "pages": "1-25"}, ctx)
+
+        assert result.is_error
+        assert str(MAX_PAGES_PER_REQUEST) in result.error
+
+    @pytest.mark.asyncio()
+    async def test_default_caps_at_max_pages(
+        self, tool: PdfReadTool, ctx: ToolContext, tmp_path: Path
+    ) -> None:
+        """When no pages specified and doc has >20 pages, only first 20 are returned."""
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.touch()
+
+        texts = [f"Page {i + 1}" for i in range(30)]
+        mock_doc = _make_mock_doc(texts)
+        mock_pymupdf = MagicMock()
+        mock_pymupdf.open.return_value = mock_doc
+
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "test.pdf"}, ctx)
+
+        assert not result.is_error
+        assert "[Page 20]:" in result.output
+        assert "[Page 21]:" not in result.output
+        assert "more pages" in result.output
+
+    @pytest.mark.asyncio()
+    async def test_non_pdf_file_rejected(
+        self, tool: PdfReadTool, ctx: ToolContext, tmp_path: Path
+    ) -> None:
+        txt_file = tmp_path / "notes.txt"
+        txt_file.write_text("not a pdf")
+
+        mock_pymupdf = MagicMock()
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "notes.txt"}, ctx)
+
+        assert result.is_error
+        assert "Not a PDF file" in result.error
+
+    @pytest.mark.asyncio()
+    async def test_windows_absolute_path_blocked(self, tool: PdfReadTool, ctx: ToolContext) -> None:
+        mock_pymupdf = MagicMock()
+        with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
+            result = await tool.execute({"file_path": "C:\\Windows\\system.pdf"}, ctx)
+
+        assert result.is_error
+        assert "Access denied" in result.error

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -1,0 +1,231 @@
+"""Tests for speculative tool execution during streaming (Unit 15)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from godspeed.agent.loop import _speculative_dispatch
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+from godspeed.tools.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ReadTool(Tool):
+    @property
+    def name(self) -> str:
+        return "file_read"
+
+    @property
+    def description(self) -> str:
+        return "read"
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self):
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, arguments, context):
+        return ToolResult.success("read content")
+
+
+class _WriteTool(Tool):
+    @property
+    def name(self) -> str:
+        return "file_write"
+
+    @property
+    def description(self) -> str:
+        return "write"
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.LOW
+
+    def get_schema(self):
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, arguments, context):
+        return ToolResult.success("written")
+
+
+# ---------------------------------------------------------------------------
+# _speculative_dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_speculative_dispatches_read_only(tmp_path):
+    """READ_ONLY tools get dispatched into the cache."""
+    registry = ToolRegistry()
+    registry.register(_ReadTool())
+    registry.register(_WriteTool())
+
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    cache: dict[str, asyncio.Task[ToolResult]] = {}
+
+    raw_calls = [
+        {"id": "tc1", "function": {"name": "file_read", "arguments": "{}"}},
+        {"id": "tc2", "function": {"name": "file_write", "arguments": "{}"}},
+    ]
+
+    _speculative_dispatch(raw_calls, registry, ctx, cache)
+
+    # Only read tool should be cached
+    assert "tc1" in cache
+    assert "tc2" not in cache
+
+    # Await the cached task
+    result = await cache["tc1"]
+    assert result.output == "read content"
+
+
+@pytest.mark.asyncio
+async def test_speculative_skips_unknown_tools(tmp_path):
+    """Unknown tools are not dispatched."""
+    registry = ToolRegistry()
+    registry.register(_ReadTool())
+
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    cache: dict[str, asyncio.Task[ToolResult]] = {}
+
+    raw_calls = [
+        {"id": "tc1", "function": {"name": "unknown_tool", "arguments": "{}"}},
+    ]
+
+    _speculative_dispatch(raw_calls, registry, ctx, cache)
+    assert len(cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_speculative_skips_malformed_calls(tmp_path):
+    """Malformed tool calls are skipped."""
+    registry = ToolRegistry()
+    registry.register(_ReadTool())
+
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    cache: dict[str, asyncio.Task[ToolResult]] = {}
+
+    raw_calls = [
+        {"id": "tc1", "function": {"name": "", "arguments": "{}"}},
+    ]
+
+    _speculative_dispatch(raw_calls, registry, ctx, cache)
+    assert len(cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_speculative_no_duplicate_dispatch(tmp_path):
+    """Same call_id is not dispatched twice."""
+    registry = ToolRegistry()
+    registry.register(_ReadTool())
+
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    cache: dict[str, asyncio.Task[ToolResult]] = {}
+
+    raw_calls = [
+        {"id": "tc1", "function": {"name": "file_read", "arguments": "{}"}},
+    ]
+
+    _speculative_dispatch(raw_calls, registry, ctx, cache)
+    first_task = cache["tc1"]
+
+    # Dispatch again with same id
+    _speculative_dispatch(raw_calls, registry, ctx, cache)
+    assert cache["tc1"] is first_task  # Same task, not replaced
+
+    await first_task
+
+
+@pytest.mark.asyncio
+async def test_speculative_empty_call_id_skipped(tmp_path):
+    """Tool calls with empty call_id are not speculatively dispatched."""
+    registry = ToolRegistry()
+    registry.register(_ReadTool())
+
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    cache: dict[str, asyncio.Task[ToolResult]] = {}
+
+    raw_calls = [
+        {"id": "", "function": {"name": "file_read", "arguments": "{}"}},
+    ]
+
+    _speculative_dispatch(raw_calls, registry, ctx, cache)
+    assert len(cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_speculative_cache_consumed_by_loop(tmp_path):
+    """Speculative cache entries are consumed (popped) when used."""
+    registry = ToolRegistry()
+    registry.register(_ReadTool())
+
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    cache: dict[str, asyncio.Task[ToolResult]] = {}
+
+    raw_calls = [
+        {"id": "tc1", "function": {"name": "file_read", "arguments": "{}"}},
+    ]
+
+    _speculative_dispatch(raw_calls, registry, ctx, cache)
+    assert "tc1" in cache
+
+    # Simulate main loop consuming the cache
+    task = cache.pop("tc1")
+    result = await task
+    assert result.output == "read content"
+    assert "tc1" not in cache
+
+
+@pytest.mark.asyncio
+async def test_speculative_multiple_read_tools(tmp_path):
+    """Multiple READ_ONLY calls are all dispatched."""
+
+    class _GrepTool(Tool):
+        @property
+        def name(self) -> str:
+            return "grep_search"
+
+        @property
+        def description(self) -> str:
+            return "grep"
+
+        @property
+        def risk_level(self) -> RiskLevel:
+            return RiskLevel.READ_ONLY
+
+        def get_schema(self):
+            return {"type": "object", "properties": {}}
+
+        async def execute(self, arguments, context):
+            return ToolResult.success("grep results")
+
+    registry = ToolRegistry()
+    registry.register(_ReadTool())
+    registry.register(_GrepTool())
+    registry.register(_WriteTool())
+
+    ctx = ToolContext(cwd=tmp_path, session_id="test")
+    cache: dict[str, asyncio.Task[ToolResult]] = {}
+
+    raw_calls = [
+        {"id": "tc1", "function": {"name": "file_read", "arguments": "{}"}},
+        {"id": "tc2", "function": {"name": "grep_search", "arguments": "{}"}},
+        {"id": "tc3", "function": {"name": "file_write", "arguments": "{}"}},
+    ]
+
+    _speculative_dispatch(raw_calls, registry, ctx, cache)
+    assert "tc1" in cache
+    assert "tc2" in cache
+    assert "tc3" not in cache
+
+    r1 = await cache["tc1"]
+    r2 = await cache["tc2"]
+    assert r1.output == "read content"
+    assert r2.output == "grep results"

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -1,0 +1,357 @@
+"""Tests for extended thinking support (Unit 1)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from godspeed.llm.client import ChatResponse, LLMClient
+
+# ---------------------------------------------------------------------------
+# Config: thinking_budget field
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_budget_defaults_zero():
+    """thinking_budget defaults to 0 (disabled)."""
+    from godspeed.config import GodspeedSettings
+
+    with patch("godspeed.config.DEFAULT_GLOBAL_DIR", MagicMock(exists=lambda: False)):
+        settings = GodspeedSettings(model="test")
+    assert settings.thinking_budget == 0
+
+
+def test_thinking_budget_config_value():
+    """thinking_budget can be set via constructor."""
+    from godspeed.config import GodspeedSettings
+
+    with patch("godspeed.config.DEFAULT_GLOBAL_DIR", MagicMock(exists=lambda: False)):
+        settings = GodspeedSettings(model="test", thinking_budget=10000)
+    assert settings.thinking_budget == 10000
+
+
+# ---------------------------------------------------------------------------
+# LLMClient: thinking parameter passed to Anthropic models
+# ---------------------------------------------------------------------------
+
+
+def test_llm_client_stores_thinking_budget():
+    """LLMClient stores thinking_budget from constructor."""
+    client = LLMClient(model="claude-sonnet-4-20250514", thinking_budget=8000)
+    assert client.thinking_budget == 8000
+
+
+def test_is_anthropic_model_true():
+    """Claude models are correctly identified as Anthropic."""
+    client = LLMClient(model="claude-sonnet-4-20250514")
+    assert client._is_anthropic_model() is True
+    assert client._is_anthropic_model("anthropic/claude-3.5-sonnet") is True
+
+
+def test_is_anthropic_model_false():
+    """Non-Claude models are not Anthropic."""
+    client = LLMClient(model="gpt-4o")
+    assert client._is_anthropic_model() is False
+    assert client._is_anthropic_model("ollama/qwen3:4b") is False
+
+
+@pytest.mark.asyncio
+async def test_thinking_param_added_for_claude():
+    """When thinking_budget > 0 and model is Claude, thinking param is added."""
+    client = LLMClient(model="claude-sonnet-4-20250514", thinking_budget=10000)
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(
+                content="Hello",
+                tool_calls=None,
+                thinking=None,
+            ),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+
+    with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+        mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_response)
+        await client._call("claude-sonnet-4-20250514", [{"role": "user", "content": "hi"}], None)
+
+        call_kwargs = mock_litellm.return_value.acompletion.call_args[1]
+        assert "thinking" in call_kwargs
+        assert call_kwargs["thinking"]["type"] == "enabled"
+        assert call_kwargs["thinking"]["budget_tokens"] == 10000
+
+
+@pytest.mark.asyncio
+async def test_thinking_param_skipped_for_non_claude():
+    """When model is not Claude, thinking param is not added."""
+    client = LLMClient(model="gpt-4o", thinking_budget=10000)
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(
+                content="Hello",
+                tool_calls=None,
+                thinking=None,
+            ),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+
+    with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+        mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_response)
+        await client._call("gpt-4o", [{"role": "user", "content": "hi"}], None)
+
+        call_kwargs = mock_litellm.return_value.acompletion.call_args[1]
+        assert "thinking" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_thinking_param_skipped_when_zero():
+    """When thinking_budget is 0, no thinking param even for Claude."""
+    client = LLMClient(model="claude-sonnet-4-20250514", thinking_budget=0)
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(
+                content="Hello",
+                tool_calls=None,
+                thinking=None,
+            ),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+
+    with patch("godspeed.llm.client._get_litellm") as mock_litellm:
+        mock_litellm.return_value.acompletion = AsyncMock(return_value=mock_response)
+        await client._call("claude-sonnet-4-20250514", [{"role": "user", "content": "hi"}], None)
+
+        call_kwargs = mock_litellm.return_value.acompletion.call_args[1]
+        assert "thinking" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# ChatResponse: thinking field
+# ---------------------------------------------------------------------------
+
+
+def test_chat_response_thinking_field():
+    """ChatResponse includes thinking field."""
+    resp = ChatResponse(content="hello", thinking="I need to think about this...")
+    assert resp.thinking == "I need to think about this..."
+
+
+def test_chat_response_thinking_default_empty():
+    """ChatResponse thinking defaults to empty string."""
+    resp = ChatResponse(content="hello")
+    assert resp.thinking == ""
+
+
+# ---------------------------------------------------------------------------
+# Agent loop: on_thinking callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_thinking_callback_called(tmp_path):
+    """Agent loop calls on_thinking when response has thinking content."""
+    from godspeed.agent.conversation import Conversation
+    from godspeed.tools.base import ToolContext
+    from godspeed.tools.registry import ToolRegistry
+
+    # Mock LLM to return a response with thinking
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat = AsyncMock(
+        return_value=ChatResponse(
+            content="The answer is 42.",
+            thinking="Let me reason step by step...",
+            finish_reason="stop",
+        )
+    )
+    mock_llm.stream_chat = AsyncMock()
+
+    conversation = Conversation(system_prompt="test", model="test", max_tokens=10000)
+    registry = ToolRegistry()
+    context = ToolContext(cwd=tmp_path, session_id="test")
+
+    thinking_texts: list[str] = []
+
+    def capture_thinking(text: str) -> None:
+        thinking_texts.append(text)
+
+    from godspeed.agent.loop import agent_loop
+
+    await agent_loop(
+        user_input="What is the meaning of life?",
+        conversation=conversation,
+        llm_client=mock_llm,
+        tool_registry=registry,
+        tool_context=context,
+        on_thinking=capture_thinking,
+    )
+
+    assert len(thinking_texts) == 1
+    assert "step by step" in thinking_texts[0]
+
+
+@pytest.mark.asyncio
+async def test_on_thinking_not_called_when_empty(tmp_path):
+    """Agent loop does not call on_thinking when thinking is empty."""
+    from godspeed.agent.conversation import Conversation
+    from godspeed.tools.base import ToolContext
+    from godspeed.tools.registry import ToolRegistry
+
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.chat = AsyncMock(
+        return_value=ChatResponse(
+            content="Hello!",
+            thinking="",
+            finish_reason="stop",
+        )
+    )
+
+    conversation = Conversation(system_prompt="test", model="test", max_tokens=10000)
+    registry = ToolRegistry()
+    context = ToolContext(cwd=tmp_path, session_id="test")
+
+    thinking_texts: list[str] = []
+
+    from godspeed.agent.loop import agent_loop
+
+    await agent_loop(
+        user_input="Hi",
+        conversation=conversation,
+        llm_client=mock_llm,
+        tool_registry=registry,
+        tool_context=context,
+        on_thinking=lambda t: thinking_texts.append(t),
+    )
+
+    assert len(thinking_texts) == 0
+
+
+# ---------------------------------------------------------------------------
+# TUI: /think command
+# ---------------------------------------------------------------------------
+
+
+def test_think_command_toggle_on(tmp_path):
+    """'/think' toggles thinking ON with default 10k budget."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.thinking_budget = 0
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/think")
+    assert result.handled
+    assert llm_client.thinking_budget == 10_000
+
+
+def test_think_command_toggle_off(tmp_path):
+    """'/think' toggles thinking OFF when already on."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.thinking_budget = 10_000
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/think")
+    assert result.handled
+    assert llm_client.thinking_budget == 0
+
+
+def test_think_command_set_budget(tmp_path):
+    """'/think 20000' sets a custom budget."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.thinking_budget = 0
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/think 20000")
+    assert result.handled
+    assert llm_client.thinking_budget == 20_000
+
+
+def test_think_command_reject_small_budget(tmp_path):
+    """'/think 500' rejects budgets under 1000."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.thinking_budget = 0
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/think 500")
+    assert result.handled
+    assert llm_client.thinking_budget == 0  # unchanged
+
+
+def test_think_command_off_keyword(tmp_path):
+    """'/think off' explicitly disables."""
+    from godspeed.tui.commands import Commands
+
+    llm_client = MagicMock()
+    llm_client.thinking_budget = 10_000
+    commands = Commands(
+        conversation=MagicMock(),
+        llm_client=llm_client,
+        permission_engine=MagicMock(),
+        audit_trail=None,
+        session_id="test",
+        cwd=tmp_path,
+    )
+    result = commands.dispatch("/think off")
+    assert result.handled
+    assert llm_client.thinking_budget == 0
+
+
+# ---------------------------------------------------------------------------
+# TUI: format_thinking
+# ---------------------------------------------------------------------------
+
+
+def test_format_thinking_nonempty(capsys):
+    """format_thinking displays non-empty text."""
+    from godspeed.tui.output import format_thinking
+
+    # Just verify it doesn't raise
+    format_thinking("I'm thinking about this problem...")
+
+
+def test_format_thinking_empty():
+    """format_thinking does nothing for empty text."""
+    from godspeed.tui.output import format_thinking
+
+    format_thinking("")  # Should not raise
+    format_thinking("   ")  # Whitespace only

--- a/tests/test_tools/test_github.py
+++ b/tests/test_tools/test_github.py
@@ -1,0 +1,295 @@
+"""Tests for GitHub tool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+from godspeed.tools.github import GithubTool
+
+
+@pytest.fixture
+def tool() -> GithubTool:
+    return GithubTool()
+
+
+def _mock_run_gh(
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+) -> AsyncMock:
+    """Build an AsyncMock that returns (returncode, stdout, stderr) tuple."""
+    return AsyncMock(return_value=(returncode, stdout, stderr))
+
+
+class TestGithubToolMetadata:
+    """Basic tool metadata checks."""
+
+    def test_name(self, tool: GithubTool) -> None:
+        assert tool.name == "github"
+
+    def test_risk_level(self, tool: GithubTool) -> None:
+        assert tool.risk_level == "high"
+
+    def test_schema_has_action(self, tool: GithubTool) -> None:
+        schema = tool.get_schema()
+        assert "action" in schema["properties"]
+        assert schema["required"] == ["action"]
+
+
+class TestGhNotInstalled:
+    """gh CLI missing — graceful error."""
+
+    @pytest.mark.asyncio
+    async def test_gh_not_installed(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        with patch("godspeed.tools.github.shutil.which", return_value=None):
+            result = await tool.execute({"action": "list_prs"}, tool_context)
+
+        assert result.is_error
+        assert "gh CLI is not installed" in (result.error or "")
+
+
+class TestInvalidAction:
+    """Unknown action rejected."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_action(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        result = await tool.execute({"action": "delete_repo"}, tool_context)
+        assert result.is_error
+        assert "Invalid action" in (result.error or "")
+
+
+class TestCreatePr:
+    """create_pr action."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        pr_url = "https://github.com/o/r/pull/42"
+        mock = _mock_run_gh(stdout=pr_url)
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute(
+                {"action": "create_pr", "title": "feat", "body": "desc", "base": "main"},
+                tool_context,
+            )
+
+        assert not result.is_error
+        assert "42" in result.output
+
+    @pytest.mark.asyncio
+    async def test_missing_title(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        with patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"):
+            result = await tool.execute({"action": "create_pr"}, tool_context)
+
+        assert result.is_error
+        assert "title is required" in (result.error or "")
+
+
+class TestListPrs:
+    """list_prs action."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        data = [{"number": 1, "title": "pr1", "state": "open", "author": {"login": "u"}}]
+        mock = _mock_run_gh(stdout=json.dumps(data))
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute({"action": "list_prs"}, tool_context)
+
+        assert not result.is_error
+        assert "pr1" in result.output
+
+
+class TestGetPr:
+    """get_pr action."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        data = {"number": 5, "title": "fix bug", "state": "open", "body": "details"}
+        mock = _mock_run_gh(stdout=json.dumps(data))
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute({"action": "get_pr", "number": 5}, tool_context)
+
+        assert not result.is_error
+        assert "fix bug" in result.output
+
+    @pytest.mark.asyncio
+    async def test_missing_number(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        with patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"):
+            result = await tool.execute({"action": "get_pr"}, tool_context)
+
+        assert result.is_error
+        assert "number is required" in (result.error or "")
+
+
+class TestListIssues:
+    """list_issues action."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        data = [{"number": 10, "title": "bug", "state": "open", "labels": []}]
+        mock = _mock_run_gh(stdout=json.dumps(data))
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute(
+                {"action": "list_issues", "state": "open", "labels": "bug"},
+                tool_context,
+            )
+
+        assert not result.is_error
+        assert "bug" in result.output
+
+
+class TestGetIssue:
+    """get_issue action."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        data = {"number": 3, "title": "feature req", "state": "open", "body": "want this"}
+        mock = _mock_run_gh(stdout=json.dumps(data))
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute({"action": "get_issue", "number": 3}, tool_context)
+
+        assert not result.is_error
+        assert "feature req" in result.output
+
+    @pytest.mark.asyncio
+    async def test_missing_number(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        with patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"):
+            result = await tool.execute({"action": "get_issue"}, tool_context)
+
+        assert result.is_error
+        assert "number is required" in (result.error or "")
+
+
+class TestCreateIssue:
+    """create_issue action."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        issue_url = "https://github.com/o/r/issues/7"
+        mock = _mock_run_gh(stdout=issue_url)
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute(
+                {"action": "create_issue", "title": "new", "body": "desc", "labels": "enhancement"},
+                tool_context,
+            )
+
+        assert not result.is_error
+        assert "7" in result.output
+
+    @pytest.mark.asyncio
+    async def test_missing_title(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        with patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"):
+            result = await tool.execute({"action": "create_issue"}, tool_context)
+
+        assert result.is_error
+        assert "title is required" in (result.error or "")
+
+
+class TestCommentIssue:
+    """comment_issue action."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        mock = _mock_run_gh(stdout="")
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute(
+                {"action": "comment_issue", "number": 10, "body": "LGTM"},
+                tool_context,
+            )
+
+        assert not result.is_error
+        assert "Commented on issue #10" in result.output
+
+    @pytest.mark.asyncio
+    async def test_missing_body(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        with patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"):
+            result = await tool.execute({"action": "comment_issue", "number": 10}, tool_context)
+
+        assert result.is_error
+        assert "body is required" in (result.error or "")
+
+
+class TestCommentPr:
+    """comment_pr action."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        mock = _mock_run_gh(stdout="")
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute(
+                {"action": "comment_pr", "number": 5, "body": "Nice work"},
+                tool_context,
+            )
+
+        assert not result.is_error
+        assert "Commented on PR #5" in result.output
+
+    @pytest.mark.asyncio
+    async def test_missing_body(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        with patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"):
+            result = await tool.execute({"action": "comment_pr", "number": 5}, tool_context)
+
+        assert result.is_error
+        assert "body is required" in (result.error or "")
+
+
+class TestSubprocessErrors:
+    """Timeout and failure cases."""
+
+    @pytest.mark.asyncio
+    async def test_timeout(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", AsyncMock(side_effect=TimeoutError)),
+        ):
+            result = await tool.execute({"action": "list_prs"}, tool_context)
+
+        assert result.is_error
+        assert "timed out" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit(self, tool: GithubTool, tool_context: ToolContext) -> None:
+        mock = _mock_run_gh(stderr="not found", returncode=1)
+
+        with (
+            patch("godspeed.tools.github.shutil.which", return_value="/usr/bin/gh"),
+            patch("godspeed.tools.github._run_gh", mock),
+        ):
+            result = await tool.execute({"action": "list_prs"}, tool_context)
+
+        assert result.is_error
+        assert "not found" in (result.error or "")

--- a/tests/test_tools/test_repo_map.py
+++ b/tests/test_tools/test_repo_map.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,8 @@ import pytest
 from godspeed.context.repo_map import RepoMapper, Symbol
 from godspeed.tools.base import ToolContext
 from godspeed.tools.repo_map import RepoMapTool
+
+_has_tree_sitter = importlib.util.find_spec("tree_sitter_language_pack") is not None
 
 
 @pytest.fixture
@@ -21,6 +24,13 @@ def tool() -> RepoMapTool:
     return RepoMapTool()
 
 
+_skip_no_treesitter = pytest.mark.skipif(
+    not _has_tree_sitter,
+    reason="requires godspeed[context]",
+)
+
+
+@_skip_no_treesitter
 class TestRepoMapper:
     """Test the tree-sitter symbol extraction."""
 
@@ -144,6 +154,7 @@ class TestSymbol:
         assert "  method(L3)" in formatted
 
 
+@_skip_no_treesitter
 class TestRepoMapTool:
     """Test the tool wrapper."""
 

--- a/tests/test_tui_output.py
+++ b/tests/test_tui_output.py
@@ -10,6 +10,8 @@ from rich.console import Console
 from godspeed.tui.output import (
     format_assistant_text,
     format_error,
+    format_parallel_results,
+    format_parallel_tool_calls,
     format_permission_denied,
     format_permission_prompt,
     format_session_summary,
@@ -325,3 +327,107 @@ class TestDecorativeElements:
         }
         output = _capture(format_tool_call, "file_edit", args)
         assert "\u2502" in output  # │ gutter
+
+
+class TestFormatParallelToolCalls:
+    """Test grouped header for parallel tool dispatch."""
+
+    def test_shows_count(self) -> None:
+        calls = [
+            ("file_read", {"file_path": "a.py"}),
+            ("grep_search", {"pattern": "TODO"}),
+            ("shell", {"command": "ls"}),
+        ]
+        output = _capture(format_parallel_tool_calls, calls)
+        assert "3 tools" in output
+        assert "parallel" in output
+
+    def test_shows_tool_names(self) -> None:
+        calls = [
+            ("file_read", {"file_path": "main.py"}),
+            ("shell", {"command": "echo hi"}),
+        ]
+        output = _capture(format_parallel_tool_calls, calls)
+        assert "file_read" in output
+        assert "shell" in output
+
+    def test_shows_primary_arg(self) -> None:
+        calls = [("file_read", {"file_path": "src/app.py"})]
+        output = _capture(format_parallel_tool_calls, calls)
+        assert "src/app.py" in output
+
+    def test_truncates_long_arg(self) -> None:
+        long_path = "a/" * 30 + "file.py"
+        calls = [("file_read", {"file_path": long_path})]
+        output = _capture(format_parallel_tool_calls, calls)
+        assert "..." in output
+
+    def test_has_parallel_marker(self) -> None:
+        calls = [("file_read", {"file_path": "x.py"}), ("shell", {"command": "ls"})]
+        output = _capture(format_parallel_tool_calls, calls)
+        assert "\u26a1" in output  # ⚡ parallel marker
+
+    def test_has_tool_markers(self) -> None:
+        calls = [("file_read", {"file_path": "x.py"}), ("shell", {"command": "ls"})]
+        output = _capture(format_parallel_tool_calls, calls)
+        assert "\u25b8" in output  # ▸ tool marker
+
+    def test_empty_args(self) -> None:
+        calls = [("custom_tool", {})]
+        output = _capture(format_parallel_tool_calls, calls)
+        assert "1 tools" in output
+        assert "custom_tool" in output
+
+
+class TestFormatParallelResults:
+    """Test batch summary of parallel tool results."""
+
+    def test_all_success(self) -> None:
+        results = [
+            ("file_read", "contents of file", False),
+            ("shell", "output", False),
+        ]
+        output = _capture(format_parallel_results, results)
+        assert "\u2713" in output  # ✓ success marker
+        assert "file_read" in output
+        assert "shell" in output
+
+    def test_all_errors(self) -> None:
+        results = [
+            ("shell", "command not found", True),
+            ("file_read", "file not found", True),
+        ]
+        output = _capture(format_parallel_results, results)
+        assert "\u2717" in output  # ✗ error marker
+        assert "command not found" in output
+        assert "file not found" in output
+
+    def test_mixed_success_and_error(self) -> None:
+        results = [
+            ("file_read", "ok", False),
+            ("shell", "Permission denied", True),
+        ]
+        output = _capture(format_parallel_results, results)
+        assert "\u2713" in output  # ✓ for success
+        assert "\u2717" in output  # ✗ for error
+        assert "file_read" in output
+        assert "Permission denied" in output
+
+    def test_empty_error_output(self) -> None:
+        results = [("shell", "", True)]
+        output = _capture(format_parallel_results, results)
+        assert "no output" in output
+
+    def test_long_error_truncated(self) -> None:
+        long_line = "x" * 200
+        results = [("shell", long_line, True)]
+        output = _capture(format_parallel_results, results)
+        assert "..." in output
+
+    def test_success_uses_dot_separator(self) -> None:
+        results = [
+            ("file_read", "ok", False),
+            ("shell", "ok", False),
+        ]
+        output = _capture(format_parallel_results, results)
+        assert "\u00b7" in output  # · dot separator

--- a/tests/test_verify_fix_retry.py
+++ b/tests/test_verify_fix_retry.py
@@ -1,0 +1,226 @@
+"""Tests for lint-fix retry loop (_verify_with_retry)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.tools.base import ToolResult
+from godspeed.tools.verify import (
+    _FIXABLE_LANGUAGES,
+    _verify_with_retry,
+)
+
+
+@pytest.fixture
+def tmp_py_file(tmp_path: Path) -> Path:
+    """Create a temporary Python file for testing."""
+    f = tmp_path / "example.py"
+    f.write_text("x = 1\n")
+    return f
+
+
+class TestVerifyFixRetry:
+    """Tests for the _verify_with_retry function."""
+
+    def test_clean_file_no_retry(self, tmp_py_file: Path) -> None:
+        """Clean file: verify runs once, returns pass — no fix needed."""
+        with (
+            patch(
+                "godspeed.tools.verify._one_shot_verify",
+                return_value=ToolResult.success("Verification passed (ruff): example.py"),
+            ) as mock_verify,
+            patch(
+                "godspeed.tools.verify._run_fix",
+            ) as mock_fix,
+        ):
+            result = _verify_with_retry(
+                resolved=tmp_py_file,
+                display_path="example.py",
+                lang="python",
+                cwd=tmp_py_file.parent,
+                max_retries=3,
+            )
+
+        assert "Verification passed" in result.output
+        assert not result.is_error
+        mock_verify.assert_called_once()
+        mock_fix.assert_not_called()
+
+    def test_fixable_issues_auto_fixed(self, tmp_py_file: Path) -> None:
+        """Mock ruff finding fixable issues: verify --fix runs, re-check passes."""
+        call_count = 0
+
+        def fake_verify(resolved, display_path, lang, cwd):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First check finds issues
+                return ToolResult.success("Lint issues in example.py (ruff):\nexample.py:1:1: F401")
+            # After fix, clean
+            return ToolResult.success("Verification passed (ruff): example.py")
+
+        with (
+            patch(
+                "godspeed.tools.verify._one_shot_verify",
+                side_effect=fake_verify,
+            ),
+            patch(
+                "godspeed.tools.verify._run_fix",
+            ) as mock_fix,
+        ):
+            result = _verify_with_retry(
+                resolved=tmp_py_file,
+                display_path="example.py",
+                lang="python",
+                cwd=tmp_py_file.parent,
+                max_retries=3,
+            )
+
+        assert "Auto-fixed" in result.output
+        assert "0 remaining" in result.output
+        assert not result.is_error
+        mock_fix.assert_called_once()
+
+    def test_unfixable_issues_stop_after_max_retries(self, tmp_py_file: Path) -> None:
+        """Unfixable issues: verify stops at max_retries."""
+        with (
+            patch(
+                "godspeed.tools.verify._one_shot_verify",
+                return_value=ToolResult.success(
+                    "Lint issues in example.py (ruff):\nexample.py:1:1: E999 SyntaxError"
+                ),
+            ),
+            patch(
+                "godspeed.tools.verify._run_fix",
+            ) as mock_fix,
+        ):
+            result = _verify_with_retry(
+                resolved=tmp_py_file,
+                display_path="example.py",
+                lang="python",
+                cwd=tmp_py_file.parent,
+                max_retries=3,
+            )
+
+        assert "some remaining" in result.output
+        assert not result.is_error
+        # Fix was attempted max_retries times
+        assert mock_fix.call_count == 3
+
+    def test_retry_count_configurable(self, tmp_py_file: Path) -> None:
+        """Set max_retries=1: verify only retries once."""
+        with (
+            patch(
+                "godspeed.tools.verify._one_shot_verify",
+                return_value=ToolResult.success(
+                    "Lint issues in example.py (ruff):\nexample.py:1:1: E999"
+                ),
+            ),
+            patch(
+                "godspeed.tools.verify._run_fix",
+            ) as mock_fix,
+        ):
+            result = _verify_with_retry(
+                resolved=tmp_py_file,
+                display_path="example.py",
+                lang="python",
+                cwd=tmp_py_file.parent,
+                max_retries=1,
+            )
+
+        assert "some remaining" in result.output
+        assert mock_fix.call_count == 1
+
+    def test_retry_disabled_when_zero(self, tmp_py_file: Path) -> None:
+        """max_retries=0: one-shot behavior, no fix attempted."""
+        with (
+            patch(
+                "godspeed.tools.verify._one_shot_verify",
+                return_value=ToolResult.success(
+                    "Lint issues in example.py (ruff):\nexample.py:1:1: F401"
+                ),
+            ) as mock_verify,
+            patch(
+                "godspeed.tools.verify._run_fix",
+            ) as mock_fix,
+        ):
+            result = _verify_with_retry(
+                resolved=tmp_py_file,
+                display_path="example.py",
+                lang="python",
+                cwd=tmp_py_file.parent,
+                max_retries=0,
+            )
+
+        # One-shot: returns the check result directly, no fix
+        assert "Lint issues" in result.output
+        mock_verify.assert_called_once()
+        mock_fix.assert_not_called()
+
+    def test_fix_summary_in_output(self, tmp_py_file: Path) -> None:
+        """Result includes 'Auto-fixed' message after successful fix."""
+        call_count = 0
+
+        def fake_verify(resolved, display_path, lang, cwd):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                # First two checks find issues
+                return ToolResult.success("Lint issues in example.py (ruff):\nexample.py:1:1: W291")
+            # Third check is clean
+            return ToolResult.success("Verification passed (ruff): example.py")
+
+        with (
+            patch(
+                "godspeed.tools.verify._one_shot_verify",
+                side_effect=fake_verify,
+            ),
+            patch(
+                "godspeed.tools.verify._run_fix",
+            ),
+        ):
+            result = _verify_with_retry(
+                resolved=tmp_py_file,
+                display_path="example.py",
+                lang="python",
+                cwd=tmp_py_file.parent,
+                max_retries=3,
+            )
+
+        assert "Auto-fixed" in result.output
+        assert "0 remaining" in result.output
+
+    def test_non_fixable_language_skips_retry(self, tmp_py_file: Path) -> None:
+        """Go/Rust/C++ files use one-shot verify, no retry loop."""
+        with (
+            patch(
+                "godspeed.tools.verify._one_shot_verify",
+                return_value=ToolResult.success("Build issues in main.go (go vet):\nerror"),
+            ) as mock_verify,
+            patch(
+                "godspeed.tools.verify._run_fix",
+            ) as mock_fix,
+        ):
+            result = _verify_with_retry(
+                resolved=tmp_py_file,
+                display_path="main.go",
+                lang="go",
+                cwd=tmp_py_file.parent,
+                max_retries=3,
+            )
+
+        assert "Build issues" in result.output
+        mock_verify.assert_called_once()
+        mock_fix.assert_not_called()
+
+    def test_fixable_languages_constant(self) -> None:
+        """Verify that only Python and JS/TS are in the fixable set."""
+        assert "python" in _FIXABLE_LANGUAGES
+        assert "javascript" in _FIXABLE_LANGUAGES
+        assert "typescript" in _FIXABLE_LANGUAGES
+        assert "go" not in _FIXABLE_LANGUAGES
+        assert "rust" not in _FIXABLE_LANGUAGES
+        assert "c_cpp" not in _FIXABLE_LANGUAGES


### PR DESCRIPTION
## Summary

- **Extended thinking**: `thinking` parameter for Anthropic/Claude models, `/think [budget]` command, collapsible TUI display
- **Cost budgets**: Hard cost limit via `max_cost_usd`, `BudgetExceededError` stops agent, `/budget` command
- **Architect mode**: `/architect` toggles two-phase plan-then-execute pipeline (read-only planning → full execution)
- **8 new tools**: `image_read`, `pdf_read`, `notebook_edit`, `github`, `background_check`, `diff_apply` + notebook support in `file_read` + background mode in `shell`
- **Speculative tool execution**: READ_ONLY tools dispatch during streaming before response completes — eliminates dispatch latency
- **Risk-based parallel/serial dispatch**: Phase 3 partitions by RiskLevel — reads parallel via `asyncio.gather()`, writes serial
- **Cheapest-model compaction**: `_compact_conversation()` selects cheapest model from fallback chain
- **Typed event system**: 11 frozen dataclass event types (`AgentEvent` union) for composable agent loop consumption

## Stats

- **53 files changed**, +9,603 lines
- **1,212 tests passing** (250+ new)
- `ruff check` and `ruff format` clean
- No hardcoded secrets, no bare `except:`, no `print()` in production
- `from __future__ import annotations` on all new modules
- Version bumped to `2.1.0` in `pyproject.toml`, `__init__.py`, and `CHANGELOG.md`

## Test plan

- [x] `ruff check . --fix && ruff format .` — all clean
- [x] `pytest --tb=short -q` — 1,212 passed, 13 skipped (pre-existing tree-sitter dep)
- [x] Security audit: no secrets, no bare except, no print(), path traversal protection on all file tools
- [x] Type hints on all public functions
- [ ] CI pipeline (lint → type-check → security → test matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)