### PR TITLE
feat(v2.9.0): auto-index on session start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] — 2026-04-17
+
+Final entry in the v2.5.1 review follow-up chain. Auto-index on session
+start so the agent has semantic code search available by default instead
+of requiring a manual `/reindex`.
+
+### Added
+
+- **Auto-index on session start** (`src/godspeed/context/auto_index.py`).
+  New helper `maybe_start_auto_index(project_dir, auto_index_enabled)`
+  that:
+  - Returns `None` when disabled, when `chromadb` isn't installed (graceful
+    degradation via the `[index]` extra), or when the index is already
+    fresh (`needs_reindex()` returns `False`).
+  - Otherwise schedules `build_index_async()` as an `asyncio.Task` so the
+    session continues without blocking on index construction.
+  - Swallows exceptions in the build coroutine so an indexing failure
+    never crashes the agent.
+
+  Wired into both the TUI and headless paths in `cli.py`, right after
+  the `ToolContext` is constructed.
+- **`GodspeedSettings.auto_index`** field (default `True`). Disable with
+  `auto_index: false` in `~/.godspeed/settings.yaml` or `GODSPEED_AUTO_INDEX=false`.
+
+### Changed
+
+- Sessions started without a fresh codebase index now rebuild it in the
+  background automatically (assuming `[index]` extra is installed). The
+  previous behavior required a manual `/reindex`.
+
 ## [2.8.0] — 2026-04-17
 
 Closes the last of the v2.5.1 review follow-ups. New LLM-driven test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed"
-version = "2.8.0"
+version = "2.9.0"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.8.0"
+__version__ = "2.9.0"

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -321,6 +321,11 @@ async def _run_app(
         llm_client=llm_client,  # type: ignore[arg-type]
     )
 
