### PR TITLE
feat(v2.7.0): complexity + dep_audit tools; audit-log drift test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] — 2026-04-17
+
+Quality-tooling minor release, continuation of v2.6.0. Closes two more
+deferred items from the v2.5.1 review and adds an integration-level
+invariant check between the audit trail and training log.
+
+### Added
+
+- **`complexity` tool** (`src/godspeed/tools/complexity.py`) — wraps
+  `radon cc` (Python, with grade mapping from the McCabe CC threshold)
+  and `lizard` (polyglot, when installed). Functions above `max_cc`
+  (default 10) fail the call — lets the agent enforce a complexity
+  budget on edits rather than catching it in code review.
+- **`dep_audit` tool** (`src/godspeed/tools/dep_audit.py`) — auto-detects
+  the project's package manager from manifests (`pyproject.toml` /
+  `requirements.txt` → pip-audit; `package.json` → npm audit;
+  `Cargo.toml` → cargo-audit) and runs the matching CVE scanner.
+  Vulnerabilities produce an error result so the agent treats them as
+  gating. Explicit `manager` argument overrides detection.
+- **E2E drift test** (`tests/test_audit_log_drift.py`) — integration-level
+  assertion that the audit trail's `session_end` detail and
+  `ConversationLogger.log_session_end` record agree on every field
+  (`exit_reason`, `exit_code`, all metrics). Catches regressions where
+  the two streams could drift after independent edits.
+
+### Changed
+
+- `_build_tool_registry` (`cli.py`) registers `ComplexityTool` and
+  `DepAuditTool` alongside the existing quality tools.
+
 ## [2.6.0] — 2026-04-17
 
 Quality-tooling minor release. Two new tools the agent can call to enforce

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed"
-version = "2.6.0"
+version = "2.7.0"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.6.0"
+__version__ = "2.7.0"

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -132,7 +132,9 @@ def _build_tool_registry() -> tuple:
     risk_levels: dict[str, RiskLevel] = {}
 
     from godspeed.tools.background import BackgroundCheckTool
+    from godspeed.tools.complexity import ComplexityTool
     from godspeed.tools.coverage import CoverageTool
+    from godspeed.tools.dep_audit import DepAuditTool
     from godspeed.tools.git import GitTool
     from godspeed.tools.glob_search import GlobSearchTool
     from godspeed.tools.grep_search import GrepSearchTool
@@ -158,6 +160,8 @@ def _build_tool_registry() -> tuple:
         TestRunnerTool(),
         CoverageTool(),
         SecurityScanTool(),
+        ComplexityTool(),
+        DepAuditTool(),
         WebSearchTool(),
         WebFetchTool(),
         NotebookEditTool(),

