### PR TITLE
feat(v2.6.0): coverage + security_scan tools; MUST-FIX metrics; fingerprint constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] — 2026-04-17
+
+Quality-tooling minor release. Two new tools the agent can call to enforce
+production-grade code; efficiency telemetry in training logs; follow-up
+cleanup from v2.5.1.
+
+### Added
+
+- **`coverage` tool** (`src/godspeed/tools/coverage.py`) — wraps
+  `coverage run pytest` + `coverage report -m`. Optional `min_percent`
+  argument fails the call below the threshold, turning coverage into a
+  quality gate the agent can enforce per-session. Auto-detects `--source`
+  (`./src` if present, else cwd). Graceful error when `coverage` isn't
+  installed.
+- **`security_scan` tool** (`src/godspeed/tools/security_scan.py`) —
+  wraps `bandit` (Python) and `semgrep` (polyglot, when installed). Both
+  optional; falls back when neither is available. Non-zero findings
+  produce an error result so the agent treats them as gating rather than
+  advisory. Configurable minimum severity (`low` / `medium` / `high`).
+- **`AgentMetrics.must_fix_injections`** counter — increments each time
+  the MUST-FIX gate injects a fix-required message. Exposed in headless
+  JSON output, audit trail `session_end` detail, and `ConversationLogger`
+  `log_session_end` record. Training signal: agents that trigger many
+  MUST-FIX injections are less efficient per unit of successful work;
+  downstream RL (GRPO) can penalize against this counter.
+
+### Changed
+
+- **Fingerprint coupling reduced** — `verify.REMAINING_ERRORS_FINGERPRINT`
+  is now a module-level constant imported by `loop._maybe_inject_must_fix`.
+  Eliminates the duplicated `"some remaining"` string literal identified
+  in the v2.5.1 review follow-ups.
+- `ConversationLogger.log_session_end(...)` accepts a new
+  `must_fix_injections` keyword argument (defaulted to 0 for
+  backwards-compatibility with existing callers).
+- `_build_tool_registry` (`cli.py`) registers `CoverageTool` and
+  `SecurityScanTool` alongside the existing quality tools.
+
+### Fixed
+
+- `tests/test_agent_result.py::test_duration_before_finalize` — flaked on
+  Windows where `time.monotonic()` granularity could return identical
+  values across a `0.01s` sleep. Assertion relaxed to `>= 0.0` (the
+  semantically correct invariant — duration is never negative).
+
 ## [2.5.1] — 2026-04-17
 
 Patch release — code-quality enforcement and training-record alignment. No new

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed"
-version = "2.5.1"
+version = "2.6.0"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.5.1"
+__version__ = "2.6.0"

--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -395,6 +395,7 @@ async def agent_loop(
                             file_path,
                             verify_result.output or "",
                             must_fix_injections,
+                            metrics,
                         )
 
             # Auto-stash: count writes in batch
@@ -564,6 +565,7 @@ async def agent_loop(
                             file_path,
                             verify_result.output or "",
                             must_fix_injections,
+                            metrics,
                         )
 
                 # Auto-stash: track consecutive write operations
@@ -695,21 +697,28 @@ def _maybe_inject_must_fix(
     file_path: str,
     verify_output: str,
     injections: int,
+    metrics: AgentMetrics | None = None,
 ) -> int:
     """Force the model to address unresolved lint errors after auto-verify.
 
     verify_with_retry returns a success ToolResult even when lint errors
-    persist (fingerprint: "some remaining"). Without this gate the model
-    sees a success marker and can proceed to unrelated edits while quality
-    silently degrades. On detection, inject a user-role message naming the
-    file and errors so the constraint is in-conversation.
+    persist (fingerprint: verify.REMAINING_ERRORS_FINGERPRINT). Without
+    this gate the model sees a success marker and can proceed to unrelated
+    edits while quality silently degrades. On detection, inject a
+    user-role message naming the file and errors so the constraint is
+    in-conversation.
 
     Caps at MUST_FIX_CAP injections per session. After the cap we log a
     warning and fail open — better to let the agent try a different tack
     than to deadlock on a fundamentally unfixable error (broken ruff
     config, upstream dep bug, etc.).
+
+    When `metrics` is provided, each successful injection is recorded so
+    downstream RL can shape rewards against agent efficiency.
     """
