### PR TITLE
fix(v2.5.1): MUST-FIX gate on auto-verify + log_session_end + quality prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.1] — 2026-04-17
+
+Patch release — code-quality enforcement and training-record alignment. No new
+user-facing CLI flags or JSON schema changes.
+
+### Added
+
+- **`ConversationLogger.log_session_end()`** emits a terminal record per
+  headless session with `exit_reason`, `exit_code`, `iterations_used`,
+  `tool_call_count`, `tool_error_count`, `duration_seconds`, `cost_usd`.
+  Fields mirror the audit-trail `session_end` detail so the two streams stay
+  comparable. Enables RL pipelines (GRPO) to shape rewards on `exit_code`
+  without parsing the audit log.
+- **Quality defaults** in the system prompt: a new `QUALITY_PROMPT` block
+  (type hints, test-first, read-before-edit, comments-only-when-non-obvious,
+  secrets policy, anti-premature-abstraction) appended after `WORKFLOW_PROMPT`.
+
+### Changed
+
+- **MUST-FIX gate on auto-verify failures**. When `_auto_verify_file` leaves
+  unresolved lint errors (fingerprint: "some remaining"), the agent loop
+  injects a user-role message naming the file and errors, instructing the
+  model to fix them before any other edits. Capped at 3 injections per
+  session — after the cap, the gate logs a warning and fails open so the
+  agent isn't deadlocked on a fundamentally unfixable error (e.g., broken
+  project ruff config). Wired into both parallel and sequential dispatch
+  paths. Structural enforcement closes a silent-error channel where the
+  model could read a `verify` success marker despite persistent lint issues.
+
+### Fixed
+
+- `src/godspeed/__init__.py:5` — stale `__version__` (was `"2.2.0"`; now
+  tracks `pyproject.toml`).
+
 ## [2.5.0] — 2026-04-16
 
 MLOps-readiness release. Closes the headless/pipeline gaps found in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed"
-version = "2.5.0"
+version = "2.5.1"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.2.0"
+__version__ = "2.5.1"

--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -26,6 +26,7 @@ MAX_ITERATIONS = 50
 MAX_RETRIES = 3
 STUCK_LOOP_THRESHOLD = 3
 AUTO_STASH_THRESHOLD = 3