--- a/src/godspeed/tools/complexity.py
+++ b/src/godspeed/tools/complexity.py
@@ -1,0 +1,191 @@
+"""Complexity tool — surface functions likely to need refactoring.
+
+Wraps ``radon`` (cyclomatic + maintainability) for Python and ``lizard``
+(polyglot cyclomatic + length) when installed. Both optional. Returns an
+error result when any function exceeds the configured cyclomatic threshold
+so the agent can treat complexity as a gate.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+logger = logging.getLogger(__name__)
+
+COMPLEXITY_TIMEOUT = 60
+MAX_OUTPUT_CHARS = 5000
+
+# Default cyclomatic-complexity ceiling: anything above this is flagged.
+# 10 is the commonly cited "avoid unless necessary" threshold (McCabe 1976).
+DEFAULT_MAX_CC = 10
+
+
+class ComplexityTool(Tool):
+    """Report cyclomatic complexity + flag functions above a threshold.
+
+    - ``radon`` for Python (cyclomatic + maintainability index)
+    - ``lizard`` for polyglot (cyclomatic + function length, when installed)
+
+    Fails the tool call when any function's cyclomatic complexity exceeds
+    ``max_cc`` (default 10). Lets the agent enforce a complexity budget per
+    edit rather than catching violations in code review.
+    """
+
+    @property
+    def name(self) -> str:
+        return "complexity"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Report cyclomatic complexity on a file or directory. "
+            "Uses radon (Python) and lizard (polyglot) when available. "
+            "Fails the call when any function exceeds max_cc (default 10), "
+            "so callers can treat complexity as a budget.\n\n"
+            "Example: complexity(target='src/myapp')\n"
+            "Example: complexity(target='src/myapp/core.py', max_cc=15)"
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": (
+                        "File or directory to analyze (relative to project root). "
+                        "Defaults to 'src' if present, else the cwd."
+                    ),
+                },
+                "max_cc": {
+                    "type": "integer",
+                    "description": (
+                        f"Maximum cyclomatic complexity per function "
+                        f"(default: {DEFAULT_MAX_CC}). Findings above this "
+                        "threshold fail the tool call."
+                    ),
+                },
+            },
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        target = arguments.get("target") or _detect_target(context)
+        max_cc = int(arguments.get("max_cc", DEFAULT_MAX_CC))
+        if max_cc <= 0:
+            return ToolResult.failure(f"max_cc must be positive, got {max_cc}")
+
+        radon_bin = shutil.which("radon")
+        lizard_bin = shutil.which("lizard")
+        if radon_bin is None and lizard_bin is None:
+            return ToolResult.failure(
+                "Neither `radon` nor `lizard` is installed. Install with "
+                "`pip install radon` or `pip install lizard`."
+            )
+
+        sections: list[str] = []
+        any_breach = False
+
+        if radon_bin is not None:
+            out, breach = _run_radon(radon_bin, target, max_cc, context)
+            sections.append(out)
+            any_breach = any_breach or breach
+
+        if lizard_bin is not None:
+            out, breach = _run_lizard(lizard_bin, target, max_cc, context)
+            sections.append(out)
+            any_breach = any_breach or breach
+
+        header = f"Complexity scan of {target} (max_cc: {max_cc})\n"
+        body = header + "\n\n".join(sections)
+        body = body[-MAX_OUTPUT_CHARS:] if len(body) > MAX_OUTPUT_CHARS else body
+
+        if any_breach:
+            return ToolResult.failure(body)
+        return ToolResult.success(body)
+
+
+def _detect_target(context: ToolContext) -> str:
+    src = context.cwd / "src"
+    if src.is_dir():
+        return "src"
+    return "."
+
+
+def _run_radon(radon_bin: str, target: str, max_cc: int, context: ToolContext) -> tuple[str, bool]:
+    """Run ``radon cc -s -n <letter>`` to report functions above the threshold.
+
+    radon maps grades to ranges: A=1-5, B=6-10, C=11-20, D=21-30, E=31-40, F=41+.
+    We map max_cc to the minimum grade to show and use that as the breach signal.
+    """
+    min_grade = _cc_to_radon_grade(max_cc + 1)
+    cmd = [radon_bin, "cc", target, "-s", "-n", min_grade]
+    logger.info("radon cmd=%r cwd=%s", cmd, context.cwd)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=COMPLEXITY_TIMEOUT,
+            cwd=str(context.cwd),
+        )
+    except subprocess.TimeoutExpired:
+        return f"[radon] timed out after {COMPLEXITY_TIMEOUT}s", True
+
+    output = proc.stdout.strip()
+    # radon prints nothing when no function exceeds the threshold.
+    if not output:
+        return f"## radon\nAll functions within CC <= {max_cc}.", False
+    return f"## radon (functions above max_cc={max_cc})\n{output}", True
+
+
+def _cc_to_radon_grade(cc: int) -> str:
+    """Map a cyclomatic complexity value to its radon grade letter."""
+    if cc <= 5:
+        return "A"
+    if cc <= 10:
+        return "B"
+    if cc <= 20:
+        return "C"
+    if cc <= 30:
+        return "D"
+    if cc <= 40:
+        return "E"
+    return "F"
+
+
+def _run_lizard(
+    lizard_bin: str, target: str, max_cc: int, context: ToolContext
+) -> tuple[str, bool]:
+    """Run ``lizard --CCN <max_cc> -w <target>`` to report over-threshold functions.
+
+    ``-w`` prints warnings only (one line per over-threshold function).
+    Exit code is non-zero when any function exceeds the threshold.
+    """
+    cmd = [lizard_bin, "--CCN", str(max_cc), "-w", target]
+    logger.info("lizard cmd=%r cwd=%s", cmd, context.cwd)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=COMPLEXITY_TIMEOUT,
+            cwd=str(context.cwd),
+        )
+    except subprocess.TimeoutExpired:
+        return f"[lizard] timed out after {COMPLEXITY_TIMEOUT}s", True
+
+    output = (proc.stdout + proc.stderr).strip()
+    breach = proc.returncode != 0
+    if not output:
+        return f"## lizard\nAll functions within CC <= {max_cc}.", False
+    return f"## lizard (functions above max_cc={max_cc})\n{output}", breach

--- a/src/godspeed/tools/dep_audit.py
+++ b/src/godspeed/tools/dep_audit.py
@@ -1,0 +1,206 @@
+"""Dep-audit tool — scan project dependencies for known CVEs.
+
+Auto-detects the project's package manager from the working directory:
+- ``pyproject.toml`` / ``requirements.txt`` → ``pip-audit``
+- ``package.json`` → ``npm audit``
+- ``Cargo.toml`` → ``cargo audit`` (when installed)
+
+All scanners optional; if none installed and a relevant manifest is
+present, returns a clear error asking the agent to install the right one.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import Any
+
+from godspeed.tools.base import RiskLevel, Tool, ToolContext, ToolResult
+
+logger = logging.getLogger(__name__)
+
+AUDIT_TIMEOUT = 120
+MAX_OUTPUT_CHARS = 5000
+
+
+class DepAuditTool(Tool):
+    """Scan project dependencies for known CVEs.
+
+    Detects the package manager from files in the project root and runs
+    the matching auditor. Non-zero vulnerabilities produce an error
+    result so the agent treats them as gating.
+    """
+
+    @property
+    def name(self) -> str:
+        return "dep_audit"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Scan project dependencies for known CVEs. Auto-detects the "
+            "package manager (pip / npm / cargo) from project files. "
+            "Returns an error result when vulnerabilities are found so "
+            "the agent treats them as gating.\n\n"
+            "Example: dep_audit()\n"
+            "Example: dep_audit(manager='pip')"
+        )
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        return RiskLevel.READ_ONLY
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "manager": {
+                    "type": "string",
+                    "enum": ["pip", "npm", "cargo", "auto"],
+                    "description": (
+                        "Package manager to audit. Defaults to 'auto' "
+                        "which detects from project files. Explicit "
+                        "values override detection."
+                    ),
+                },
+            },
+            "required": [],
+        }
+
+    async def execute(self, arguments: dict[str, Any], context: ToolContext) -> ToolResult:
+        requested = arguments.get("manager", "auto").lower()
+        if requested not in ("pip", "npm", "cargo", "auto"):
+            return ToolResult.failure(
+                f"manager must be one of pip/npm/cargo/auto, got {requested!r}"
+            )
+
+        managers = _detect_managers(context) if requested == "auto" else [requested]
+        if not managers:
+            return ToolResult.failure(
+                "No supported package manifest found in project "
+                "(looked for pyproject.toml/requirements.txt, package.json, Cargo.toml)."
+            )
+
+        sections: list[str] = []
+        any_vulns = False
+        ran_any = False
+
+        for mgr in managers:
+            out, vuln, ran = _run_one(mgr, context)
+            if ran:
+                ran_any = True
+                sections.append(out)
+                any_vulns = any_vulns or vuln
+
+        if not ran_any:
+            # Every detected manager had its auditor uninstalled.
+            detected = ", ".join(managers)
+            return ToolResult.failure(
+                f"Detected package manager(s) [{detected}] but none of the "
+                "corresponding auditors are installed. Install with one of "
+                "`pip install pip-audit`, `npm install -g npm`, or "
+                "`cargo install cargo-audit`."
+            )
+
+        body = "\n\n".join(sections)
+        body = body[-MAX_OUTPUT_CHARS:] if len(body) > MAX_OUTPUT_CHARS else body
+
+        if any_vulns:
+            return ToolResult.failure(body)
+        return ToolResult.success(body)
+
+
+def _detect_managers(context: ToolContext) -> list[str]:
+    """Return the ordered list of package managers detected from files."""
+    managers: list[str] = []
+    cwd = context.cwd
+    if (cwd / "pyproject.toml").exists() or (cwd / "requirements.txt").exists():
+        managers.append("pip")
+    if (cwd / "package.json").exists():
+        managers.append("npm")
+    if (cwd / "Cargo.toml").exists():
+        managers.append("cargo")
+    return managers
+
+
+def _run_one(manager: str, context: ToolContext) -> tuple[str, bool, bool]:
+    """Run the auditor for one manager.
+
+    Returns (section_text, has_vulns, did_run). When did_run is False the
+    auditor binary is missing and the tool call hasn't consumed that slot.
+    """
+    if manager == "pip":
+        return _run_pip_audit(context)
+    if manager == "npm":
+        return _run_npm_audit(context)
+    if manager == "cargo":
+        return _run_cargo_audit(context)
+    return (f"[dep_audit] unknown manager: {manager}", False, False)
+
+
+def _run_pip_audit(context: ToolContext) -> tuple[str, bool, bool]:
+    pip_audit_bin = shutil.which("pip-audit")
+    if pip_audit_bin is None:
+        return ("", False, False)
+    cmd = [pip_audit_bin, "--strict"]
+    logger.info("pip-audit cmd=%r cwd=%s", cmd, context.cwd)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=AUDIT_TIMEOUT,
+            cwd=str(context.cwd),
+        )
+    except subprocess.TimeoutExpired:
+        return (f"[pip-audit] timed out after {AUDIT_TIMEOUT}s", True, True)
+    output = (proc.stdout + proc.stderr).strip()
+    vuln = proc.returncode != 0
+    return (f"## pip-audit\n{output or '(no vulnerabilities)'}", vuln, True)
+
+
+def _run_npm_audit(context: ToolContext) -> tuple[str, bool, bool]:
+    npm_bin = shutil.which("npm")
+    if npm_bin is None:
+        return ("", False, False)
+    cmd = [npm_bin, "audit", "--audit-level=low"]
+    logger.info("npm-audit cmd=%r cwd=%s", cmd, context.cwd)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=AUDIT_TIMEOUT,
+            cwd=str(context.cwd),
+        )
+    except subprocess.TimeoutExpired:
+        return (f"[npm audit] timed out after {AUDIT_TIMEOUT}s", True, True)
+    output = (proc.stdout + proc.stderr).strip()
+    vuln = proc.returncode != 0
+    return (f"## npm audit\n{output or '(no vulnerabilities)'}", vuln, True)
+
+
+def _run_cargo_audit(context: ToolContext) -> tuple[str, bool, bool]:
+    cargo_bin = shutil.which("cargo")
+    if cargo_bin is None:
+        return ("", False, False)
+    cmd = [cargo_bin, "audit", "--quiet"]
+    logger.info("cargo-audit cmd=%r cwd=%s", cmd, context.cwd)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=AUDIT_TIMEOUT,
+            cwd=str(context.cwd),
+        )
+    except subprocess.TimeoutExpired:
+        return (f"[cargo-audit] timed out after {AUDIT_TIMEOUT}s", True, True)
+    # `cargo audit` is a subcommand — if cargo-audit isn't installed, cargo
+    # returns a usage error. Treat exit 101 (no such command) as "not installed".
+    if proc.returncode == 101 and "no such command" in (proc.stderr or "").lower():
+        return ("", False, False)
+    output = (proc.stdout + proc.stderr).strip()
+    vuln = proc.returncode != 0
+    return (f"## cargo audit\n{output or '(no vulnerabilities)'}", vuln, True)

