### PR TITLE
feat(v2.5.0): MLOps-readiness — exit codes, timeout, audit, retry, prompt-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.4.0] — 2026-04-16
+## [2.5.0] — 2026-04-16
+
+MLOps-readiness release. Closes the headless/pipeline gaps found in the
+feature + logic audit on 2026-04-16. The `godspeed run` command is now
+suitable for unattended use in CI, W&B sweeps, and ML research pipelines.
+
+### Added
+
+- **Exit code contract** (`godspeed.agent.result.ExitCode`). `godspeed run`
+  now returns differentiated exit codes so orchestrators can switch on them:
+  `0` success, `1` tool error, `2` max iterations, `3` budget exceeded,
+  `4` LLM error, `5` invalid input, `6` timeout, `130` interrupted. Codes
+  are stable across minor versions.
+- **JSON output schema extended** with `exit_reason`, `exit_code`,
+  `iterations_used`, `tool_calls` (list of `{name, is_error}`),
+  `tool_call_count`, `tool_error_count`, `duration_seconds`, `cost_usd`,
+  and `audit_log_path`. Existing fields preserved.
+- **`--timeout N`** wall-clock session cap on `godspeed run`. Wraps the
+  agent loop in `asyncio.wait_for`; exits with code 6 on timeout. Default
+  `0` (no limit) preserves existing behavior.
+- **`--prompt-file FILE`** flag on `godspeed run` reads the task from a
+  file. Task input precedence: `--prompt-file` > positional > stdin.
+  Passing `-` as the positional task reads from stdin; an empty positional
+  with a piped stdin also reads from stdin.
+- **Rate-limit retry with exponential backoff + jitter** in `LLMClient`.
+  429/quota errors now retry up to 4 times on the same model (delays
+  1s/2s/4s/8s ± 25% jitter, capped at 60s) before falling over to the
+  next model. Honors `Retry-After` when the provider supplies it
+  (upward-only jitter — we don't retry earlier than the provider asked).
+- **`AgentMetrics`** accumulator on `agent_loop()` via the new optional
+  `metrics` kwarg. Populates `iterations_used`, `tool_calls`,
+  `exit_reason`, `duration_seconds`.
+
+### Changed
+
+- **Headless mode now has an audit trail by default**. Previously
+  `godspeed run` wired `audit=None` into the tool context — unattended
+  sessions had no tamper-evident log, the opposite of the project's
+  security posture. Audit now writes to `~/.godspeed/audit/{session}.audit.jsonl`
+  with session-start and session-end records bookending every run.
+- `agent_loop()` gains the optional `metrics: AgentMetrics | None` kwarg.
+  Omitting it preserves the prior behavior exactly — backwards-compatible.
+
+### Fixed
+
+- Addresses G1–G7 from the 2026-04-16 feature audit.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you want a coding agent you can actually point at a production codebase, this
 - **Cross-agent project instructions** -- loads `GODSPEED.md`, `AGENTS.md` (Linux Foundation standard), `CLAUDE.md`, and `.cursorrules`. Zero-friction migration from any agent.
 - **Token cost tracking** -- real-time token usage and estimated cost per session. `/stats` command. Supports 20+ model pricing tiers. Local models always show "free".
 - **Prompt caching** -- system prompt marked with `cache_control` for Anthropic/OpenAI. ~50% cost reduction on repeated prefixes.
-- **Headless/CI mode** -- `godspeed run "task" --headless` for non-interactive execution. Auto-approve levels, JSON output, exit codes for CI/CD integration.
+- **Headless/CI mode** -- `godspeed run` for non-interactive execution. Task from positional arg, `--prompt-file`, or stdin. `--timeout N` wall-clock cap. Differentiated exit codes (0 success, 1 tool error, 2 max iterations, 3 budget, 4 LLM error, 5 invalid input, 6 timeout, 130 interrupt) for pipeline orchestration. JSON output includes `exit_reason`, `iterations_used`, `tool_calls`, `cost_usd`, `duration_seconds`, `audit_log_path`. Audit trail is written by default.
 - **Web tools** -- `web_search` (DuckDuckGo, no API key) and `web_fetch` (HTML-to-text extraction) let the agent look up documentation and error messages.
 - **Multi-language verify** -- auto-verification after edits supports Python (ruff), JS/TS (biome/eslint), Go (go vet), Rust (cargo check), C/C++ (clang-tidy). Lint-fix retry loop up to 3 rounds.
 - **Test runner** -- auto-detect pytest, jest, vitest, go test, cargo test. Run targeted or full test suites. Agent-accessible for edit-test-fix loops.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed"
-version = "2.4.0"
+version = "2.5.0"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from typing import Any
 
 from godspeed.agent.conversation import Conversation
+from godspeed.agent.result import AgentMetrics, ExitReason
 from godspeed.llm.client import ChatResponse, LLMClient
 from godspeed.tools.base import ToolCall, ToolContext, ToolResult
 from godspeed.tools.registry import ToolRegistry
@@ -73,6 +74,7 @@ async def agent_loop(
     on_parallel_start: OnParallelStart | None = None,
     on_parallel_complete: OnParallelComplete | None = None,
     on_thinking: OnThinking | None = None,
+    metrics: AgentMetrics | None = None,
 ) -> str:
     """Run the agent loop until the model stops calling tools.
 
@@ -158,8 +160,14 @@ async def agent_loop(
                     "Use /budget to increase the limit."
                 )
                 logger.warning("Budget exceeded spent=%.4f limit=%.2f", exc.spent, exc.limit)
+                if metrics is not None:
+                    metrics.iterations_used = iteration
+                    metrics.finalize(ExitReason.BUDGET_EXCEEDED)
                 return msg
             logger.error("LLM call failed error=%s", exc, exc_info=True)
+            if metrics is not None:
+                metrics.iterations_used = iteration
+                metrics.finalize(ExitReason.LLM_ERROR)
             return f"Error: LLM call failed — {exc}"
 
         # Display thinking blocks (extended thinking for Anthropic models)
@@ -174,6 +182,9 @@ async def agent_loop(
                 # Skip Markdown re-render if we already streamed the text
                 if on_assistant_text and on_assistant_chunk is None:
                     on_assistant_text(final_text)
+            if metrics is not None:
+                metrics.iterations_used = iteration + 1
+                metrics.finalize(ExitReason.STOPPED)
             return final_text
 
         # Handle tool calls
@@ -197,6 +208,9 @@ async def agent_loop(
             if tool_call is None:
                 retries += 1
                 if retries > MAX_RETRIES:
+                    if metrics is not None:
+                        metrics.iterations_used = iteration + 1
+                        metrics.finalize(ExitReason.TOOL_ERROR)
                     return "Error: Too many malformed tool calls from the model."
                 conversation.add_tool_result(
                     tool_call_id=raw_tc.get("id", ""),
@@ -310,6 +324,9 @@ async def agent_loop(
 
                 if on_tool_result:
                     on_tool_result(tool_call.tool_name, result)
+
+                if metrics is not None:
+                    metrics.record_tool_call(tool_call.tool_name, result.is_error)
 
                 # Audit — use batch latency split evenly as approximation
                 if tool_context.audit is not None:
@@ -486,6 +503,9 @@ async def agent_loop(
                 if on_tool_result:
                     on_tool_result(tool_call.tool_name, result)
 
+                if metrics is not None:
+                    metrics.record_tool_call(tool_call.tool_name, result.is_error)
+
                 # Record audit event with latency
                 if tool_context.audit is not None:
                     tool_context.audit.record(
@@ -612,6 +632,9 @@ async def agent_loop(
                 else:
                     recent_error_hashes.clear()
 
+    if metrics is not None:
+        metrics.iterations_used = iteration_limit
+        metrics.finalize(ExitReason.MAX_ITERATIONS)
     return "Error: Reached maximum iterations. The task may be too complex for a single turn."
 
 

--- a/src/godspeed/agent/result.py
+++ b/src/godspeed/agent/result.py
@@ -1,0 +1,105 @@
+"""Agent loop result, metrics sink, and exit code contract.
+
+The agent loop is driven both interactively (TUI) and unattended (headless/CI).
+Interactive callers only need the final text. Unattended callers need
+structured outcomes so an orchestrator can decide what to do next — retry on
+LLM error, bail on budget, escalate on permission denial, etc.
+
+`AgentMetrics` is a mutable accumulator the loop populates as it runs.
+`ExitCode` is the headless exit-code contract exposed on `godspeed run`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import time
+
+
+class ExitCode(enum.IntEnum):
+    """Headless exit codes. Documented and stable across minor versions.
+
+    An orchestrator script can switch on the exit code to decide retry
+    behavior. Never repurpose an existing code; add new ones only.
+    """
+
+    SUCCESS = 0
+    TOOL_ERROR = 1
+    MAX_ITERATIONS = 2
+    BUDGET_EXCEEDED = 3
+    LLM_ERROR = 4
+    INVALID_INPUT = 5
+    TIMEOUT = 6
+    INTERRUPTED = 130
+
+
+class ExitReason(enum.StrEnum):
+    """Human-readable counterpart to ExitCode, emitted in JSON output."""
+
+    STOPPED = "stopped"
+    TOOL_ERROR = "tool_error"
+    MAX_ITERATIONS = "max_iterations"
+    BUDGET_EXCEEDED = "budget_exceeded"
+    LLM_ERROR = "llm_error"
+    INVALID_INPUT = "invalid_input"
+    TIMEOUT = "timeout"
+    INTERRUPTED = "interrupted"
+
+
+EXIT_REASON_TO_CODE: dict[ExitReason, ExitCode] = {
+    ExitReason.STOPPED: ExitCode.SUCCESS,
+    ExitReason.TOOL_ERROR: ExitCode.TOOL_ERROR,
+    ExitReason.MAX_ITERATIONS: ExitCode.MAX_ITERATIONS,
+    ExitReason.BUDGET_EXCEEDED: ExitCode.BUDGET_EXCEEDED,
+    ExitReason.LLM_ERROR: ExitCode.LLM_ERROR,
+    ExitReason.INVALID_INPUT: ExitCode.INVALID_INPUT,
+    ExitReason.TIMEOUT: ExitCode.TIMEOUT,
+    ExitReason.INTERRUPTED: ExitCode.INTERRUPTED,
+}
+
+
+@dataclasses.dataclass(slots=True)
+class ToolCallRecord:
+    """One tool invocation, as seen by the loop."""
+
+    name: str
+    is_error: bool
+
+
+@dataclasses.dataclass(slots=True)
+class AgentMetrics:
+    """Mutable accumulator populated by the agent loop as it runs.
+
+    Interactive callers can ignore this. Headless/CI callers pass an instance
+    in and read it after the loop returns to build the JSON result.
+    """
+
+    iterations_used: int = 0
+    exit_reason: ExitReason = ExitReason.STOPPED
+    tool_calls: list[ToolCallRecord] = dataclasses.field(default_factory=list)
+    start_time: float = dataclasses.field(default_factory=time.monotonic)
+    end_time: float | None = None
+
+    def record_tool_call(self, name: str, is_error: bool) -> None:
+        self.tool_calls.append(ToolCallRecord(name=name, is_error=is_error))
+
+    def finalize(self, reason: ExitReason) -> None:
+        self.exit_reason = reason
+        self.end_time = time.monotonic()
+
+    @property
+    def duration_seconds(self) -> float:
+        end = self.end_time if self.end_time is not None else time.monotonic()
+        return end - self.start_time
+
+    @property
+    def tool_call_count(self) -> int:
+        return len(self.tool_calls)
+
+    @property
+    def tool_error_count(self) -> int:
+        return sum(1 for tc in self.tool_calls if tc.is_error)
+
+    @property
+    def exit_code(self) -> ExitCode:
+        return EXIT_REASON_TO_CODE[self.exit_reason]

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -576,7 +576,7 @@ def init() -> None:
 
 
 @main.command("run")
-@click.argument("task")
+@click.argument("task", required=False, default="")
 @click.option("--model", "-m", default="", help="Model to use.")
 @click.option(
     "--project-dir",
@@ -593,7 +593,19 @@ def init() -> None:
     help="Auto-approve permission level (default: reads).",
 )
 @click.option("--max-iterations", type=int, default=50, help="Max agent loop iterations.")
+@click.option(
+    "--timeout",
+    type=int,
+    default=0,
+    help="Wall-clock session timeout in seconds (0 = no limit).",
+)
 @click.option("--json-output", is_flag=True, help="Output result as JSON.")
+@click.option(
+    "--prompt-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Read the task from a file instead of the positional argument.",
+)
 def headless_run(
     task: str,
     model: str,
@@ -601,26 +613,80 @@ def headless_run(
     verbose: bool,
     auto_approve: str,
     max_iterations: int,
+    timeout: int,
     json_output: bool,
+    prompt_file: Path | None,
 ) -> None:
     """Run a task non-interactively (headless/CI mode).
 
     Executes the agent loop without a TUI. Permissions are auto-approved
     based on --auto-approve level. Outputs the final response to stdout.
 
+    Task input precedence:
+        1. --prompt-file FILE          (read task from file)
+        2. TASK positional argument    (passed as argument)
+        3. stdin                       (when TASK is '-' or omitted and stdin is a pipe)
+
+    Exit codes:
+        0   success — model stopped with a final text response
+        1   tool error — final response starts with "Error:"
+        2   max iterations reached without the model stopping
+        3   cost budget exceeded
+        4   LLM provider failure (all fallbacks exhausted)
+        5   invalid input (no task provided)
+        6   wall-clock timeout (--timeout exceeded)
+        130 keyboard interrupt (SIGINT)
+
     Examples:
         godspeed run "Fix the failing test in test_auth.py"
-        godspeed run "Add type hints to utils.py" --auto-approve all
-        godspeed run "Explain main.py" --json-output
+        godspeed run --prompt-file experiment.prompt --json-output
+        cat task.md | godspeed run -
+        godspeed run "Long running task" --timeout 1800
     """
+    from godspeed.agent.result import ExitCode
+
     _setup_logging(verbose)
-    try:
-        result = asyncio.run(
-            _headless_run(task, model, project_dir, auto_approve, max_iterations, json_output)
+
+    resolved_task = _resolve_task_input(task, prompt_file)
+    if not resolved_task:
+        sys.stderr.write(
+            "Error: No task provided. Pass a positional argument, use --prompt-file, "
+            "or pipe via stdin with `godspeed run -`.\n"
         )
-        sys.exit(0 if result else 1)
+        sys.exit(ExitCode.INVALID_INPUT)
+
+    try:
+        exit_code = asyncio.run(
+            _headless_run(
+                resolved_task,
+                model,
+                project_dir,
+                auto_approve,
+                max_iterations,
+                timeout,
+                json_output,
+            )
+        )
+        sys.exit(int(exit_code))
     except KeyboardInterrupt:
-        sys.exit(130)
+        sys.exit(ExitCode.INTERRUPTED)
+
+
+def _resolve_task_input(task_arg: str, prompt_file: Path | None) -> str:
+    """Resolve the task text from the available sources (in precedence order).
+
+    Returns an empty string when no task is available — the caller treats
+    that as INVALID_INPUT.
+    """
+    if prompt_file is not None:
+        return prompt_file.read_text(encoding="utf-8").strip()
+    if task_arg == "-":
+        return sys.stdin.read().strip()
+    if task_arg:
+        return task_arg
+    if not sys.stdin.isatty():
+        return sys.stdin.read().strip()
+    return ""
 
 
 async def _headless_run(
@@ -629,14 +695,23 @@ async def _headless_run(
     project_dir: Path,
     auto_approve: str,
     max_iterations: int,
+    timeout: int,
     json_output: bool,
-) -> bool:
-    """Execute the headless agent loop."""
+) -> int:
+    """Execute the headless agent loop.
+
+    Returns an ExitCode-compatible integer:
+        0 SUCCESS, 1 TOOL_ERROR, 2 MAX_ITERATIONS, 3 BUDGET_EXCEEDED,
+        4 LLM_ERROR, 6 TIMEOUT. Never returns INTERRUPTED (130) — the
+        caller translates KeyboardInterrupt.
+    """
     import json as json_module
 
     from godspeed.agent.conversation import Conversation
     from godspeed.agent.loop import agent_loop
+    from godspeed.agent.result import AgentMetrics, ExitCode, ExitReason
     from godspeed.agent.system_prompt import build_system_prompt
+    from godspeed.audit.trail import AuditTrail
     from godspeed.config import GodspeedSettings
     from godspeed.context.project_instructions import load_project_instructions
     from godspeed.llm.client import LLMClient, ModelRouter
@@ -651,6 +726,21 @@ async def _headless_run(
     effective_model = model or settings.model
     effective_project_dir = project_dir.resolve()
     session_id = str(uuid4())
+
+    # Audit trail — headless must have an audit trail by default. A
+    # security-first agent without a tamper-evident log in unattended mode
+    # is the worst of both worlds.
+    audit_dir = settings.global_dir / "audit"
+    audit_trail = AuditTrail(log_dir=audit_dir, session_id=session_id)
+    audit_trail.record(
+        event_type="session_start",
+        detail={
+            "mode": "headless",
+            "task": task[:500],  # clipped; full task goes to training logger
+            "model": effective_model,
+            "auto_approve": auto_approve,
+        },
+    )
 
     # Tools
     registry, risk_levels = _build_tool_registry()
@@ -688,12 +778,11 @@ async def _headless_run(
     if effective_model.lower().startswith("ollama"):
         _ensure_ollama()
 
-    # Build components
     tool_context = ToolContext(
         cwd=effective_project_dir,
         session_id=session_id,
         permissions=_HeadlessPermissionProxy(permission_engine, auto_approve),
-        audit=None,
+        audit=audit_trail,
     )
 
     project_instructions = load_project_instructions(
@@ -745,8 +834,12 @@ async def _headless_run(
         if is_error:
             logger.warning("Tool error: %s", name)
 
-    # Run agent loop
-    final_text = await agent_loop(
+    metrics = AgentMetrics()
+    timed_out = False
+    final_text: str
+
+    # Run agent loop, optionally under a wall-clock timeout.
+    loop_coro = agent_loop(
         user_input=task,
         conversation=conversation,
         llm_client=llm_client,
@@ -755,11 +848,47 @@ async def _headless_run(
         on_tool_call=on_tool_call,
         on_tool_result=on_tool_result,
         max_iterations=max_iterations,
+        metrics=metrics,
     )
+    try:
+        if timeout > 0:
+            final_text = await asyncio.wait_for(loop_coro, timeout=timeout)
+        else:
+            final_text = await loop_coro
+    except TimeoutError:
+        timed_out = True
+        final_text = f"Error: Session exceeded wall-clock timeout of {timeout}s."
+        metrics.finalize(ExitReason.TIMEOUT)
 
     # Close conversation logger
     if conversation_logger is not None:
         conversation_logger.close()
+
+    # Resolve final exit code. TOOL_ERROR overrides STOPPED when the model's
+    # final message starts with "Error:" (common pattern for tool failures
+    # that the model surfaces rather than silently ignoring).
+    exit_code = int(metrics.exit_code)
+    if (
+        not timed_out
+        and metrics.exit_reason == ExitReason.STOPPED
+        and final_text.startswith("Error:")
+    ):
+        exit_code = int(ExitCode.TOOL_ERROR)
+        metrics.exit_reason = ExitReason.TOOL_ERROR
+
+    audit_trail.record(
+        event_type="session_end",
+        detail={
+            "exit_reason": metrics.exit_reason.value,
+            "exit_code": exit_code,
+            "iterations_used": metrics.iterations_used,
+            "tool_call_count": metrics.tool_call_count,
+            "tool_error_count": metrics.tool_error_count,
+            "duration_seconds": round(metrics.duration_seconds, 3),
+            "cost_usd": round(llm_client.total_cost_usd, 6),
+        },
+        outcome="success" if exit_code == 0 else "error",
+    )
 
     # Output result to stdout
     if json_output:
@@ -768,14 +897,23 @@ async def _headless_run(
             "model": effective_model,
             "session_id": session_id,
             "response": final_text,
+            "exit_reason": metrics.exit_reason.value,
+            "exit_code": exit_code,
+            "iterations_used": metrics.iterations_used,
+            "tool_calls": [{"name": tc.name, "is_error": tc.is_error} for tc in metrics.tool_calls],
+            "tool_call_count": metrics.tool_call_count,
+            "tool_error_count": metrics.tool_error_count,
+            "duration_seconds": round(metrics.duration_seconds, 3),
             "input_tokens": llm_client.total_input_tokens,
             "output_tokens": llm_client.total_output_tokens,
+            "cost_usd": round(llm_client.total_cost_usd, 6),
+            "audit_log_path": str(audit_trail.log_path),
         }
         sys.stdout.write(json_module.dumps(output, indent=2) + "\n")
     else:
         sys.stdout.write(final_text + "\n")
 
-    return not final_text.startswith("Error:")
+    return exit_code
 
 
 @main.command()

--- a/src/godspeed/llm/client.py
+++ b/src/godspeed/llm/client.py
@@ -4,9 +4,27 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
+import re
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from typing import Any
+
+# Rate-limit retry policy
+RATE_LIMIT_MAX_RETRIES = 4
+RATE_LIMIT_BASE_DELAY = 1.0  # seconds — doubles each retry
+RATE_LIMIT_MAX_DELAY = 60.0  # hard ceiling — past this, give up and fall over
+RATE_LIMIT_JITTER = 0.25  # ±25% random jitter on each delay
+
+_RATE_LIMIT_MARKERS = (
+    "429",
+    "rate_limit",
+    "rate limit",
+    "ratelimiterror",
+    "too many requests",
+    "quota",
+)
+_RETRY_AFTER_RE = re.compile(r"retry-?after[:\s]+(\d+)", re.IGNORECASE)
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +171,57 @@ class LLMClient:
             for marker in ("connection refused", "cannot connect", "connect call failed")
         )
 
+    @staticmethod
+    def _is_rate_limit_error(exc: Exception) -> bool:
+        """Check if the error is a 429 / rate limit / quota error.
+
+        These are transient and should be retried with exponential backoff,
+        not failed over immediately (falling over from rate-limited primary
+        to a fallback often just rate-limits the fallback too).
+        """
+        exc_str = str(exc).lower()
+        # "429" appears in many unrelated contexts (ports, request IDs) — only
+        # count it when paired with a rate-limit word nearby.
+        if "429" in exc_str and any(w in exc_str for w in ("too many", "rate", "quota", "throttl")):
+            return True
+        return any(marker in exc_str for marker in _RATE_LIMIT_MARKERS if marker != "429")
+
+    @staticmethod
+    def _parse_retry_after(error_message: str) -> float | None:
+        """Extract a Retry-After hint (seconds) from the error message.
+
+        Returns None when no hint is present. Clamps to RATE_LIMIT_MAX_DELAY
+        so a misbehaving provider can't block the session for hours.
+        """
+        match = _RETRY_AFTER_RE.search(error_message)
+        if match is None:
+            return None
+        try:
+            hint = float(match.group(1))
+        except ValueError:
+            return None
+        return min(hint, RATE_LIMIT_MAX_DELAY)
+
+    @classmethod
+    def _backoff_delay(cls, retry_index: int, retry_after: float | None) -> float:
+        """Compute the sleep duration for the N-th retry (0-indexed).
+
+        If the provider supplied Retry-After, treat it as a floor and add
+        upward-only jitter (waiting *less* than the provider asked is
+        counterproductive — we'd just trigger another 429).
+
+        Otherwise use exponential backoff (base * 2^n) with ±25% jitter
+        to break up thundering-herd retries across concurrent agents.
+        Capped at RATE_LIMIT_MAX_DELAY.
+        """
+        if retry_after is not None:
+            # Retry jitter for backoff — not a security context, so random.uniform is fine.
+            jitter = 1.0 + random.uniform(0.0, RATE_LIMIT_JITTER)  # noqa: S311
+            return min(retry_after * jitter, RATE_LIMIT_MAX_DELAY)
+        base = min(RATE_LIMIT_BASE_DELAY * (2**retry_index), RATE_LIMIT_MAX_DELAY)
+        jitter = 1.0 + random.uniform(-RATE_LIMIT_JITTER, RATE_LIMIT_JITTER)  # noqa: S311
+        return min(max(base * jitter, 0.0), RATE_LIMIT_MAX_DELAY)
+
     async def chat(
         self,
         messages: list[dict[str, Any]],
@@ -188,7 +257,17 @@ class LLMClient:
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
     ) -> ChatResponse:
-        """Internal: send messages with fallback chain."""
+        """Internal: send messages with fallback chain.
+
+        Classification of failures:
+        - Connection errors: server is down; skip retry, try next fallback.
+        - Rate-limit / 429 / quota: retry the SAME model with exponential
+          backoff + jitter up to RATE_LIMIT_MAX_RETRIES, honoring
+          Retry-After when provided. Falling over to a fallback on
+          rate-limit often just rate-limits the fallback too.
+        - Other errors: one short retry on the primary model, then fall
+          over to the next model in the chain.
+        """
         models_to_try = [self._effective_model(), *self.fallback_models]
 
         last_error: Exception | None = None
@@ -198,9 +277,20 @@ class LLMClient:
             except Exception as exc:
                 logger.warning("LLM call failed model=%s error=%s", model, exc)
                 last_error = exc
-                # Skip retry for connection errors — server is down, retrying is pointless
+
                 if self._is_connection_error(exc):
+                    # Server down — retrying is pointless, try next fallback.
                     continue
+
+                if self._is_rate_limit_error(exc):
+                    # Retry same model with exponential backoff + jitter.
+                    recovered = await self._retry_on_rate_limit(model, messages, tools, exc)
+                    if recovered is not None:
+                        return recovered
+                    # Exhausted rate-limit retries; move on to the next model.
+                    last_error = exc
+                    continue
+
                 # Retry primary model once after short delay before trying fallbacks
                 if idx == 0:
                     await asyncio.sleep(1)
@@ -215,6 +305,47 @@ class LLMClient:
                         last_error = retry_exc
 
         raise self._build_failure_error(last_error)
+
+    async def _retry_on_rate_limit(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        first_exc: Exception,
+    ) -> ChatResponse | None:
+        """Retry a rate-limited call with exponential backoff + jitter.
+
+        Returns the successful ChatResponse, or None if retries are exhausted.
+        Caller decides what to do with a None result (typically fall over to
+        the next model in the chain).
+        """
+        current_exc: Exception = first_exc
+        for attempt in range(RATE_LIMIT_MAX_RETRIES):
+            retry_after = self._parse_retry_after(str(current_exc))
+            delay = self._backoff_delay(attempt, retry_after)
+            logger.warning(
+                "Rate limit model=%s attempt=%d/%d delay=%.2fs retry_after=%s",
+                model,
+                attempt + 1,
+                RATE_LIMIT_MAX_RETRIES,
+                delay,
+                retry_after,
+            )
+            await asyncio.sleep(delay)
+            try:
+                return await self._call(model, messages, tools)
+            except Exception as exc:
+                if not self._is_rate_limit_error(exc):
+                    # Morphed into a different kind of failure — let the
+                    # outer loop handle it (fall over, build failure, etc.).
+                    raise
+                current_exc = exc
+        logger.warning(
+            "Rate limit retries exhausted model=%s after %d attempts",
+            model,
+            RATE_LIMIT_MAX_RETRIES,
+        )
+        return None
 
     def _build_failure_error(self, last_error: Exception | None) -> RuntimeError:
         """Build an actionable error message based on the failure type."""

--- a/tests/test_agent_result.py
+++ b/tests/test_agent_result.py
@@ -1,0 +1,211 @@
+"""Tests for the agent result/metrics contract (v2.5.0)."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from godspeed.agent.conversation import Conversation
+from godspeed.agent.loop import agent_loop
+from godspeed.agent.result import (
+    EXIT_REASON_TO_CODE,
+    AgentMetrics,
+    ExitCode,
+    ExitReason,
+    ToolCallRecord,
+)
+from godspeed.llm.client import BudgetExceededError, ChatResponse, LLMClient
+from godspeed.tools.base import ToolResult
+from godspeed.tools.registry import ToolRegistry
+from tests.conftest import MockTool
+
+
+def _text_resp(text: str) -> ChatResponse:
+    return ChatResponse(content=text, tool_calls=[], finish_reason="stop")
+
+
+def _tool_resp(name: str, args: dict[str, Any]) -> ChatResponse:
+    return ChatResponse(
+        content="",
+        tool_calls=[{"id": "call_1", "function": {"name": name, "arguments": json.dumps(args)}}],
+        finish_reason="tool_calls",
+    )
+
+
+class TestExitCode:
+    """Exit code contract — values are stable and documented."""
+
+    def test_success_is_zero(self) -> None:
+        assert ExitCode.SUCCESS == 0
+
+    def test_interrupted_is_130_posix_convention(self) -> None:
+        """SIGINT exit code by POSIX convention is 128 + 2."""
+        assert ExitCode.INTERRUPTED == 130
+
+    def test_each_reason_maps_to_code(self) -> None:
+        """Every ExitReason has a unique ExitCode — no reason unmapped."""
+        for reason in ExitReason:
+            assert reason in EXIT_REASON_TO_CODE
+
+    def test_no_duplicate_codes(self) -> None:
+        """No two reasons share an exit code."""
+        codes = list(EXIT_REASON_TO_CODE.values())
+        assert len(codes) == len(set(codes))
+
+
+class TestAgentMetrics:
+    """AgentMetrics accumulator behavior."""
+
+    def test_defaults(self) -> None:
+        m = AgentMetrics()
+        assert m.iterations_used == 0
+        assert m.tool_call_count == 0
+        assert m.tool_error_count == 0
+        assert m.end_time is None
+        assert m.exit_reason == ExitReason.STOPPED
+
+    def test_record_tool_call(self) -> None:
+        m = AgentMetrics()
+        m.record_tool_call("shell", is_error=False)
+        m.record_tool_call("file_edit", is_error=True)
+        assert m.tool_call_count == 2
+        assert m.tool_error_count == 1
+        assert m.tool_calls[0] == ToolCallRecord(name="shell", is_error=False)
+
+    def test_finalize_sets_reason_and_end_time(self) -> None:
+        m = AgentMetrics()
+        m.finalize(ExitReason.BUDGET_EXCEEDED)
+        assert m.exit_reason == ExitReason.BUDGET_EXCEEDED
+        assert m.end_time is not None
+        assert m.duration_seconds >= 0
+
+    def test_exit_code_derived_from_reason(self) -> None:
+        m = AgentMetrics()
+        m.finalize(ExitReason.MAX_ITERATIONS)
+        assert m.exit_code == ExitCode.MAX_ITERATIONS
+
+    def test_duration_before_finalize(self) -> None:
+        """duration_seconds should work even before finalize() is called."""
+        m = AgentMetrics()
+        time.sleep(0.01)
+        d = m.duration_seconds
+        assert d > 0
+
+
+class TestAgentLoopPopulatesMetrics:
+    """The agent loop must populate metrics at every exit path when the
+    metrics arg is provided. This is what the headless runner relies on
+    to report accurate exit codes in CI.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_populates_stopped(self, tool_context) -> None:
+        metrics = AgentMetrics()
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(return_value=_text_resp("all done"))
+
+        result = await agent_loop(
+            "hi", conversation, client, registry, tool_context, metrics=metrics
+        )
+
+        assert result == "all done"
+        assert metrics.exit_reason == ExitReason.STOPPED
+        assert metrics.exit_code == ExitCode.SUCCESS
+        assert metrics.iterations_used == 1
+        assert metrics.end_time is not None
+
+    @pytest.mark.asyncio
+    async def test_budget_exceeded_populates_budget(self, tool_context) -> None:
+        metrics = AgentMetrics()
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(side_effect=BudgetExceededError(spent=5.0, limit=1.0))
+
+        result = await agent_loop(
+            "hi", conversation, client, registry, tool_context, metrics=metrics
+        )
+
+        assert "Budget exceeded" in result
+        assert metrics.exit_reason == ExitReason.BUDGET_EXCEEDED
+        assert metrics.exit_code == ExitCode.BUDGET_EXCEEDED
+
+    @pytest.mark.asyncio
+    async def test_llm_error_populates_llm_error(self, tool_context) -> None:
+        metrics = AgentMetrics()
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(side_effect=RuntimeError("provider 500"))
+
+        result = await agent_loop(
+            "hi", conversation, client, registry, tool_context, metrics=metrics
+        )
+
+        assert result.startswith("Error: LLM call failed")
+        assert metrics.exit_reason == ExitReason.LLM_ERROR
+        assert metrics.exit_code == ExitCode.LLM_ERROR
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_populates_max_iter(self, tool_context) -> None:
+        """Looping forever on tool calls should exit at MAX_ITERATIONS."""
+        metrics = AgentMetrics()
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="shell"))
+        client = LLMClient(model="test")
+        # Always return a tool call — never a text response.
+        client.chat = AsyncMock(return_value=_tool_resp("shell", {"command": "ls"}))
+
+        result = await agent_loop(
+            "loop forever",
+            conversation,
+            client,
+            registry,
+            tool_context,
+            metrics=metrics,
+            max_iterations=3,
+        )
+
+        assert "maximum iterations" in result.lower()
+        assert metrics.exit_reason == ExitReason.MAX_ITERATIONS
+        assert metrics.exit_code == ExitCode.MAX_ITERATIONS
+        assert metrics.iterations_used == 3
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_are_recorded(self, tool_context) -> None:
+        """Every tool dispatch populates metrics.tool_calls."""
+        metrics = AgentMetrics()
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="shell", result=ToolResult.success("ok")))
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _tool_resp("shell", {"command": "ls"}),
+                _text_resp("done"),
+            ]
+        )
+
+        await agent_loop("run ls", conversation, client, registry, tool_context, metrics=metrics)
+
+        assert metrics.tool_call_count == 1
+        assert metrics.tool_calls[0].name == "shell"
+        assert metrics.tool_calls[0].is_error is False
+
+    @pytest.mark.asyncio
+    async def test_metrics_arg_is_optional(self, tool_context) -> None:
+        """Callers that don't pass metrics must continue to work (backwards-compat)."""
+        conversation = Conversation("You are a coding agent.", max_tokens=100_000)
+        registry = ToolRegistry()
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(return_value=_text_resp("fine"))
+
+        result = await agent_loop("hi", conversation, client, registry, tool_context)
+        assert result == "fine"

--- a/tests/test_cli_headless.py
+++ b/tests/test_cli_headless.py
@@ -1,0 +1,206 @@
+"""Tests for the headless `godspeed run` command (v2.5.0).
+
+Covers the MLOps-pipeline-facing contract: task input resolution,
+exit-code mapping, JSON output schema, --timeout wiring, and audit
+trail auto-creation.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.agent.result import ExitCode
+from godspeed.cli import _resolve_task_input
+
+
+class TestResolveTaskInput:
+    """_resolve_task_input precedence: --prompt-file > TASK > stdin."""
+
+    def test_prompt_file_wins_over_positional(self, tmp_path: Path) -> None:
+        prompt = tmp_path / "task.md"
+        prompt.write_text("task from file", encoding="utf-8")
+        assert _resolve_task_input("ignored", prompt) == "task from file"
+
+    def test_positional_task_used_when_no_file(self) -> None:
+        assert _resolve_task_input("do the thing", None) == "do the thing"
+
+    def test_dash_reads_from_stdin(self) -> None:
+        with patch("sys.stdin", StringIO("piped task\n")):
+            assert _resolve_task_input("-", None) == "piped task"
+
+    def test_empty_task_and_pipe_stdin_reads_stdin(self) -> None:
+        fake_stdin = StringIO("from pipe\n")
+        # isatty defaults to False on StringIO → resolve treats it as a pipe.
+        with patch("sys.stdin", fake_stdin):
+            assert _resolve_task_input("", None) == "from pipe"
+
+    def test_empty_task_and_tty_stdin_returns_empty(self) -> None:
+        """Interactive shell with no positional and no pipe → INVALID_INPUT."""
+
+        class _TTYStream:
+            def isatty(self) -> bool:
+                return True
+
+            def read(self) -> str:  # pragma: no cover — never called
+                return "should not be read"
+
+        with patch("sys.stdin", _TTYStream()):
+            assert _resolve_task_input("", None) == ""
+
+    def test_prompt_file_strips_trailing_whitespace(self, tmp_path: Path) -> None:
+        prompt = tmp_path / "task.md"
+        prompt.write_text("  task  \n\n", encoding="utf-8")
+        assert _resolve_task_input("", prompt) == "task"
+
+
+class TestExitCodeOrdering:
+    """The exit-code contract is public API. Values must not drift."""
+
+    def test_success_is_zero(self) -> None:
+        assert int(ExitCode.SUCCESS) == 0
+
+    def test_exit_codes_are_stable(self) -> None:
+        """If this test fails, a minor-version bump has broken pipeline
+        orchestrators that switch on exit code. Bump the major version."""
+        assert int(ExitCode.SUCCESS) == 0
+        assert int(ExitCode.TOOL_ERROR) == 1
+        assert int(ExitCode.MAX_ITERATIONS) == 2
+        assert int(ExitCode.BUDGET_EXCEEDED) == 3
+        assert int(ExitCode.LLM_ERROR) == 4
+        assert int(ExitCode.INVALID_INPUT) == 5
+        assert int(ExitCode.TIMEOUT) == 6
+        assert int(ExitCode.INTERRUPTED) == 130
+
+
+class TestHeadlessRunCommand:
+    """Integration-style smoke test for the Click command wiring.
+
+    We don't exercise the full agent loop (would need a live model) — we
+    verify the flag parsing, input resolution, and error paths.
+    """
+
+    def test_invalid_input_exit_code(self) -> None:
+        """No task and no stdin pipe → exit 5 (INVALID_INPUT)."""
+        from click.testing import CliRunner
+
+        from godspeed.cli import headless_run
+
+        runner = CliRunner()
+
+        class _TTYStream:
+            def isatty(self) -> bool:
+                return True
+
+            def read(self) -> str:
+                return ""
+
+        with patch("sys.stdin", _TTYStream()):
+            result = runner.invoke(headless_run, [], standalone_mode=False)
+
+        assert result.exit_code == int(ExitCode.INVALID_INPUT)
+
+    def test_timeout_flag_accepted(self) -> None:
+        """--timeout N parses without error (won't actually run to timeout)."""
+        from click.testing import CliRunner
+
+        from godspeed.cli import headless_run
+
+        runner = CliRunner()
+        result = runner.invoke(
+            headless_run,
+            ["--timeout", "30", "--help"],
+            standalone_mode=False,
+        )
+        # --help short-circuits Click; we just confirm the flag is valid.
+        assert result.exit_code == 0
+        assert "--timeout" in result.output
+
+    def test_prompt_file_flag_registered(self) -> None:
+        from click.testing import CliRunner
+
+        from godspeed.cli import headless_run
+
+        runner = CliRunner()
+        result = runner.invoke(headless_run, ["--help"], standalone_mode=False)
+        assert "--prompt-file" in result.output
+
+
+class TestEnrichedJsonSchema:
+    """The JSON output contract is documented in the CLI help and consumed
+    by pipeline orchestrators. Every field must be present when --json-output
+    is set, even when the run is a no-op.
+
+    We assert the schema shape by inspecting `_headless_run`'s local output
+    dict construction — the true integration test lives in the e2e suite.
+    """
+
+    def test_expected_fields_are_referenced(self) -> None:
+        """All promised JSON fields appear in the cli.py source."""
+        import inspect
+
+        from godspeed import cli
+
+        source = inspect.getsource(cli._headless_run)
+        for field in [
+            '"task"',
+            '"model"',
+            '"session_id"',
+            '"response"',
+            '"exit_reason"',
+            '"exit_code"',
+            '"iterations_used"',
+            '"tool_calls"',
+            '"tool_call_count"',
+            '"tool_error_count"',
+            '"duration_seconds"',
+            '"input_tokens"',
+            '"output_tokens"',
+            '"cost_usd"',
+            '"audit_log_path"',
+        ]:
+            assert field in source, f"Missing JSON field reference: {field}"
+
+
+@pytest.mark.asyncio
+class TestHeadlessRunIntegration:
+    """End-to-end test with a mocked LLM client — verifies exit codes
+    and audit trail creation without needing a live API."""
+
+    async def test_success_path_creates_audit_and_returns_zero(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+
+        from godspeed.cli import _headless_run
+        from godspeed.llm.client import ChatResponse
+
+        # Redirect global_dir to tmp_path so audit writes to a test location.
+        monkeypatch.setenv("GODSPEED_GLOBAL_DIR", str(tmp_path / "godspeed"))
+
+        # Mock LLMClient.chat to return a clean final text response.
+        async def fake_chat(self, messages, tools=None, task_type=None):
+            return ChatResponse(content="hello world", finish_reason="stop")
+
+        with (
+            patch("godspeed.llm.client.LLMClient.chat", new=fake_chat),
+            patch("sys.stdout.write"),
+        ):
+            exit_code = await _headless_run(
+                task="say hello",
+                model="test-model",
+                project_dir=tmp_path,
+                auto_approve="reads",
+                max_iterations=5,
+                timeout=0,
+                json_output=False,
+            )
+
+        assert exit_code == int(ExitCode.SUCCESS)
+        # Audit directory was created.
+        audit_dir = tmp_path / "godspeed" / "audit"
+        assert audit_dir.exists()
+        audit_files = list(audit_dir.glob("*.audit.jsonl"))
+        assert len(audit_files) == 1

--- a/tests/test_llm_rate_limit.py
+++ b/tests/test_llm_rate_limit.py
@@ -1,0 +1,165 @@
+"""Tests for rate-limit retry/backoff in LLMClient (v2.5.0).
+
+MLOps pipelines hammer shared API keys. A single 429 from Anthropic must not
+collapse the whole agent — the client must back off and retry with jitter,
+and honor Retry-After when the provider sends it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from godspeed.llm.client import ChatResponse, LLMClient
+
+
+class TestRateLimitClassifier:
+    """_is_rate_limit_error recognizes 429s across provider formats."""
+
+    def test_classic_rate_limit_message(self) -> None:
+        c = LLMClient(model="test")
+        assert c._is_rate_limit_error(Exception("429 Too Many Requests"))
+
+    def test_anthropic_rate_limit_phrase(self) -> None:
+        c = LLMClient(model="test")
+        assert c._is_rate_limit_error(Exception("rate_limit_error"))
+        assert c._is_rate_limit_error(Exception("Rate limit exceeded"))
+
+    def test_openai_rate_limit_error(self) -> None:
+        c = LLMClient(model="test")
+        assert c._is_rate_limit_error(Exception("RateLimitError: tokens per minute"))
+
+    def test_generic_5xx_not_rate_limit(self) -> None:
+        """5xx errors go through the existing fallback path, not backoff."""
+        c = LLMClient(model="test")
+        assert not c._is_rate_limit_error(Exception("500 Internal Server Error"))
+
+    def test_connection_refused_not_rate_limit(self) -> None:
+        c = LLMClient(model="test")
+        assert not c._is_rate_limit_error(Exception("Connection refused"))
+
+
+class TestRetryAfterParsing:
+    """_parse_retry_after extracts a wait hint from the provider's error."""
+
+    def test_retry_after_integer_seconds(self) -> None:
+        c = LLMClient(model="test")
+        assert c._parse_retry_after("Retry-After: 30") == 30.0
+
+    def test_retry_after_embedded_in_message(self) -> None:
+        c = LLMClient(model="test")
+        msg = "429 Too Many Requests. Retry-After: 12"
+        assert c._parse_retry_after(msg) == 12.0
+
+    def test_no_hint_returns_none(self) -> None:
+        c = LLMClient(model="test")
+        assert c._parse_retry_after("429 Too Many Requests") is None
+
+    def test_clamps_absurd_values(self) -> None:
+        """If provider says 'retry in 3 hours', we clamp — user should abort,
+        not silently block the session that long."""
+        c = LLMClient(model="test")
+        parsed = c._parse_retry_after("Retry-After: 99999")
+        assert parsed is not None
+        assert parsed <= 60.0
+
+
+class TestBackoffRetry:
+    """Rate-limited calls retry with exponential backoff + jitter, then succeed."""
+
+    @pytest.mark.asyncio
+    async def test_transient_429_recovers(self) -> None:
+        """A single 429 followed by a success should return the success."""
+        c = LLMClient(model="test-model")
+        ok = ChatResponse(content="recovered", finish_reason="stop")
+
+        call_count = {"n": 0}
+
+        async def flaky(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise Exception("429 Too Many Requests")
+            return ok
+
+        with patch.object(c, "_call", side_effect=flaky), patch("asyncio.sleep", AsyncMock()):
+            result = await c._chat_with_fallback([])
+
+        assert result.content == "recovered"
+        assert call_count["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_multiple_429s_retry_up_to_cap(self) -> None:
+        """Keep retrying up to RATE_LIMIT_MAX_RETRIES, then fail over to fallback."""
+        c = LLMClient(model="test-model", fallback_models=["fallback-model"])
+        ok = ChatResponse(content="fallback used", finish_reason="stop")
+
+        call_log: list[str] = []
+
+        async def flaky(model, *args, **kwargs):
+            call_log.append(model)
+            if model == "test-model":
+                raise Exception("429 rate_limit_error")
+            return ok
+
+        with patch.object(c, "_call", side_effect=flaky), patch("asyncio.sleep", AsyncMock()):
+            result = await c._chat_with_fallback([])
+
+        assert result.content == "fallback used"
+        # Primary tried RATE_LIMIT_MAX_RETRIES + 1 times (initial + retries)
+        primary_attempts = [m for m in call_log if m == "test-model"]
+        assert len(primary_attempts) >= 2
+        assert "fallback-model" in call_log
+
+    @pytest.mark.asyncio
+    async def test_backoff_schedule_is_exponential(self) -> None:
+        """Sleep durations must grow: each retry waits longer than the last."""
+        c = LLMClient(model="test-model")
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        async def always_429(*args, **kwargs):
+            raise Exception("429 rate_limit_error")
+
+        with (
+            patch.object(c, "_call", side_effect=always_429),
+            patch("asyncio.sleep", side_effect=fake_sleep),
+            pytest.raises(RuntimeError),
+        ):
+            await c._chat_with_fallback([])
+
+        # Between retries on the primary model, we should have slept several times,
+        # and the sequence should be monotonically non-decreasing (with jitter tolerance).
+        assert len(sleeps) >= 2
+        # Strip jitter by checking the base trend: sum of sleeps grows faster than linear
+        # (exponential 1,2,4 sums to 7 which beats linear 1,1,1 at n=3).
+        assert sum(sleeps[:3]) >= 1.0
+
+    @pytest.mark.asyncio
+    async def test_retry_after_honored(self) -> None:
+        """When Retry-After is present, that value is used for the next wait."""
+        c = LLMClient(model="test-model")
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        call_count = {"n": 0}
+
+        async def flaky(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise Exception("429 rate_limit. Retry-After: 15")
+            return ChatResponse(content="ok", finish_reason="stop")
+
+        with (
+            patch.object(c, "_call", side_effect=flaky),
+            patch("asyncio.sleep", side_effect=fake_sleep),
+        ):
+            result = await c._chat_with_fallback([])
+
+        assert result.content == "ok"
+        # First sleep should be >= 15 (with small jitter tolerance upward only)
+        assert sleeps[0] >= 15.0


### PR DESCRIPTION
## Summary

Closes **G1-G7** from the 2026-04-16 feature + logic audit. Makes `godspeed run` fit for unattended use in CI, W&B sweeps, and ML research pipelines.

Minor bump per the versioning policy added in #37 — new user-facing features, backwards-compatible Python API.

## What's new

### Exit code contract (G2)
`godspeed.agent.result.ExitCode` — stable across minor versions so orchestrators can switch on it.

| Code | Reason | When |
|---|---|---|
| 0 | success | model stopped with final text |
| 1 | tool_error | final text starts with `Error:` |
| 2 | max_iterations | loop exited without model stopping |
| 3 | budget_exceeded | cost cap hit |
| 4 | llm_error | all fallbacks exhausted |
| 5 | invalid_input | no task provided |
| 6 | timeout | --timeout wall-clock cap exceeded |
| 130 | interrupted | SIGINT |

### `--timeout N` (G3)
Wall-clock cap on `godspeed run`. Wraps the loop in \`asyncio.wait_for\`; exit 6 on \`TimeoutError\`. Default 0 = no limit.

### `--prompt-file FILE` and stdin (G5)
Task input precedence: \`--prompt-file\` > positional > stdin. \`godspeed run -\` reads from stdin. Piped stdin with empty positional also reads from stdin.

### Rate-limit retry with exponential backoff (G4)
429 / rate_limit / quota errors now retry up to 4 times on the same model (1s / 2s / 4s / 8s ± 25% jitter, capped at 60s) before falling over. Honors \`Retry-After\` (upward-only jitter — never retry earlier than provider asked).

### Enriched JSON output (G6)
Existing fields preserved; added:
\`\`\`json
{
  \"exit_reason\": \"stopped\",
  \"exit_code\": 0,
  \"iterations_used\": 3,
  \"tool_calls\": [{\"name\": \"shell\", \"is_error\": false}],
  \"tool_call_count\": 1,
  \"tool_error_count\": 0,
  \"duration_seconds\": 12.345,
  \"cost_usd\": 0.042,
  \"audit_log_path\": \"~/.godspeed/audit/abc.audit.jsonl\"
}
\`\`\`

### Audit trail in headless (G1) — **security fix**
Previously \`_headless_run\` wired \`audit=None\`. A security-first agent running unattended with no tamper-evident log was the worst of both worlds. Now writes to \`~/.godspeed/audit/{session}.audit.jsonl\` with \`session_start\` and \`session_end\` records bookending every run.

## Tests (+41)

- \`tests/test_agent_result.py\` (15) — ExitCode invariants, AgentMetrics accumulation, agent_loop populates metrics at every exit path
- \`tests/test_llm_rate_limit.py\` (13) — classifier, Retry-After parsing, backoff schedule, recovery after transient 429, fall-over after cap
- \`tests/test_cli_headless.py\` (13) — input resolution precedence, exit code stability, flag wiring, JSON schema presence, e2e success path with audit directory creation

## Audit results

| Check | Result |
|---|---|
| \`ruff check .\` | ✅ all checks passed |
| \`ruff format --check .\` | ✅ 198 files formatted |
| \`mypy src/godspeed --ignore-missing-imports\` | ✅ 0 issues / 96 files |
| \`pytest -q --cov --cov-fail-under=80\` | ✅ **1,625 passed, 2 skipped, 85.74% coverage** |
| Version bump | 2.4.0 → 2.5.0 (minor, per CONTRIBUTING versioning policy) |

## Test plan

- [x] Pre-fix rate-limit tests fail; post-fix pass
- [x] Pre-fix exit-code tests fail on legacy str-return loop; post-fix populate metrics
- [x] End-to-end headless success path creates audit directory
- [x] Exit codes are stable (dedicated test guards against accidental renumbering)
- [x] Coverage gate met
- [ ] Maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)