-    if "some remaining" not in (verify_output or ""):
+    from godspeed.tools.verify import REMAINING_ERRORS_FINGERPRINT
+
+    if REMAINING_ERRORS_FINGERPRINT not in (verify_output or ""):
         return injections
     if injections >= MUST_FIX_CAP:
         logger.warning(
@@ -728,6 +737,8 @@ def _maybe_inject_must_fix(
         injections + 1,
         MUST_FIX_CAP,
     )
+    if metrics is not None:
+        metrics.record_must_fix_injection()
     return injections + 1
 
 

--- a/src/godspeed/agent/result.py
+++ b/src/godspeed/agent/result.py
@@ -77,11 +77,21 @@ class AgentMetrics:
     iterations_used: int = 0
     exit_reason: ExitReason = ExitReason.STOPPED
     tool_calls: list[ToolCallRecord] = dataclasses.field(default_factory=list)
+    must_fix_injections: int = 0
     start_time: float = dataclasses.field(default_factory=time.monotonic)
     end_time: float | None = None
 
     def record_tool_call(self, name: str, is_error: bool) -> None:
         self.tool_calls.append(ToolCallRecord(name=name, is_error=is_error))
+
+    def record_must_fix_injection(self) -> None:
+        """Increment when the MUST-FIX gate injects a fix-required message.
+
+        Training signal: agents that trigger many MUST-FIX injections are
+        less efficient per unit of successful work. GRPO can penalize on
+        this counter.
+        """
+        self.must_fix_injections += 1
 
     def finalize(self, reason: ExitReason) -> None:
         self.exit_reason = reason

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -132,11 +132,13 @@ def _build_tool_registry() -> tuple:
     risk_levels: dict[str, RiskLevel] = {}
 
     from godspeed.tools.background import BackgroundCheckTool
+    from godspeed.tools.coverage import CoverageTool
     from godspeed.tools.git import GitTool
     from godspeed.tools.glob_search import GlobSearchTool
     from godspeed.tools.grep_search import GrepSearchTool
     from godspeed.tools.notebook import NotebookEditTool
     from godspeed.tools.repo_map import RepoMapTool
+    from godspeed.tools.security_scan import SecurityScanTool
     from godspeed.tools.shell import ShellTool
     from godspeed.tools.test_runner import TestRunnerTool
     from godspeed.tools.verify import VerifyTool
@@ -154,6 +156,8 @@ def _build_tool_registry() -> tuple:
         VerifyTool(),
         RepoMapTool(),
         TestRunnerTool(),
+        CoverageTool(),
+        SecurityScanTool(),
         WebSearchTool(),
         WebFetchTool(),
         NotebookEditTool(),
@@ -880,6 +884,7 @@ async def _headless_run(
             "iterations_used": metrics.iterations_used,
             "tool_call_count": metrics.tool_call_count,
             "tool_error_count": metrics.tool_error_count,
+            "must_fix_injections": metrics.must_fix_injections,
             "duration_seconds": round(metrics.duration_seconds, 3),
             "cost_usd": round(llm_client.total_cost_usd, 6),
         },
@@ -895,6 +900,7 @@ async def _headless_run(
             iterations_used=metrics.iterations_used,
             tool_call_count=metrics.tool_call_count,
             tool_error_count=metrics.tool_error_count,
+            must_fix_injections=metrics.must_fix_injections,
             duration_seconds=metrics.duration_seconds,
             cost_usd=llm_client.total_cost_usd,
         )
@@ -913,6 +919,7 @@ async def _headless_run(
             "tool_calls": [{"name": tc.name, "is_error": tc.is_error} for tc in metrics.tool_calls],
             "tool_call_count": metrics.tool_call_count,
             "tool_error_count": metrics.tool_error_count,
+            "must_fix_injections": metrics.must_fix_injections,
             "duration_seconds": round(metrics.duration_seconds, 3),
             "input_tokens": llm_client.total_input_tokens,
             "output_tokens": llm_client.total_output_tokens,

--- a/src/godspeed/tools/coverage.py
+++ b/src/godspeed/tools/coverage.py
@@ -1,0 +1,184 @@
+"""Coverage tool — run pytest under coverage and report results.
+
+Wraps ``coverage run pytest`` + ``coverage report``. Optional dependency:
+if ``coverage`` or ``pytest`` is not installed, returns a clear error
+instead of crashing. Designed as a follow-up to ``test_runner`` for when
+the agent needs a quality signal beyond pass/fail.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+logger = logging.getLogger(__name__)
+
+COVERAGE_TIMEOUT = 180
+MAX_OUTPUT_CHARS = 5000
+
+
+class CoverageTool(Tool):
+    """Run pytest under ``coverage`` and report line/branch coverage.
+
+    Calls ``coverage run --source=<src_dir> -m pytest <target>`` then
+    ``coverage report -m``. Fails the tool call if coverage falls below
+    ``min_percent`` — lets the agent treat coverage as a gate, not a hint.
+
+    Requires the project to have both ``coverage`` and ``pytest`` installed.
+    Returns a clear error when either is missing (no attempt to install).
+    """
+
+    @property
+    def name(self) -> str:
+        return "coverage"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Run pytest under coverage and report line coverage per module. "
+            "Optional `min_percent` argument fails the call if overall "
+            "coverage is below that threshold — treat as a quality gate. "
+            "Requires `coverage` and `pytest` to be installed in the project.\n\n"
+            "Example: coverage()\n"
+            "Example: coverage(target='tests/test_api.py', min_percent=80)"
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": (
+                        "Optional pytest target (file or directory). "
+                        "Defaults to the project's configured test path."
+                    ),
+                },
+                "source": {
+                    "type": "string",
+                    "description": (
+                        "Optional --source argument for coverage "
+                        "(directory to measure, e.g. 'src/myproject'). "
+                        "Defaults to auto-detect: 'src' if present, else the cwd."
+                    ),
+                },
+                "min_percent": {
+                    "type": "number",
+                    "description": (
+                        "Optional minimum overall coverage percentage (0-100). "
+                        "If set, the tool call fails when coverage is below this."
+                    ),
+                },
+            },
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        coverage_bin = shutil.which("coverage")
+        if coverage_bin is None:
+            return ToolResult.failure(
+                "`coverage` is not installed in this environment. "
+                "Install with `pip install coverage` or `uv pip install coverage`."
+            )
+
+        target = arguments.get("target", "")
+        source = arguments.get("source") or _detect_source(context)
+        min_percent = arguments.get("min_percent")
+
+        run_cmd = [coverage_bin, "run"]
+        if source:
+            run_cmd.extend(["--source", source])
+        run_cmd.extend(["-m", "pytest"])
+        if target:
+            run_cmd.append(str(target))
+
+        logger.info("coverage run cmd=%r cwd=%s", run_cmd, context.cwd)
+        try:
+            run = subprocess.run(
+                run_cmd,
+                capture_output=True,
+                text=True,
+                timeout=COVERAGE_TIMEOUT,
+                cwd=str(context.cwd),
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult.failure(f"coverage run timed out after {COVERAGE_TIMEOUT}s")
+        except FileNotFoundError as exc:
+            return ToolResult.failure(f"coverage binary not executable: {exc}")
+
+        # pytest exit codes: 0=pass, 1=fail, 5=no tests. Non-zero means tests failed.
+        if run.returncode not in (0, 5):
+            out_tail = (run.stdout + run.stderr)[-MAX_OUTPUT_CHARS:]
+            return ToolResult.failure(f"pytest failed with exit code {run.returncode}\n{out_tail}")
+
+        # Now render the report.
+        try:
+            report = subprocess.run(
+                [coverage_bin, "report", "-m"],
+                capture_output=True,
+                text=True,
+                timeout=COVERAGE_TIMEOUT,
+                cwd=str(context.cwd),
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult.failure(f"coverage report timed out after {COVERAGE_TIMEOUT}s")
+
+        if report.returncode != 0:
+            tail = (report.stdout + report.stderr)[-MAX_OUTPUT_CHARS:]
+            return ToolResult.failure(f"coverage report failed\n{tail}")
+
+        report_text = report.stdout[-MAX_OUTPUT_CHARS:]
+        overall = _parse_overall_percent(report.stdout)
+
+        if min_percent is not None:
+            try:
+                threshold = float(min_percent)
+            except (TypeError, ValueError):
+                return ToolResult.failure(f"min_percent must be numeric, got {min_percent!r}")
+            if overall is None:
+                return ToolResult.failure(
+                    "Could not parse overall coverage percentage from report:\n" + report_text
+                )
+            if overall < threshold:
+                return ToolResult.failure(
+                    f"Coverage {overall:.1f}% is below min_percent={threshold:.1f}\n\n{report_text}"
+                )
+
+        header = f"Coverage: {overall:.1f}%\n\n" if overall is not None else ""
+        return ToolResult.success(header + report_text)
+
+
+def _detect_source(context: ToolContext) -> str:
+    """Pick a sensible --source default: prefer ./src, else cwd."""
+    src = context.cwd / "src"
+    if src.is_dir():
+        return "src"
+    return "."
+
+
+def _parse_overall_percent(report_output: str) -> float | None:
+    """Extract the overall percentage from ``coverage report`` output.
+
+    The last line of a standard report is like:
+        TOTAL                     1234    100   92%
+    with an optional 4th column for branch coverage. Returns None when
+    the TOTAL line is absent or unparseable.
+    """
+    for line in reversed(report_output.splitlines()):
+        if line.strip().startswith("TOTAL"):
+            tokens = line.split()
+            for tok in reversed(tokens):
+                if tok.endswith("%"):
+                    try:
+                        return float(tok.rstrip("%"))
+                    except ValueError:
+                        return None
+    return None

--- a/src/godspeed/tools/security_scan.py
+++ b/src/godspeed/tools/security_scan.py
@@ -1,0 +1,164 @@
+"""Security scan tool — run SAST on the project or a single file.
+
+Wraps ``bandit`` (Python SAST) and optionally ``semgrep`` (polyglot, rule-based).
+Both optional: the tool reports which scanners ran and which were skipped.
+If neither is available, returns a clear error so the agent can suggest install.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+logger = logging.getLogger(__name__)
+
+SCAN_TIMEOUT = 120
+MAX_OUTPUT_CHARS = 5000
+
+
+class SecurityScanTool(Tool):
+    """Run static security analysis on a target path.
+
+    - ``bandit`` for Python (Ruby on imports, AST-level issues)
+    - ``semgrep`` for polyglot rule-based scanning (when installed)
+
+    Returns a consolidated report with severity counts and per-finding detail.
+    Non-zero findings mark the result as an error so the agent can treat
+    security issues as gating rather than advisory.
+    """
+
+    @property
+    def name(self) -> str:
+        return "security_scan"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Run static security analysis (SAST) on a file or directory. "
+            "Uses bandit (Python) and semgrep (polyglot) when available. "
+            "Returns an error result when issues at severity >= low are found, "
+            "so callers can treat security findings as gating.\n\n"
+            "Example: security_scan(target='src/myapp')\n"
+            "Example: security_scan(target='src/myapp/auth.py', severity='medium')"
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": (
+                        "File or directory to scan (relative to project root). "
+                        "Defaults to 'src' if present, else the cwd."
+                    ),
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"],
+                    "description": (
+                        "Minimum severity level to report and to fail the "
+                        "tool call on. Defaults to 'low' (report everything)."
+                    ),
+                },
+            },
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        target = arguments.get("target") or _detect_target(context)
+        severity = arguments.get("severity", "low").lower()
+        if severity not in ("low", "medium", "high"):
+            return ToolResult.failure(f"severity must be one of low/medium/high, got {severity!r}")
+
+        bandit_bin = shutil.which("bandit")
+        semgrep_bin = shutil.which("semgrep")
+        if bandit_bin is None and semgrep_bin is None:
+            return ToolResult.failure(
+                "Neither `bandit` nor `semgrep` is installed. Install one with "
+                "`pip install bandit` or `pip install semgrep`."
+            )
+
+        sections: list[str] = []
+        any_findings = False
+
+        if bandit_bin is not None:
+            out, found = _run_bandit(bandit_bin, target, severity, context)
+            sections.append(out)
+            any_findings = any_findings or found
+
+        if semgrep_bin is not None:
+            out, found = _run_semgrep(semgrep_bin, target, context)
+            sections.append(out)
+            any_findings = any_findings or found
+
+        header = f"Security scan of {target} (min severity: {severity})\n"
+        body = header + "\n\n".join(sections)
+        body = body[-MAX_OUTPUT_CHARS:] if len(body) > MAX_OUTPUT_CHARS else body
+
+        if any_findings:
+            return ToolResult.failure(body)
+        return ToolResult.success(body)
+
+
+def _detect_target(context: ToolContext) -> str:
+    src = context.cwd / "src"
+    if src.is_dir():
+        return "src"
+    return "."
+
+
+_BANDIT_SEVERITY_FLAGS = {
+    "low": "-ll",
+    "medium": "-lll",
+    "high": "-llll",
+}
+
+
+def _run_bandit(
+    bandit_bin: str, target: str, severity: str, context: ToolContext
+) -> tuple[str, bool]:
+    flag = _BANDIT_SEVERITY_FLAGS.get(severity, "-ll")
+    cmd = [bandit_bin, "-r", target, flag, "-q"]
+    logger.info("bandit cmd=%r cwd=%s", cmd, context.cwd)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=SCAN_TIMEOUT,
+            cwd=str(context.cwd),
+        )
+    except subprocess.TimeoutExpired:
+        return f"[bandit] timed out after {SCAN_TIMEOUT}s", True
+    output = proc.stdout + proc.stderr
+    # bandit returns non-zero when issues are found
+    found = proc.returncode != 0
+    return f"## bandit\n{output.strip() or '(no issues)'}", found
+
+
+def _run_semgrep(semgrep_bin: str, target: str, context: ToolContext) -> tuple[str, bool]:
+    cmd = [semgrep_bin, "--config=auto", "--error", "--quiet", target]
+    logger.info("semgrep cmd=%r cwd=%s", cmd, context.cwd)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=SCAN_TIMEOUT,
+            cwd=str(context.cwd),
+        )
+    except subprocess.TimeoutExpired:
+        return f"[semgrep] timed out after {SCAN_TIMEOUT}s", True
+    output = proc.stdout + proc.stderr
+    # semgrep with --error returns non-zero when rules match
+    found = proc.returncode != 0
+    return f"## semgrep\n{output.strip() or '(no issues)'}", found

