### PR TITLE
docs(swebench): correct judge-union claim — real plurality is NULL RESULT

### DIFF
--- a/experiments/swebench_lite/findings_v3_2_judge_selector.md
+++ b/experiments/swebench_lite/findings_v3_2_judge_selector.md
@@ -223,7 +223,7 @@ To test for model-family bias in the Kimi K2.5 judge result, the same 5-way ense
 
 **Judge agreement: 19/23 = 82.6%.**
 
-### Judge-union analysis (free uplift)
+### Judge-union ceiling (oracle-flavored upper bound)
 
 The two judges' errors are **non-overlapping** on the resolver-recovery axis:
 
@@ -231,18 +231,42 @@ The two judges' errors are **non-overlapping** on the resolver-recovery axis:
 - GPT-OSS misses astroid-1196, Kimi catches it.
 - Both miss pydicom-1256 (only `gpt_oss` resolves; both judges defaulted to `e1_kimi`).
 
-**If we apply a "either-judge-picks-a-resolver" union policy:**
-- 11 / 12 = **91.7%** picker accuracy when a resolver exists (up from 83.3% for either solo judge)
-- Projects to **11 / 23 = 47.8%** resolved (up from 43.5%)
-- Recovers **75% of oracle lift** (up from 50%) — `(11 - 8) / (12 - 8)`
+**Oracle-knowledge "either picks a resolver" union ceiling:**
+- 11 / 12 = **91.7%** picker accuracy if you knew which judge to trust per instance
+- Projects to **11 / 23 = 47.8%** resolved
+- Recovers **75% of oracle lift**
 
-**Cost:** ~3 min additional NIM time per ensemble run (judges in parallel). $0 in API spend.
+⚠️ **This 47.8% is a CEILING, not a deployable result.** Knowing "which judge picked the resolver" requires ground-truth verdicts (oracle access). A real non-oracle deployment must pick blindly when judges disagree — see the next section.
+
+### 2-judge plurality vote — the actual non-oracle result (NULL RESULT)
+
+When the oracle is removed and the selector applies a real **plurality vote with shortest-non-empty tiebreaker** (the rule we ship in `_aggregate_plurality`), the measured rate is **9/23 = 39.1% — worse than solo judge.**
+
+Why it regresses: the two judges agree on 19/23 instances (where plurality just echoes the solo judge). On the 4 disagreements, the shortest-non-empty tiebreaker has no signal about which slot resolves — it picks shorter patches under the "minimal change" prior. That prior is wrong on 3 of 4 disagreement instances:
+
+| instance_id | Kimi | GPT-OSS | shortest-non-empty pick | actually resolves? |
+|---|---|---|---|---|
+| marshmallow-1359 | seed3 | p1_dev23_v3 | seed3 | ✗ (only p1_dev23_v3 resolves) |
+| pvlib-1606 | e1_kimi | gpt_oss | gpt_oss | ✓ (4 runs resolve) |
+| astroid-1196 | iter1 | p1_dev23_v3 | p1_dev23_v3 | ✗ (only iter1 resolves) |
+| sqlfluff-1517 | seed3 | gpt_oss | seed3 | ✗ (no run resolves) |
+
+Net: plurality loses 1 instance vs solo Kimi (astroid-1196: Kimi solo got it, plurality flipped to p1_dev23_v3), and gains nothing the solo judge didn't already have on the disagreement slots.
+
+### What we learned about multi-judge
+
+- **2-judge plurality with simple tiebreakers is a regression, not a lift.** The optimistic "either-judge wins" framing is an oracle reading.
+- A 3+ judge ensemble could break ties via majority (no shortest-non-empty needed in most disagreement cases), which is the only path to a real lift. The 3rd-judge run (Kimi-K2-Thinking) was launched but the NIM endpoint repeatedly timed out and the run was inconclusive.
+- **The honest published number remains the solo judge at 10/23 = 43.5%.** Multi-judge work is a research direction, not a shippable improvement at N=2 with plurality+shortest-non-empty.
+- Better tiebreakers worth exploring: a meta-judge LLM call that picks between the disagreed slots; weighting judges by their solo recovery rates (legal: that comes from the same offline eval reports already used); requiring 2-of-3 agreement.
+
+**Cost:** the plurality vote experiment was offline-only (re-aggregating already-saved per-judge picks); zero new NIM calls.
 
 ### What this means
 
 The 43.5% solo-judge result is **robust to judge model choice** — same headline, similar pick distribution, same picker-accuracy ceiling. The errors are not driven by Kimi-favors-Kimi or GPT-OSS-favors-GPT-OSS bias — both judges land on the same 9 / 12 "easy" oracle-resolver picks and split on the harder ones.
 