+MUST_FIX_CAP = 3
 VERIFIABLE_EXTENSIONS = (
     ".py",
     ".pyi",
@@ -118,6 +119,7 @@ async def agent_loop(
     consecutive_successful_edits = 0
     recent_change_descriptions: list[str] = []
     auto_stashed = False
+    must_fix_injections = 0
     speculative_cache: dict[str, asyncio.Task[ToolResult]] = {}
 
     for iteration in range(iteration_limit):
@@ -388,6 +390,12 @@ async def agent_loop(
                             file_path,
                             "passed" in verify_result.output.lower(),
                         )
+                        must_fix_injections = _maybe_inject_must_fix(
+                            conversation,
+                            file_path,
+                            verify_result.output or "",
+                            must_fix_injections,
+                        )
 
             # Auto-stash: count writes in batch
             batch_writes = sum(
@@ -551,6 +559,12 @@ async def agent_loop(
                             file_path,
                             "passed" in verify_result.output.lower(),
                         )
+                        must_fix_injections = _maybe_inject_must_fix(
+                            conversation,
+                            file_path,
+                            verify_result.output or "",
+                            must_fix_injections,
+                        )
 
                 # Auto-stash: track consecutive write operations
                 if not result.is_error and tool_call.tool_name in (
@@ -674,6 +688,47 @@ async def _auto_verify_file(
         call_id=f"{parent_call_id}_verify",
     )
     return await tool_registry.dispatch(verify_call, tool_context)
+
+
+def _maybe_inject_must_fix(
+    conversation: Conversation,
+    file_path: str,
+    verify_output: str,
+    injections: int,
+) -> int:
+    """Force the model to address unresolved lint errors after auto-verify.
+
+    verify_with_retry returns a success ToolResult even when lint errors
+    persist (fingerprint: "some remaining"). Without this gate the model
+    sees a success marker and can proceed to unrelated edits while quality
+    silently degrades. On detection, inject a user-role message naming the
+    file and errors so the constraint is in-conversation.
+
+    Caps at MUST_FIX_CAP injections per session. After the cap we log a
+    warning and fail open — better to let the agent try a different tack
+    than to deadlock on a fundamentally unfixable error (broken ruff
+    config, upstream dep bug, etc.).
+    """
+    if "some remaining" not in (verify_output or ""):
+        return injections
+    if injections >= MUST_FIX_CAP:
+        logger.warning(
+            "MUST-FIX cap reached for file=%s; allowing agent to proceed",
+            file_path,
+        )
+        return injections
+    conversation.add_user_message(
+        f"VERIFY FAILED on {file_path}. Unresolved lint errors remain "
+        f"after auto-fix attempts:\n\n{verify_output}\n\n"
+        "You MUST fix these errors before any other edits or writes."
+    )
+    logger.info(
+        "MUST-FIX injected file=%s count=%d/%d",
+        file_path,
+        injections + 1,
+        MUST_FIX_CAP,
+    )
+    return injections + 1
 
 
 async def _try_auto_commit(

--- a/src/godspeed/agent/system_prompt.py
+++ b/src/godspeed/agent/system_prompt.py
@@ -77,6 +77,19 @@ WORKFLOW_PROMPT = """\
 """
 
 
+QUALITY_PROMPT = """\
+
+## Code Quality Defaults
+- Type hints on public functions. No bare except. No print() in committed code.
+- When adding behavior, write a failing test first where practical.
+- Match existing patterns in the file you're editing — read it first if you
+  haven't already this turn.
+- Default to no comments. Add one only when the WHY is non-obvious.
+- Never hardcode secrets; validate at system boundaries; parameterized queries only.
+- Prefer 3 similar lines to a premature abstraction for a hypothetical case.
+"""
+
+
 PLAN_MODE_PROMPT = """\
 
 ## Plan Mode Active
@@ -101,7 +114,7 @@ def build_system_prompt(
     3. Available tool descriptions
     4. Working directory context
     """
-    parts = [CORE_PROMPT, WORKFLOW_PROMPT]
+    parts = [CORE_PROMPT, WORKFLOW_PROMPT, QUALITY_PROMPT]
 
     if plan_mode:
         parts.append(PLAN_MODE_PROMPT)

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -860,10 +860,6 @@ async def _headless_run(
         final_text = f"Error: Session exceeded wall-clock timeout of {timeout}s."
         metrics.finalize(ExitReason.TIMEOUT)
 
-    # Close conversation logger
-    if conversation_logger is not None:
-        conversation_logger.close()
-
     # Resolve final exit code. TOOL_ERROR overrides STOPPED when the model's
     # final message starts with "Error:" (common pattern for tool failures
     # that the model surfaces rather than silently ignoring).
@@ -889,6 +885,20 @@ async def _headless_run(
         },
         outcome="success" if exit_code == 0 else "error",
     )
+
+    # Mirror the audit session_end into the training log so RL pipelines
+    # can read exit_reason/exit_code without parsing the audit trail.
+    if conversation_logger is not None:
+        conversation_logger.log_session_end(
+            exit_reason=metrics.exit_reason.value,
+            exit_code=exit_code,
+            iterations_used=metrics.iterations_used,
+            tool_call_count=metrics.tool_call_count,
+            tool_error_count=metrics.tool_error_count,
+            duration_seconds=metrics.duration_seconds,
+            cost_usd=llm_client.total_cost_usd,
+        )
+        conversation_logger.close()
 
     # Output result to stdout
     if json_output:

--- a/src/godspeed/training/conversation_logger.py
+++ b/src/godspeed/training/conversation_logger.py
@@ -98,6 +98,36 @@ class ConversationLogger:
             }
         )
 
+    def log_session_end(
+        self,
+        exit_reason: str,
+        exit_code: int,
+        iterations_used: int,
+        tool_call_count: int,
+        tool_error_count: int,
+        duration_seconds: float,
+        cost_usd: float,
+    ) -> None:
+        """Terminal record per session.
+
+        Fields mirror the audit-trail session_end detail so the two streams
+        stay comparable. Downstream RL (GRPO) reads exit_code to shape
+        rewards: +1.0 on SUCCESS, -0.5 on TOOL_ERROR, -1.0 on
+        MAX_ITERATIONS, etc. See ml-lab phase4_grpo.yaml for the mapping.
+        """
+        self._write(
+            {
+                "role": "session_end",
+                "exit_reason": exit_reason,
+                "exit_code": exit_code,
+                "iterations_used": iterations_used,
+                "tool_call_count": tool_call_count,
+                "tool_error_count": tool_error_count,
+                "duration_seconds": round(duration_seconds, 3),
+                "cost_usd": round(cost_usd, 6),
+            }
+        )
+
     def close(self) -> None:
         """Flush and close the underlying file."""
         if self._file is not None:

--- a/tests/test_must_fix_gate.py
+++ b/tests/test_must_fix_gate.py
@@ -1,0 +1,176 @@
+"""Tests for the MUST-FIX gate on auto-verify failures (v2.5.1).
+
+When auto-verify leaves unresolved lint errors, the loop must inject a
+user-role message forcing the agent to fix them before any other edits.
+Capped at MUST_FIX_CAP injections per session.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from godspeed.agent.conversation import Conversation
+from godspeed.agent.loop import MUST_FIX_CAP, _maybe_inject_must_fix, agent_loop
+from godspeed.llm.client import ChatResponse, LLMClient
+from godspeed.tools.base import ToolResult
+from godspeed.tools.registry import ToolRegistry
+from tests.conftest import MockTool
+
+
+def _text_resp(text: str) -> ChatResponse:
+    return ChatResponse(content=text, tool_calls=[], finish_reason="stop")
+
+
+def _tool_resp(name: str, args: dict[str, Any], call_id: str = "call_1") -> ChatResponse:
+    return ChatResponse(
+        content="",
+        tool_calls=[{"id": call_id, "function": {"name": name, "arguments": json.dumps(args)}}],
+        finish_reason="tool_calls",
+    )
+
+
+def _count_must_fix_messages(conversation: Conversation) -> int:
+    return sum(
+        1
+        for msg in conversation.messages
+        if msg.get("role") == "user"
+        and isinstance(msg.get("content"), str)
+        and "MUST fix" in msg["content"]
+    )
+
+
+class TestMaybeInjectMustFix:
+    """Direct unit tests of the gate helper — no agent loop."""
+
+    def test_no_injection_on_clean_verify(self) -> None:
+        convo = Conversation("sys", max_tokens=100_000)
+        out = _maybe_inject_must_fix(convo, "x.py", "Verification passed: x.py", 0)
+        assert out == 0
+        assert _count_must_fix_messages(convo) == 0
+
+    def test_injects_on_some_remaining_fingerprint(self) -> None:
+        convo = Conversation("sys", max_tokens=100_000)
+        verify_output = (
+            "Auto-fixed 2 round(s) of issues, some remaining: app.py\nF401 unused import"
+        )
+        out = _maybe_inject_must_fix(convo, "app.py", verify_output, 0)
+        assert out == 1
+        assert _count_must_fix_messages(convo) == 1
+        must_fix = next(m for m in convo.messages if "MUST fix" in str(m.get("content", "")))
+        assert "app.py" in must_fix["content"]
+        assert "F401" in must_fix["content"]
+
+    def test_caps_at_must_fix_cap(self) -> None:
+        convo = Conversation("sys", max_tokens=100_000)
+        verify_output = "Auto-fixed rounds, some remaining: app.py"
+        counter = 0
+        for _ in range(MUST_FIX_CAP + 2):
+            counter = _maybe_inject_must_fix(convo, "app.py", verify_output, counter)
+        assert counter == MUST_FIX_CAP
+        assert _count_must_fix_messages(convo) == MUST_FIX_CAP
+
+    def test_empty_output_never_injects(self) -> None:
+        convo = Conversation("sys", max_tokens=100_000)
+        assert _maybe_inject_must_fix(convo, "x.py", "", 0) == 0
+        assert _maybe_inject_must_fix(convo, "x.py", None, 0) == 0  # type: ignore[arg-type]
+
+
+class TestMustFixGateInAgentLoop:
+    """End-to-end: the loop fires the gate after auto-verify leaves errors."""
+
+    @pytest.mark.asyncio
+    async def test_gate_fires_after_auto_verify_leaves_errors_sequential(
+        self, tool_context
+    ) -> None:
+        """A single file_edit → verify-with-remaining-errors → MUST-FIX injected."""
+        convo = Conversation("sys", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="file_edit", result=ToolResult.success("edited")))
+        registry.register(MockTool(name="verify"))  # presence required by the gate check
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _tool_resp("file_edit", {"file_path": "app.py"}),
+                _text_resp("done"),
+            ]
+        )
+
+        dirty = ToolResult.success("Auto-fixed 1 round(s) of issues, some remaining: app.py\nF401")
+        with patch("godspeed.agent.loop._auto_verify_file", AsyncMock(return_value=dirty)):
+            await agent_loop(
+                "edit app.py", convo, client, registry, tool_context, parallel_tool_calls=False
+            )
+
+        assert _count_must_fix_messages(convo) == 1
+
+    @pytest.mark.asyncio
+    async def test_gate_fires_in_parallel_path(self, tool_context) -> None:
+        """Two concurrent file_edit calls with failing verify → two injections."""
+        convo = Conversation("sys", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="file_edit", result=ToolResult.success("edited")))
+        registry.register(MockTool(name="verify"))
+
+        client = LLMClient(model="test")
+        # Two tool calls in one response → triggers parallel path (len > 1).
+        client.chat = AsyncMock(
+            side_effect=[
+                ChatResponse(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "c1",
+                            "function": {
+                                "name": "file_edit",
+                                "arguments": json.dumps({"file_path": "a.py"}),
+                            },
+                        },
+                        {
+                            "id": "c2",
+                            "function": {
+                                "name": "file_edit",
+                                "arguments": json.dumps({"file_path": "b.py"}),
+                            },
+                        },
+                    ],
+                    finish_reason="tool_calls",
+                ),
+                _text_resp("done"),
+            ]
+        )
+
+        dirty = ToolResult.success("Auto-fixed 1 round(s) of issues, some remaining: app.py\nF401")
+        with patch("godspeed.agent.loop._auto_verify_file", AsyncMock(return_value=dirty)):
+            await agent_loop(
+                "edit both", convo, client, registry, tool_context, parallel_tool_calls=True
+            )
+
+        assert _count_must_fix_messages(convo) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_injection_when_verify_passes(self, tool_context) -> None:
+        convo = Conversation("sys", max_tokens=100_000)
+        registry = ToolRegistry()
+        registry.register(MockTool(name="file_edit", result=ToolResult.success("edited")))
+        registry.register(MockTool(name="verify"))
+
+        client = LLMClient(model="test")
+        client.chat = AsyncMock(
+            side_effect=[
+                _tool_resp("file_edit", {"file_path": "app.py"}),
+                _text_resp("done"),
+            ]
+        )
+
+        clean = ToolResult.success("Verification passed: app.py")
+        with patch("godspeed.agent.loop._auto_verify_file", AsyncMock(return_value=clean)):
+            await agent_loop(
+                "edit app.py", convo, client, registry, tool_context, parallel_tool_calls=False
+            )
+
+        assert _count_must_fix_messages(convo) == 0

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1,0 +1,64 @@
+"""Tests for system prompt assembly — quality defaults + existing sections."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from godspeed.agent.system_prompt import build_system_prompt
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+
+class _StubTool(Tool):
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    @property
+    def description(self) -> str:
+        return "A stub tool for testing."
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict:
+        return {"type": "object", "properties": {}, "required": []}
+
+    async def execute(self, arguments: dict, context: ToolContext) -> ToolResult:
+        return ToolResult.success("ok")
+
+
+def test_prompt_includes_core_and_workflow_and_quality() -> None:
+    prompt = build_system_prompt(tools=[_StubTool()])
+
+    # Existing sections still rendered
+    assert "security-first coding agent" in prompt
+    assert "Common Workflows" in prompt
+    assert "Available Tools" in prompt
+    assert "stub" in prompt
+
+    # New quality defaults (v2.5.1)
+    assert "Code Quality Defaults" in prompt
+    assert "Type hints on public functions" in prompt
+    assert "failing test first" in prompt
+    assert "Default to no comments" in prompt
+    assert "parameterized queries" in prompt
+    assert "premature abstraction" in prompt
+
+
+def test_plan_mode_appended_when_flag_set() -> None:
+    prompt = build_system_prompt(tools=[_StubTool()], plan_mode=True)
+    assert "PLAN MODE" in prompt
+    # Quality defaults still present in plan mode.
+    assert "Code Quality Defaults" in prompt
+
+
+def test_project_instructions_still_render(tmp_path: Path) -> None:
+    prompt = build_system_prompt(
+        tools=[_StubTool()],
+        project_instructions="ALWAYS use uv, not pip.",
+        cwd=tmp_path,
+    )
+    assert "Project Instructions" in prompt
+    assert "ALWAYS use uv" in prompt
+    assert str(tmp_path) in prompt

--- a/tests/test_training/test_session_end.py
+++ b/tests/test_training/test_session_end.py
@@ -1,0 +1,66 @@
+"""Tests for ConversationLogger.log_session_end (v2.5.1).
+
+The session_end record is the terminal signal RL pipelines use to score
+a run. It must carry the exit_reason / exit_code / metrics that the audit
+trail records, so both streams can be cross-referenced.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from godspeed.training.conversation_logger import ConversationLogger
+
+
+def _read_all(path: Path) -> list[dict]:
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def test_log_session_end_writes_expected_record(tmp_path: Path) -> None:
+    logger = ConversationLogger(session_id="sess-1", output_dir=tmp_path)
+    try:
+        logger.log_system("you are helpful")
+        logger.log_session_end(
+            exit_reason="stopped",
+            exit_code=0,
+            iterations_used=3,
+            tool_call_count=5,
+            tool_error_count=0,
+            duration_seconds=12.3456,
+            cost_usd=0.012345,
+        )
+    finally:
+        logger.close()
+
+    records = _read_all(logger.path)
+    assert len(records) == 2
+    end = records[-1]
+    assert end["role"] == "session_end"
+    assert end["exit_reason"] == "stopped"
+    assert end["exit_code"] == 0
+    assert end["iterations_used"] == 3
+    assert end["tool_call_count"] == 5
+    assert end["tool_error_count"] == 0
+    # Fields rounded as documented
+    assert end["duration_seconds"] == 12.346
+    assert end["cost_usd"] == 0.012345
+    # Shared envelope fields
+    assert end["session_id"] == "sess-1"
+    assert "timestamp" in end
+
+
+def test_multiple_session_end_records_are_append_only(tmp_path: Path) -> None:
+    """The logger is append-only; a caller writing two session_end records
+    (e.g., on retry in an orchestrator) should see both preserved."""
+    logger = ConversationLogger(session_id="sess-2", output_dir=tmp_path)
+    try:
+        logger.log_session_end("timeout", 6, 50, 12, 3, 1800.0, 0.42)
+        logger.log_session_end("stopped", 0, 20, 5, 0, 60.0, 0.05)
+    finally:
+        logger.close()
+
+    records = _read_all(logger.path)
+    assert [r["exit_reason"] for r in records] == ["timeout", "stopped"]
+    assert [r["exit_code"] for r in records] == [6, 0]


### PR DESCRIPTION
## Summary

Ultraplan-refined patch release. Research (Arize 2025 prompt-learning study + \"Tools Fail\" paper arXiv 2406.19228 + ESLint-as-AI-guardrails) pointed at **structural enforcement over prompt verbosity** — the MUST-FIX gate is the force multiplier; the system-prompt additions are a complement.

Plan: \`~/.claude/plans/validated-moseying-graham.md\`

## Changes

### MUST-FIX gate on auto-verify failures
Previously \`verify._verify_with_retry\` returned \`ToolResult.success(\"...some remaining: ...\")\` when lint errors persisted — the model read success and proceeded to unrelated edits. Silent-error channel.

Now: on \"some remaining\" fingerprint, the loop injects a user-role message naming the file + errors with \"You MUST fix these errors before any other edits or writes.\" Capped at \`MUST_FIX_CAP = 3\` per session; after the cap logs a warning and fails open (avoids deadlock on fundamentally unfixable errors).

Wired into both parallel and sequential dispatch paths.

### \`ConversationLogger.log_session_end()\`
New terminal record per session with \`exit_reason\`, \`exit_code\`, \`iterations_used\`, \`tool_call_count\`, \`tool_error_count\`, \`duration_seconds\`, \`cost_usd\`. Fields mirror the audit-trail \`session_end\` detail so the two streams stay directly comparable. Emitted from \`_headless_run\`. Downstream RL (GRPO in ml-lab) can now score runs on \`exit_code\` without parsing the audit trail.

### \`QUALITY_PROMPT\` block in system prompt
6 lines appended after \`WORKFLOW_PROMPT\`: type hints, test-first, read-before-edit, comments-only-when-WHY-non-obvious, secrets policy, anti-premature-abstraction.

### Stale \`__version__\` fix
\`src/godspeed/__init__.py:5\` was frozen at \`\"2.2.0\"\` — now tracks \`pyproject.toml\` at \`\"2.5.1\"\`.

## Tests (+12 new)

- \`tests/test_must_fix_gate.py\` (7) — direct unit tests of \`_maybe_inject_must_fix\` (no-op on clean, inject on fingerprint, cap, empty/None-safe) + end-to-end tests driving the loop through both parallel and sequential paths
- \`tests/test_system_prompt.py\` (3) — quality defaults present, plan-mode composition, project instructions + cwd still render
- \`tests/test_training/test_session_end.py\` (2) — record shape, append-only semantics

## Audit

| Check | Result |
|---|---|
| \`ruff check .\` | ✅ all checks passed |
| \`ruff format --check .\` | ✅ 201 files formatted |
| \`mypy src/godspeed --ignore-missing-imports\` | ✅ 0 issues / 96 files |
| \`pytest -q --cov --cov-fail-under=80\` | ✅ 1,637 passed, 2 skipped, **85.87% coverage** |
| Version bump | 2.5.0 → 2.5.1 (patch — behavior change is a quality fix to existing feature) |

## What this does NOT change

- \`verify._verify_with_retry\` return semantics unchanged (3 existing tests in \`test_verify_fix_retry.py\` assert \`not is_error\` with remaining issues — the deeper fix lands in v2.6.0 with the broader quality-tooling pass)
- No new CLI flags, no JSON-output schema change, no new config keys
- \`session_end\` record is additive — existing JSONL consumers tolerate unknown roles

## Test plan

- [x] All existing tests pass (1,625 → 1,637)
- [x] Coverage gate met (85.87%)
- [x] MUST-FIX gate fires on parallel path
- [x] MUST-FIX gate fires on sequential path
- [x] Gate does not fire on clean verify
- [x] Gate caps at 3 injections
- [x] \`log_session_end\` emits terminal record with all required fields
- [ ] Maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)