--- a/tests/test_audit_log_drift.py
+++ b/tests/test_audit_log_drift.py
@@ -1,0 +1,83 @@
+"""E2E drift test: audit trail and conversation log must agree on session_end.
+
+The two logs are written independently from `_headless_run`. If they ever
+drift on `exit_reason`, `exit_code`, or the metrics fields, downstream RL
+sees inconsistent signals. This test asserts the invariant in one
+integration-style run so regressions surface immediately.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.cli import _headless_run
+from godspeed.llm.client import ChatResponse
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_audit_and_conversation_log_agree_on_session_end(tmp_path: Path, monkeypatch) -> None:
+    """Audit session_end and conversation session_end must carry the same
+    values for exit_reason, exit_code, and every metrics field.
+    """
+    monkeypatch.setenv("GODSPEED_GLOBAL_DIR", str(tmp_path / "godspeed"))
+    monkeypatch.setenv("GODSPEED_LOG_CONVERSATIONS", "true")
+
+    async def fake_chat(self, messages, tools=None, task_type=None):
+        return ChatResponse(content="done", finish_reason="stop")
+
+    with (
+        patch("godspeed.llm.client.LLMClient.chat", new=fake_chat),
+        patch("sys.stdout.write"),
+    ):
+        exit_code = await _headless_run(
+            task="say done",
+            model="test-model",
+            project_dir=tmp_path,
+            auto_approve="reads",
+            max_iterations=5,
+            timeout=0,
+            json_output=False,
+        )
+
+    audit_dir = tmp_path / "godspeed" / "audit"
+    training_dir = tmp_path / "godspeed" / "training"
+
+    audit_files = list(audit_dir.glob("*.audit.jsonl"))
+    training_files = list(training_dir.glob("*.conversation.jsonl"))
+    assert len(audit_files) == 1, "expected one audit log"
+    assert len(training_files) == 1, "expected one conversation log"
+
+    audit_records = _read_jsonl(audit_files[0])
+    training_records = _read_jsonl(training_files[0])
+
+    audit_end = next(r for r in audit_records if r.get("action_type") == "session_end")
+    training_end = next(r for r in training_records if r.get("role") == "session_end")
+
+    # Core invariant: both records agree on the exit signal and metrics.
+    audit_detail = audit_end["action_detail"]
+    for field in (
+        "exit_reason",
+        "exit_code",
+        "iterations_used",
+        "tool_call_count",
+        "tool_error_count",
+        "must_fix_injections",
+        "duration_seconds",
+        "cost_usd",
+    ):
+        assert audit_detail[field] == training_end[field], (
+            f"Drift on field {field}: "
+            f"audit={audit_detail[field]!r} vs training={training_end[field]!r}"
+        )
+
+    # Cross-check with the returned exit_code so the full chain is consistent.
+    assert exit_code == audit_detail["exit_code"] == training_end["exit_code"]

--- a/tests/test_complexity_tool.py
+++ b/tests/test_complexity_tool.py
@@ -1,0 +1,111 @@
+"""Tests for the complexity tool (v2.7.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+from godspeed.tools.complexity import ComplexityTool, _cc_to_radon_grade
+
+
+class TestCcToRadonGrade:
+    @pytest.mark.parametrize(
+        ("cc", "expected"),
+        [
+            (1, "A"),
+            (5, "A"),
+            (6, "B"),
+            (10, "B"),
+            (11, "C"),
+            (20, "C"),
+            (21, "D"),
+            (30, "D"),
+            (31, "E"),
+            (40, "E"),
+            (41, "F"),
+            (100, "F"),
+        ],
+    )
+    def test_grade_boundaries(self, cc: int, expected: str) -> None:
+        assert _cc_to_radon_grade(cc) == expected
+
+
+class TestComplexityTool:
+    @pytest.mark.asyncio
+    async def test_no_tools_installed_returns_error(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = ComplexityTool()
+        with patch("godspeed.tools.complexity.shutil.which", return_value=None):
+            result = await tool.execute({}, ctx)
+        assert result.is_error
+        err = (result.error or "").lower()
+        assert "radon" in err
+        assert "lizard" in err
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_cc_rejected(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = ComplexityTool()
+        result = await tool.execute({"max_cc": 0}, ctx)
+        assert result.is_error
+        assert "max_cc" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_clean_radon_run(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = ComplexityTool()
+        clean = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with (
+            patch(
+                "godspeed.tools.complexity.shutil.which",
+                side_effect=lambda name: "/usr/bin/radon" if name == "radon" else None,
+            ),
+            patch("godspeed.tools.complexity.subprocess.run", return_value=clean),
+        ):
+            result = await tool.execute({"target": "src", "max_cc": 10}, ctx)
+        assert not result.is_error
+        assert "radon" in result.output
+        assert "All functions within CC <= 10" in result.output
+
+    @pytest.mark.asyncio
+    async def test_radon_findings_produce_error(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = ComplexityTool()
+        found = CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="src/app.py\n  F 24:0 bad_func - C (15)",
+            stderr="",
+        )
+        with (
+            patch(
+                "godspeed.tools.complexity.shutil.which",
+                side_effect=lambda name: "/usr/bin/radon" if name == "radon" else None,
+            ),
+            patch("godspeed.tools.complexity.subprocess.run", return_value=found),
+        ):
+            result = await tool.execute({"target": "src"}, ctx)
+        assert result.is_error
+        assert "bad_func" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_lizard_nonzero_exit_is_breach(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = ComplexityTool()
+        # lizard exits non-zero when functions exceed the threshold
+        breach = CompletedProcess(
+            args=[], returncode=1, stdout="src/a.py:12: complex_func CCN=15", stderr=""
+        )
+        with (
+            patch(
+                "godspeed.tools.complexity.shutil.which",
+                side_effect=lambda name: "/usr/bin/lizard" if name == "lizard" else None,
+            ),
+            patch("godspeed.tools.complexity.subprocess.run", return_value=breach),
+        ):
+            result = await tool.execute({"target": "src"}, ctx)
+        assert result.is_error

--- a/tests/test_dep_audit_tool.py
+++ b/tests/test_dep_audit_tool.py
@@ -1,0 +1,111 @@
+"""Tests for the dep_audit tool (v2.7.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.tools.base import ToolContext
+from godspeed.tools.dep_audit import DepAuditTool, _detect_managers
+
+
+class TestDetectManagers:
+    def test_pyproject_detected_as_pip(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        assert _detect_managers(ctx) == ["pip"]
+
+    def test_requirements_txt_detected_as_pip(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text("requests\n", encoding="utf-8")
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        assert _detect_managers(ctx) == ["pip"]
+
+    def test_package_json_detected_as_npm(self, tmp_path: Path) -> None:
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        assert _detect_managers(ctx) == ["npm"]
+
+    def test_cargo_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='x'\n", encoding="utf-8")
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        assert _detect_managers(ctx) == ["cargo"]
+
+    def test_multi_language_monorepo(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        assert _detect_managers(ctx) == ["pip", "npm"]
+
+    def test_empty_project(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        assert _detect_managers(ctx) == []
+
+
+class TestDepAuditTool:
+    @pytest.mark.asyncio
+    async def test_no_manifests_returns_clear_error(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = DepAuditTool()
+        result = await tool.execute({}, ctx)
+        assert result.is_error
+        assert "manifest" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_manager_rejected(self, tmp_path: Path) -> None:
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = DepAuditTool()
+        result = await tool.execute({"manager": "yarn"}, ctx)
+        assert result.is_error
+        assert "manager" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_pip_audit_clean(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = DepAuditTool()
+        clean = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with (
+            patch(
+                "godspeed.tools.dep_audit.shutil.which",
+                side_effect=lambda name: "/usr/bin/pip-audit" if name == "pip-audit" else None,
+            ),
+            patch("godspeed.tools.dep_audit.subprocess.run", return_value=clean),
+        ):
+            result = await tool.execute({}, ctx)
+        assert not result.is_error
+        assert "pip-audit" in result.output
+
+    @pytest.mark.asyncio
+    async def test_pip_audit_vulns_are_gating(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = DepAuditTool()
+        vuln = CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="requests 2.28.0 has CVE-2023-32681",
+            stderr="",
+        )
+        with (
+            patch(
+                "godspeed.tools.dep_audit.shutil.which",
+                side_effect=lambda name: "/usr/bin/pip-audit" if name == "pip-audit" else None,
+            ),
+            patch("godspeed.tools.dep_audit.subprocess.run", return_value=vuln),
+        ):
+            result = await tool.execute({}, ctx)
+        assert result.is_error
+        assert "CVE-2023-32681" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_no_auditor_installed_despite_manifest(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+        ctx = ToolContext(cwd=tmp_path, session_id="t")
+        tool = DepAuditTool()
+        with patch("godspeed.tools.dep_audit.shutil.which", return_value=None):
+            result = await tool.execute({}, ctx)
+        assert result.is_error
+        assert "pip-audit" in (result.error or "")


### PR DESCRIPTION
## Summary

Minor release continuing the v2.5.1 deferred-items cleanup. Two more agent-callable quality tools + an integration-level invariant check.

## What's new

### \`complexity\` tool
Wraps \`radon cc\` (Python) and \`lizard\` (polyglot). Functions above \`max_cc\` (default 10 per McCabe) fail the call — the agent can enforce a complexity budget during edits.

### \`dep_audit\` tool
Auto-detects the package manager from project manifests:
- \`pyproject.toml\` / \`requirements.txt\` → pip-audit
- \`package.json\` → npm audit  
- \`Cargo.toml\` → cargo-audit (when installed)

Vulnerabilities are gating. Explicit \`manager\` argument overrides detection.

### E2E drift test
Single integration-level test asserting the audit trail's \`session_end\` detail and \`ConversationLogger.log_session_end\` record agree on every field (\`exit_reason\`, \`exit_code\`, all metrics). Catches regressions where the two streams could silently diverge after independent edits — one of the follow-ups flagged in the v2.5.1 review.

## Audit

| Check | Result |
|---|---|
| \`ruff check .\` | ✅ all checks passed |
| \`ruff format --check .\` | ✅ 210 files formatted |
| \`mypy src/godspeed --ignore-missing-imports\` | ✅ 0 issues / 100 files |
| \`pytest -q --cov --cov-fail-under=80\` | ✅ **1,682 passed, 2 skipped, 85.64% coverage** |
| Version bump | 2.6.0 → 2.7.0 (minor — new user-facing tools) |

## Tests (+29 new)

- \`test_complexity_tool.py\` (16): CC-to-radon-grade boundary table + tool integration
- \`test_dep_audit_tool.py\` (12): manager detection + tool integration
- \`test_audit_log_drift.py\` (1): E2E invariant check

## Deferred to v2.8.0

- \`generate_tests\` tool (needs LLM call inside the tool)
- Auto-index (requires session init refactor)
- Fix \`verify._verify_with_retry\` return semantics (breaks 3 existing tests)

## Test plan

- [x] ruff / format / mypy / tests all green
- [x] Coverage gate met
- [x] Both new tools register and are discoverable
- [x] E2E drift test passes — audit + training log agree on all session_end fields
- [ ] Maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)