-The non-overlapping-errors finding is the actionable one: a **judge-ensemble (vote / union)** trivially lifts picker accuracy from 83% → 92% with a tiny cost increase. This is the next implementation step.
+**The non-overlapping-errors finding does NOT translate into a free uplift via simple plurality.** When the oracle is removed and a real non-oracle plurality vote is applied (the rule shipped in `_aggregate_plurality`), the result regresses to 9/23 = 39.1% — see the next subsection. Recovering the union ceiling requires either a 3rd judge (so plurality can resolve disagreements without arbitrary tiebreakers) or a smarter meta-aggregator. Initial Kimi-K2-Thinking 3rd-judge attempts hit NIM timeout repeatedly and did not complete a full run.
 
 ### Additional artifacts
 


### PR DESCRIPTION
## Summary

Earlier addendum (PR #66) cited a \"+13pp via judge-union → 47.8%\" lift based on an \"either-judge-picks-resolver\" framing. That framing is **oracle-flavored**: knowing which judge to trust per instance requires ground-truth verdicts.

Running the actual non-oracle plurality vote shipped in \`_aggregate_plurality\` (PR #67) gives the corrected reading:

| Selector | Resolved | Rate |
|---|---|---|
| Solo Kimi K2.5 judge | 10/23 | 43.5% |
| Solo GPT-OSS-120B judge | 10/23 | 43.5% |
| **2-judge plurality (Kimi + GPT-OSS), shortest-non-empty tiebreaker** | **9/23** | **39.1% (regression)** |
| Oracle-knowledge \"union\" ceiling | 11/23 | 47.8% |
| Full oracle (sb-cli verdicts) | 12/23 | 52.2% |

## Why plurality regresses

19/23 instances → both judges agree → plurality echoes the solo judge.
4/23 instances → judges disagree → shortest-non-empty tiebreaker guesses → wrong on 3 of 4:

| instance_id | Kimi | GPT-OSS | tiebreak pick | resolves? |
|---|---|---|---|---|
| marshmallow-1359 | seed3 | p1_dev23_v3 | seed3 | ✗ |
| pvlib-1606 | e1_kimi | gpt_oss | gpt_oss | ✓ |
| astroid-1196 | iter1 | p1_dev23_v3 | p1_dev23_v3 | ✗ |
| sqlfluff-1517 | seed3 | gpt_oss | seed3 | ✗ |

Net: plurality loses astroid-1196 (Kimi solo had it) and gains nothing the solo judge didn't have. **The honest published number remains the solo judge at 10/23 = 43.5%.**

## What changed in the doc

- The 47.8% / 91.7%-picker-accuracy union numbers are now framed explicitly as an **oracle-knowledge ceiling**, not a deployable result.
- New \"2-judge plurality vote — the actual non-oracle result\" section with per-instance reasoning.
- The \"what this means\" subsection retracts the \"free uplift\" claim and points at the actual paths forward: 3+ judge majority (so plurality has clear winners on most disagreements without arbitrary tiebreakers), or a smarter meta-aggregator.

## Why this matters

Researchers reading the doc would (correctly) call out the original framing. Better to surface the null result ourselves than have a reviewer find it. Negative results are publishable and informative — see \`findings_2026_04_21.md\` for the v3.1.0 agent-in-loop null-result precedent.

## Files

- \`experiments/swebench_lite/findings_v3_2_judge_selector.md\` — addendum updated, retraction noted, null result documented (+31 / -7 lines)

## Test plan

- [x] No code changes; ruff/tests not affected
- [x] Numbers re-derived offline from already-committed source-log JSONLs (Kimi + GPT-OSS) and per-constituent sb-cli reports
- [ ] CI lint/security/type-check/tests — THIS PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)