+    # Kick off background codebase index if needed (non-blocking).
+    from godspeed.context.auto_index import maybe_start_auto_index
+
+    maybe_start_auto_index(effective_project_dir, settings.auto_index)
+
     # Conversation
     conversation = Conversation(
         system_prompt=system_prompt,
@@ -818,6 +823,11 @@ async def _headless_run(
         audit=audit_trail,
         llm_client=llm_client,  # type: ignore[arg-type]
     )
+
+    # Kick off background codebase index if needed (non-blocking).
+    from godspeed.context.auto_index import maybe_start_auto_index
+
+    maybe_start_auto_index(effective_project_dir, settings.auto_index)
 
     # Conversation logger (training data collection)
     conversation_logger = None

--- a/src/godspeed/config.py
+++ b/src/godspeed/config.py
@@ -204,6 +204,12 @@ class GodspeedSettings(BaseSettings):
     # Memory
     memory_enabled: bool = True
 
+    # Codebase auto-indexing — build a ChromaDB semantic index in the
+    # background on session start (when the `[index]` extra is installed
+    # and the project has no fresh index). Non-blocking; the session
+    # continues without waiting for it to complete.
+    auto_index: bool = True
+
     # Nested settings
     permissions: PermissionSettings = Field(default_factory=PermissionSettings)
     audit: AuditSettings = Field(default_factory=AuditSettings)

--- a/src/godspeed/context/auto_index.py
+++ b/src/godspeed/context/auto_index.py
@@ -1,0 +1,91 @@
+"""Auto-indexing helper — kick off a non-blocking codebase index on session start.
+
+The ChromaDB-backed index in ``codebase_index.py`` was previously opt-in:
+the user had to call ``/reindex`` before the agent could use semantic
+search. This helper makes it automatic and non-blocking — the session
+starts immediately and the index builds in the background.
+
+Design notes:
+- Gated on ``settings.auto_index`` (default True)
+- No-op if the ``[index]`` extra isn't installed (chromadb missing)
+- No-op if the index is already fresh (``needs_reindex()`` returns False)
+- Uses ``asyncio.create_task`` so the main loop is not blocked
+- Logs completion/failure; never raises out of the scheduling path
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from godspeed.context.codebase_index import CodebaseIndex
+
+logger = logging.getLogger(__name__)
+
+
+def maybe_start_auto_index(
+    project_dir: Path,
+    auto_index_enabled: bool,
+) -> asyncio.Task[int] | None:
+    """Schedule a background index build if needed.
+
+    Returns the asyncio.Task so the caller can await or cancel it during
+    shutdown if desired. Returns None when:
+
+    - ``auto_index_enabled`` is False
+    - chromadb isn't installed (``[index]`` extra missing)
+    - The index is already fresh
+
+    Never raises — a scheduling failure is logged and the function
+    returns None so the session continues normally.
+    """
+    if not auto_index_enabled:
+        logger.debug("Auto-index disabled by settings")
+        return None
+
+    try:
+        from godspeed.context.codebase_index import CodebaseIndex
+    except ImportError:
+        logger.debug("codebase_index module unavailable; skipping auto-index")
+        return None
+
+    try:
+        index = CodebaseIndex(project_dir=project_dir)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("Auto-index init failed: %s", exc)
+        return None
+
+    if not index.is_available:
+        logger.info("chromadb not installed; auto-index skipped (install `godspeed[index]`)")
+        return None
+
+    if not index.needs_reindex():
+        logger.debug("Codebase index is fresh; skipping rebuild")
+        return None
+
+    logger.info("Scheduling background codebase re-index project_dir=%s", project_dir)
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        logger.warning("No running event loop; cannot schedule auto-index")
+        return None
+
+    return loop.create_task(_run_auto_index(index))
+
+
+async def _run_auto_index(index: CodebaseIndex) -> int:
+    """Coroutine wrapper: builds the index and logs the outcome.
+
+    Swallows exceptions — an indexing failure must not crash the agent
+    session. Returns the chunk count on success, 0 on failure.
+    """
+    try:
+        count = await index.build_index_async()
+        logger.info("Auto-index built chunks=%d", count)
+        return count
+    except Exception as exc:
+        logger.warning("Auto-index build failed: %s", exc, exc_info=True)
+        return 0

--- a/tests/test_auto_index.py
+++ b/tests/test_auto_index.py
@@ -1,0 +1,83 @@
+"""Tests for the auto-index helper (v2.9.0)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from godspeed.context.auto_index import _run_auto_index, maybe_start_auto_index
+
+
+def test_disabled_returns_none(tmp_path: Path) -> None:
+    """auto_index_enabled=False short-circuits."""
+    assert maybe_start_auto_index(tmp_path, auto_index_enabled=False) is None
+
+
+def test_skips_when_chromadb_unavailable(tmp_path: Path) -> None:
+    """When chromadb isn't installed, is_available=False → skip."""
+    fake_index = MagicMock(is_available=False)
+    with patch("godspeed.context.codebase_index.CodebaseIndex", return_value=fake_index):
+        result = maybe_start_auto_index(tmp_path, auto_index_enabled=True)
+    assert result is None
+
+
+def test_skips_when_index_fresh(tmp_path: Path) -> None:
+    """Fresh index → no rebuild scheduled."""
+    fake_index = MagicMock(is_available=True)
+    fake_index.needs_reindex.return_value = False
+    with patch("godspeed.context.codebase_index.CodebaseIndex", return_value=fake_index):
+        result = maybe_start_auto_index(tmp_path, auto_index_enabled=True)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_schedules_task_when_stale(tmp_path: Path) -> None:
+    """Stale index → a Task is returned + build_index_async is scheduled."""
+    fake_index = MagicMock(is_available=True)
+    fake_index.needs_reindex.return_value = True
+    fake_index.build_index_async = AsyncMock(return_value=42)
+    with patch("godspeed.context.codebase_index.CodebaseIndex", return_value=fake_index):
+        task = maybe_start_auto_index(tmp_path, auto_index_enabled=True)
+    assert isinstance(task, asyncio.Task)
+    result = await task
+    assert result == 42
+    fake_index.build_index_async.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_exception_during_build_is_swallowed(tmp_path: Path) -> None:
+    """A failing build_index_async must not crash the session."""
+    fake_index = MagicMock()
+    fake_index.build_index_async = AsyncMock(side_effect=RuntimeError("disk full"))
+    result = await _run_auto_index(fake_index)
+    assert result == 0
+
+
+def test_codebase_index_constructor_failure_returns_none(tmp_path: Path) -> None:
+    """If instantiating CodebaseIndex raises, we swallow + return None."""
+    with patch(
+        "godspeed.context.codebase_index.CodebaseIndex",
+        side_effect=RuntimeError("ctor failure"),
+    ):
+        result = maybe_start_auto_index(tmp_path, auto_index_enabled=True)
+    assert result is None
+
+
+def test_no_event_loop_returns_none(tmp_path: Path) -> None:
+    """When called outside an event loop, return None rather than raising."""
+    fake_index = MagicMock(is_available=True)
+    fake_index.needs_reindex.return_value = True
+
+    def _fake_get_event_loop() -> Any:
+        raise RuntimeError("no current event loop")
+
+    with (
+        patch("godspeed.context.codebase_index.CodebaseIndex", return_value=fake_index),
+        patch("asyncio.get_event_loop", side_effect=_fake_get_event_loop),
+    ):
+        result = maybe_start_auto_index(tmp_path, auto_index_enabled=True)
+    assert result is None


### PR DESCRIPTION
## Summary

Final entry in the v2.5.1 review follow-up chain. Sessions now build the ChromaDB-backed codebase index in the background on startup when needed, so the agent has semantic code search available by default instead of requiring a manual \`/reindex\`.

## What's new

### \`src/godspeed/context/auto_index.py\`
\`maybe_start_auto_index(project_dir, auto_index_enabled)\`:
- Returns \`None\` when disabled, chromadb unavailable, or index already fresh
- Otherwise schedules \`build_index_async()\` as an \`asyncio.Task\` — session continues without blocking
- Swallows exceptions in the build coroutine so indexing failures never crash the agent

Wired into both TUI (\`_run_app\`) and headless (\`_headless_run\`) paths in \`cli.py\`, right after \`ToolContext\` construction.

### \`GodspeedSettings.auto_index\` field (default \`True\`)
Disable with \`auto_index: false\` in settings.yaml or \`GODSPEED_AUTO_INDEX=false\`.

## Audit

| Check | Result |
|---|---|
| \`ruff check .\` | ✅ all checks passed |
| \`ruff format --check .\` | ✅ 214 files formatted |
| \`mypy src/godspeed --ignore-missing-imports\` | ✅ 0 issues / 102 files |
| \`pytest -q --cov --cov-fail-under=80\` | ✅ **1,704 passed, 2 skipped, 86.17% coverage** |
| Version bump | 2.8.0 → 2.9.0 (minor — new config field + behavior change) |

## Tests (+7 new)

- \`test_auto_index.py\` (7): disabled short-circuit, chromadb-unavailable skip, fresh-index skip, stale-index schedules Task, build exception swallowed, constructor failure returns None, no-event-loop returns None

## Completes the v2.5.1 review follow-up list

| Item | Shipped in |
|---|---|
| MUST-FIX gate structural enforcement | v2.5.1 |
| Shared \"some remaining\" fingerprint constant | v2.6.0 |
| \`must_fix_injections\` counter in AgentMetrics | v2.6.0 |
| E2E audit-log drift test | v2.7.0 |
| \`generate_tests\` tool (LLM-in-tool pattern) | v2.8.0 |
| Verify failure-result semantics | v2.8.0 |
| **Auto-index on session start** | **v2.9.0** ← this PR |

## Test plan

- [x] Tests pass for every code path (disabled, missing dep, fresh, stale, failure, no-loop)
- [x] No blocking on session start (task scheduled and returned)
- [x] Both TUI and headless paths call the helper after ToolContext construction
- [ ] Maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)