--- a/src/godspeed/tools/verify.py
+++ b/src/godspeed/tools/verify.py
@@ -27,6 +27,12 @@ _FIXABLE_LANGUAGES: frozenset[str] = frozenset({"python", "javascript", "typescr
 # Timeout for linter subprocess
 VERIFY_TIMEOUT = 30
 
+# Sentinel substring embedded in the output when auto-fix-with-retry exhausts
+# retries with lint errors still present. loop.py's MUST-FIX gate matches this
+# substring to detect silent-success-with-remaining-errors. Keep in sync if
+# the output format ever changes.
+REMAINING_ERRORS_FINGERPRINT = "some remaining"
+
 # Extension → verifier function mapping
 _EXTENSION_MAP: dict[str, str] = {
     ".py": "python",
@@ -312,7 +318,7 @@ def _verify_with_retry(
     remaining_output = final.output if not final.is_error else (final.error or "")
     return ToolResult.success(
         f"Auto-fixed {total_fixed} round(s) of issues, "
-        f"some remaining: {display_path}\n{remaining_output}"
+        f"{REMAINING_ERRORS_FINGERPRINT}: {display_path}\n{remaining_output}"
     )
 
 

--- a/src/godspeed/training/conversation_logger.py
+++ b/src/godspeed/training/conversation_logger.py
@@ -107,6 +107,7 @@ class ConversationLogger:
         tool_error_count: int,
         duration_seconds: float,
         cost_usd: float,
+        must_fix_injections: int = 0,
     ) -> None:
         """Terminal record per session.
 
@@ -114,6 +115,10 @@ class ConversationLogger:
         stay comparable. Downstream RL (GRPO) reads exit_code to shape
         rewards: +1.0 on SUCCESS, -0.5 on TOOL_ERROR, -1.0 on
         MAX_ITERATIONS, etc. See ml-lab phase4_grpo.yaml for the mapping.
+
+        `must_fix_injections` (v2.6.0+) is a quality signal: agents that
+        triggered many fix-required injections are less efficient per unit
+        of successful work.
         """
         self._write(
             {
@@ -123,6 +128,7 @@ class ConversationLogger:
                 "iterations_used": iterations_used,
                 "tool_call_count": tool_call_count,
                 "tool_error_count": tool_error_count,
+                "must_fix_injections": must_fix_injections,
                 "duration_seconds": round(duration_seconds, 3),
                 "cost_usd": round(cost_usd, 6),
             }

--- a/tests/test_agent_result.py
+++ b/tests/test_agent_result.py
@@ -65,8 +65,15 @@ class TestAgentMetrics:
         assert m.iterations_used == 0
         assert m.tool_call_count == 0
         assert m.tool_error_count == 0
+        assert m.must_fix_injections == 0
         assert m.end_time is None
         assert m.exit_reason == ExitReason.STOPPED
+
+    def test_record_must_fix_injection_increments(self) -> None:
+        m = AgentMetrics()
+        m.record_must_fix_injection()
+        m.record_must_fix_injection()
+        assert m.must_fix_injections == 2
 
     def test_record_tool_call(self) -> None:
         m = AgentMetrics()
@@ -89,11 +96,13 @@ class TestAgentMetrics:
         assert m.exit_code == ExitCode.MAX_ITERATIONS
 
     def test_duration_before_finalize(self) -> None:
-        """duration_seconds should work even before finalize() is called."""
+        """duration_seconds should return a non-negative value (doesn't raise)
+        even before finalize() has set end_time. Windows monotonic() has
+        coarse granularity so we only assert non-negative, not >0."""
         m = AgentMetrics()
         time.sleep(0.01)
         d = m.duration_seconds
-        assert d > 0
+        assert d >= 0.0
 
 
 class TestAgentLoopPopulatesMetrics:

--- a/tests/test_coverage_tool.py
+++ b/tests/test_coverage_tool.py
@@ -1,0 +1,109 @@
+"""Tests for the coverage tool (v2.6.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+from godspeed.tools.coverage import CoverageTool, _parse_overall_percent
+
+
+class TestParseOverallPercent:
+    def test_parses_standard_total_line(self) -> None:
+        report = """Name                     Stmts   Miss  Cover
+src/app.py                  50     4    92%
+TOTAL                      100     8    92%
+"""
+        assert _parse_overall_percent(report) == 92.0
+
+    def test_parses_with_branch_column(self) -> None:
+        report = "TOTAL    100    4    40    2    95%\n"
+        assert _parse_overall_percent(report) == 95.0
+
+    def test_none_when_no_total_line(self) -> None:
+        assert _parse_overall_percent("something random") is None
+
+    def test_handles_decimal_percentage(self) -> None:
+        report = "TOTAL    100    3    97.5%\n"
+        assert _parse_overall_percent(report) == 97.5
+
+
+class TestCoverageTool:
+    @pytest.mark.asyncio
+    async def test_missing_coverage_binary_returns_clear_error(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = CoverageTool()
+        with patch("godspeed.tools.coverage.shutil.which", return_value=None):
+            result = await tool.execute({}, ctx)
+        assert result.is_error
+        assert "coverage" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_success_path_returns_report(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = CoverageTool()
+
+        run_result = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        report_result = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                "Name            Stmts   Miss  Cover\n"
+                "src/app.py         10      1    90%\n"
+                "TOTAL              10      1    90%\n"
+            ),
+            stderr="",
+        )
+        with (
+            patch("godspeed.tools.coverage.shutil.which", return_value="/usr/bin/coverage"),
+            patch(
+                "godspeed.tools.coverage.subprocess.run",
+                side_effect=[run_result, report_result],
+            ),
+        ):
+            result = await tool.execute({}, ctx)
+
+        assert not result.is_error
+        assert "Coverage: 90.0%" in result.output
+        assert "src/app.py" in result.output
+
+    @pytest.mark.asyncio
+    async def test_min_percent_fails_when_below_threshold(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = CoverageTool()
+        run_result = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        report_result = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="TOTAL    10    5    50%\n",
+            stderr="",
+        )
+        with (
+            patch("godspeed.tools.coverage.shutil.which", return_value="/usr/bin/coverage"),
+            patch(
+                "godspeed.tools.coverage.subprocess.run",
+                side_effect=[run_result, report_result],
+            ),
+        ):
+            result = await tool.execute({"min_percent": 80}, ctx)
+        assert result.is_error
+        assert "50" in (result.error or "")
+        assert "80" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_pytest_failure_propagates(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = CoverageTool()
+        # pytest returncode 1 = tests failed
+        run_result = CompletedProcess(args=[], returncode=1, stdout="fail", stderr="")
+        with (
+            patch("godspeed.tools.coverage.shutil.which", return_value="/usr/bin/coverage"),
+            patch("godspeed.tools.coverage.subprocess.run", side_effect=[run_result]),
+        ):
+            result = await tool.execute({}, ctx)
+        assert result.is_error
+        assert "pytest failed" in (result.error or "")

--- a/tests/test_must_fix_gate.py
+++ b/tests/test_must_fix_gate.py
@@ -15,6 +15,7 @@ import pytest
 
 from godspeed.agent.conversation import Conversation
 from godspeed.agent.loop import MUST_FIX_CAP, _maybe_inject_must_fix, agent_loop
+from godspeed.agent.result import AgentMetrics
 from godspeed.llm.client import ChatResponse, LLMClient
 from godspeed.tools.base import ToolResult
 from godspeed.tools.registry import ToolRegistry
@@ -77,6 +78,23 @@ class TestMaybeInjectMustFix:
         convo = Conversation("sys", max_tokens=100_000)
         assert _maybe_inject_must_fix(convo, "x.py", "", 0) == 0
         assert _maybe_inject_must_fix(convo, "x.py", None, 0) == 0  # type: ignore[arg-type]
+
+    def test_injection_records_on_metrics(self) -> None:
+        """When metrics is provided, each injection bumps the counter."""
+        convo = Conversation("sys", max_tokens=100_000)
+        metrics = AgentMetrics()
+        verify_output = "Auto-fixed 2 rounds, some remaining: app.py\nF401"
+        out = _maybe_inject_must_fix(convo, "app.py", verify_output, 0, metrics)
+        assert out == 1
+        assert metrics.must_fix_injections == 1
+
+    def test_cap_reached_does_not_record_on_metrics(self) -> None:
+        """After the cap the gate doesn't inject — metrics should not increment."""
+        convo = Conversation("sys", max_tokens=100_000)
+        metrics = AgentMetrics()
+        verify_output = "Auto-fixed rounds, some remaining: app.py"
+        _maybe_inject_must_fix(convo, "app.py", verify_output, MUST_FIX_CAP, metrics)
+        assert metrics.must_fix_injections == 0
 
 
 class TestMustFixGateInAgentLoop:

--- a/tests/test_security_scan_tool.py
+++ b/tests/test_security_scan_tool.py
@@ -1,0 +1,82 @@
+"""Tests for the security_scan tool (v2.6.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+from godspeed.tools.security_scan import SecurityScanTool
+
+
+class TestSecurityScanTool:
+    @pytest.mark.asyncio
+    async def test_no_scanners_installed_returns_clear_error(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = SecurityScanTool()
+        with patch("godspeed.tools.security_scan.shutil.which", return_value=None):
+            result = await tool.execute({}, ctx)
+        assert result.is_error
+        assert "bandit" in (result.error or "").lower()
+        assert "semgrep" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_clean_bandit_run_reports_no_issues(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = SecurityScanTool()
+        # returncode 0 = no issues for bandit
+        clean = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with (
+            patch(
+                "godspeed.tools.security_scan.shutil.which",
+                side_effect=lambda name: "/usr/bin/bandit" if name == "bandit" else None,
+            ),
+            patch("godspeed.tools.security_scan.subprocess.run", return_value=clean),
+        ):
+            result = await tool.execute({"target": "src"}, ctx)
+        assert not result.is_error
+        assert "bandit" in result.output
+
+    @pytest.mark.asyncio
+    async def test_bandit_findings_produce_error_result(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = SecurityScanTool()
+        issue = CompletedProcess(args=[], returncode=1, stdout="Issue: [B102] exec_used", stderr="")
+        with (
+            patch(
+                "godspeed.tools.security_scan.shutil.which",
+                side_effect=lambda name: "/usr/bin/bandit" if name == "bandit" else None,
+            ),
+            patch("godspeed.tools.security_scan.subprocess.run", return_value=issue),
+        ):
+            result = await tool.execute({"target": "src"}, ctx)
+        assert result.is_error
+        assert "B102" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_invalid_severity_rejected(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = SecurityScanTool()
+        result = await tool.execute({"severity": "critical"}, ctx)
+        assert result.is_error
+        assert "severity" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_both_scanners_run_when_available(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = SecurityScanTool()
+        clean = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with (
+            patch(
+                "godspeed.tools.security_scan.shutil.which",
+                side_effect=lambda name: f"/usr/bin/{name}",
+            ),
+            patch("godspeed.tools.security_scan.subprocess.run", return_value=clean),
+        ):
+            result = await tool.execute({"target": "src"}, ctx)
+        assert not result.is_error
+        assert "bandit" in result.output
+        assert "semgrep" in result.output

--- a/tests/test_training/test_session_end.py
+++ b/tests/test_training/test_session_end.py
@@ -30,6 +30,7 @@ def test_log_session_end_writes_expected_record(tmp_path: Path) -> None:
             tool_error_count=0,
             duration_seconds=12.3456,
             cost_usd=0.012345,
+            must_fix_injections=2,
         )
     finally:
         logger.close()
@@ -43,6 +44,7 @@ def test_log_session_end_writes_expected_record(tmp_path: Path) -> None:
     assert end["iterations_used"] == 3
     assert end["tool_call_count"] == 5
     assert end["tool_error_count"] == 0
+    assert end["must_fix_injections"] == 2
     # Fields rounded as documented
     assert end["duration_seconds"] == 12.346
     assert end["cost_usd"] == 0.012345


### PR DESCRIPTION
## Summary

Minor release closing the top follow-ups from the v2.5.1 review. Two new agent-callable quality tools + one new training-signal counter + fingerprint coupling cleanup.

## What's new

### \`coverage\` tool
Wraps \`coverage run pytest\` + \`coverage report -m\` with a \`min_percent\` quality gate. The agent can now enforce coverage thresholds during edits rather than after.

### \`security_scan\` tool
Wraps \`bandit\` + optional \`semgrep\`. Non-zero findings produce error results so the agent treats security issues as gating rather than advisory. Configurable severity floor.

### \`AgentMetrics.must_fix_injections\`
New counter tracking how many times the MUST-FIX gate fired per session. Exposed in audit detail, headless JSON output, and \`log_session_end\` record. Training signal for GRPO — fewer injections = more efficient agent.

### \`verify.REMAINING_ERRORS_FINGERPRINT\`
The \"some remaining\" string literal that the MUST-FIX gate matches against is now a shared constant, eliminating the v2.5.1 review's flagged coupling.

## Audit

| Check | Result |
|---|---|
| \`ruff check .\` | ✅ all checks passed |
| \`ruff format --check .\` | ✅ 205 files formatted |
| \`mypy src/godspeed --ignore-missing-imports\` | ✅ 0 issues / 98 files |
| \`pytest -q --cov --cov-fail-under=80\` | ✅ **1,653 passed, 2 skipped, 85.85% coverage** |
| Version bump | 2.5.1 → 2.6.0 (minor — new user-facing tools) |

## Tests (+16 new)

- \`test_coverage_tool.py\` (8): parser invariants + tool integration (missing binary, success path, min_percent gate, pytest failure)
- \`test_security_scan_tool.py\` (5): missing scanners, clean run, findings, invalid severity, both-scanners-available
- \`test_must_fix_gate.py\` (+2): metrics counter increments on inject, does not after cap
- \`test_agent_result.py\` (+1): \`record_must_fix_injection\` method

## Deferred to v2.7.0

Per the v2.5.1 plan's deferred list:
- Fix \`verify._verify_with_retry\` to return \`ToolResult.failure\` semantically (breaks 3 existing tests — needs a cohesive pass)
- \`complexity\`, \`dep_audit\`, \`generate_tests\`, auto-index tools
- E2E drift test asserting audit + training-log streams agree on exit_reason / exit_code

## Test plan

- [x] ruff / format / mypy / tests all green locally
- [x] Coverage gate met (85.85%)
- [x] New tools register in \`_build_tool_registry\`
- [x] \`must_fix_injections\` counter propagates: loop → metrics → headless JSON + audit detail + log_session_end
- [x] Fingerprint constant is the single source of truth (one definition, one import)
- [ ] Maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)