### PR TITLE
docs(swebench): flag local-harness/sb-cli numpy discrepancy + smoke artifacts

### DIFF
--- a/experiments/swebench_lite/leaderboard_submission/README.md
+++ b/experiments/swebench_lite/leaderboard_submission/README.md
@@ -53,6 +53,18 @@ bash experiments/swebench_lite/leaderboard_submission/run_local_swebench_eval.sh
 
 The runner detects git-bash vs WSL path styles, invokes the harness via WSL Ubuntu (swebench's `resource` import is Unix-only), and copies the per-instance artifacts into the submission's `logs/` subtree automatically.
 
+### ⚠️ Environmental caveat: local harness (swebench 4.1.0) vs sb-cli disagreement
+
+A 3-instance smoke run (2026-04-21) exposed a Docker-image drift bug in the pip-installed `swebench` 4.1.0 harness that affects pvlib instances:
+
+- **Symptom:** `pvlib__pvlib-python-1072` was graded `resolved=False` locally despite a byte-identical patch that sb-cli's cloud graded `resolved=True`.
+- **Root cause:** the pvlib Docker testbed image ships NumPy 2.0+, which removed `np.Inf`. pvlib's `singlediode.py` still uses the old alias, so `import pvlib` raises `AttributeError` at test collection time, causing every test in `test_temperature.py` to fail before our patch is exercised. This is a base-image upstream issue in swebench's published Docker images, not a defect in our patch.
+- **Blast radius:** ~5 of our 23 instances are pvlib. Running the full local harness would therefore produce 4-5 fewer "resolved" instances than sb-cli's correct grading.
+
+**Recommendation:** do NOT use the local harness output as the `logs/` source for the leaderboard submission until either (a) swebench's pvlib Docker image is fixed upstream, or (b) the local environment pins NumPy < 2.0 in the testbed image. Wait for sb-cli dev quota reset and use its cloud reports as authoritative.
+
+Smoke evidence committed in the `logs_smoke3/` subdirectory alongside this README so reviewers can audit the discrepancy directly.
+
 Either path is fine to close the leaderboard requirement; until one of the two is done, this directory is *complete in content but not in format* per SWE-bench's checklist.
 
 ## Dev-23 vs full-Lite

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/marshmallow-code__marshmallow-1343/eval.sh
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/marshmallow-code__marshmallow-1343/eval.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -uxo pipefail
+source /opt/miniconda3/bin/activate
+conda activate testbed
+cd /testbed
+git config --global --add safe.directory /testbed
+cd /testbed
+git status
+git show
+git -c core.fileMode=false diff 2be2d83a1a9a6d3d9b85804f3ab545cecc409bb0
+source /opt/miniconda3/bin/activate
+conda activate testbed
+python -m pip install -e '.[dev]'
+git checkout 2be2d83a1a9a6d3d9b85804f3ab545cecc409bb0 tests/test_marshalling.py
+git apply -v - <<'EOF_114329324912'
+diff --git a/tests/test_marshalling.py b/tests/test_marshalling.py
+--- a/tests/test_marshalling.py
++++ b/tests/test_marshalling.py
+@@ -2,7 +2,7 @@
+ 
+ import pytest
+ 
+-from marshmallow import fields, Schema
++from marshmallow import fields, Schema, validates
+ from marshmallow.marshalling import Marshaller, Unmarshaller, missing
+ from marshmallow.exceptions import ValidationError
+ 
+@@ -283,3 +283,24 @@ class TestSchema(Schema):
+ 
+             assert result is None
+             assert excinfo.value.messages == {'foo': {'_schema': ['Invalid input type.']}}
++
++    # Regression test for https://github.com/marshmallow-code/marshmallow/issues/1342
++    def test_deserialize_wrong_nested_type_with_validates_method(self, unmarshal):
++        class TestSchema(Schema):
++            value = fields.String()
++
++            @validates('value')
++            def validate_value(self, value):
++                pass
++
++        data = {
++            'foo': 'not what we need'
++        }
++        fields_dict = {
++            'foo': fields.Nested(TestSchema, required=True)
++        }
++        with pytest.raises(ValidationError) as excinfo:
++            result = unmarshal.deserialize(data, fields_dict)
++
++            assert result is None
++            assert excinfo.value.messages == {'foo': {'_schema': ['Invalid input type.']}}
+
+EOF_114329324912
+: '>>>>> Start Test Output'
+pytest -rA tests/test_marshalling.py
+: '>>>>> End Test Output'
+git checkout 2be2d83a1a9a6d3d9b85804f3ab545cecc409bb0 tests/test_marshalling.py

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/marshmallow-code__marshmallow-1343/patch.diff
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/marshmallow-code__marshmallow-1343/patch.diff
@@ -1,0 +1,13 @@
+diff --git a/src/marshmallow/schema.py b/src/marshmallow/schema.py
+index 085c509..5dea285 100644
+--- a/src/marshmallow/schema.py
++++ b/src/marshmallow/schema.py
+@@ -861,6 +861,8 @@ class BaseSchema(base.SchemaABC):
+         return data
+ 
+     def _invoke_field_validators(self, unmarshal, data, many):
++        if data is None:
++            return
+         for attr_name in self.__processors__[(VALIDATES, False)]:
+             validator = getattr(self, attr_name)
+             validator_kwargs = validator.__marshmallow_kwargs__[(VALIDATES, False)]

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/marshmallow-code__marshmallow-1343/report.json
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/marshmallow-code__marshmallow-1343/report.json
@@ -1,0 +1,53 @@
+{
+    "marshmallow-code__marshmallow-1343": {
+        "patch_is_None": false,
+        "patch_exists": true,
+        "patch_successfully_applied": true,
+        "resolved": true,
+        "tests_status": {
+            "FAIL_TO_PASS": {
+                "success": [
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_nested_type_with_validates_method"
+                ],
+                "failure": []
+            },
+            "PASS_TO_PASS": {
+                "success": [
+                    "tests/test_marshalling.py::test_missing_is_falsy",
+                    "tests/test_marshalling.py::TestMarshaller::test_prefix",
+                    "tests/test_marshalling.py::TestMarshaller::test_marshalling_generator",
+                    "tests/test_marshalling.py::TestMarshaller::test_default_to_missing",
+                    "tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_load_only_param",
+                    "tests/test_marshalling.py::TestMarshaller::test_missing_data_are_skipped",
+                    "tests/test_marshalling.py::TestMarshaller::test_serialize_with_load_only_doesnt_validate",
+                    "tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_dump_to_param",
+                    "tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_dump_to_and_prefix_params",
+                    "tests/test_marshalling.py::TestMarshaller::test_stores_indices_of_errors_when_many_equals_true",
+                    "tests/test_marshalling.py::TestMarshaller::test_doesnt_store_errors_when_index_errors_equals_false",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_extra_data_is_ignored",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_stores_errors",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_stores_indices_of_errors_when_many_equals_true",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_doesnt_store_errors_when_index_errors_equals_false",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_extra_fields",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize_many",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize_stores_errors",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_attribute_param",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_load_from_param",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_dump_only_param",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_type_root_data",
+                    "tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_type_nested_data"
+                ],
+                "failure": []
+            },
+            "FAIL_TO_FAIL": {
+                "success": [],
+                "failure": []
+            },
+            "PASS_TO_FAIL": {
+                "success": [],
+                "failure": []
+            }
+        }
+    }
+}

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/marshmallow-code__marshmallow-1343/test_output.txt
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/marshmallow-code__marshmallow-1343/test_output.txt
@@ -1,0 +1,403 @@
++ source /opt/miniconda3/bin/activate
+++ _CONDA_ROOT=/opt/miniconda3
+++ . /opt/miniconda3/etc/profile.d/conda.sh
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ '[' -z '' ']'
++++ export CONDA_SHLVL=0
++++ CONDA_SHLVL=0
++++ '[' -n '' ']'
++++++ dirname /opt/miniconda3/bin/conda
+++++ dirname /opt/miniconda3/bin
++++ PATH=/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export PATH
++++ '[' -z '' ']'
++++ PS1=
+++ conda activate
+++ local cmd=activate
+++ case "$cmd" in
+++ __conda_activate activate
+++ '[' -n '' ']'
+++ local ask_conda
++++ PS1=
++++ __conda_exe shell.posix activate
++++ /opt/miniconda3/bin/conda shell.posix activate
+++ ask_conda='PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''1'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ eval 'PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''1'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++++ PS1='(base) '
++++ export PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export CONDA_PREFIX=/opt/miniconda3
++++ CONDA_PREFIX=/opt/miniconda3
++++ export CONDA_SHLVL=1
++++ CONDA_SHLVL=1
++++ export CONDA_DEFAULT_ENV=base
++++ CONDA_DEFAULT_ENV=base
++++ export 'CONDA_PROMPT_MODIFIER=(base) '
++++ CONDA_PROMPT_MODIFIER='(base) '
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ __conda_hashr
+++ '[' -n '' ']'
+++ '[' -n '' ']'
+++ hash -r
++ conda activate testbed
++ local cmd=activate
++ case "$cmd" in
++ __conda_activate activate testbed
++ '[' -n '' ']'
++ local ask_conda
+++ PS1='(base) '
+++ __conda_exe shell.posix activate testbed
+++ /opt/miniconda3/bin/conda shell.posix activate testbed
++ ask_conda='PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''2'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_1='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++ eval 'PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''2'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_1='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ PS1='(testbed) '
+++ export PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ export CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ export CONDA_SHLVL=2
+++ CONDA_SHLVL=2
+++ export CONDA_DEFAULT_ENV=testbed
+++ CONDA_DEFAULT_ENV=testbed
+++ export 'CONDA_PROMPT_MODIFIER=(testbed) '
+++ CONDA_PROMPT_MODIFIER='(testbed) '
+++ export CONDA_PREFIX_1=/opt/miniconda3
+++ CONDA_PREFIX_1=/opt/miniconda3
+++ export CONDA_EXE=/opt/miniconda3/bin/conda
+++ CONDA_EXE=/opt/miniconda3/bin/conda
+++ export _CE_M=
+++ _CE_M=
+++ export _CE_CONDA=
+++ _CE_CONDA=
+++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++ __conda_hashr
++ '[' -n '' ']'
++ '[' -n '' ']'
++ hash -r
++ cd /testbed
++ git config --global --add safe.directory /testbed
++ cd /testbed
++ git status
+On branch dev
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+	modified:   src/marshmallow/schema.py
+
+no changes added to commit (use "git add" and/or "git commit -a")
++ git show
+commit d4f98233971ee3e73bba47026cd77b4ba69a25bb
+Author: SWE-bench <setup@swebench.config>
+Date:   Tue May 6 23:07:21 2025 +0000
+
+    SWE-bench
++ git -c core.fileMode=false diff 2be2d83a1a9a6d3d9b85804f3ab545cecc409bb0
+diff --git a/src/marshmallow/schema.py b/src/marshmallow/schema.py
+index 085c509b..5dea2853 100644
+--- a/src/marshmallow/schema.py
++++ b/src/marshmallow/schema.py
+@@ -861,6 +861,8 @@ class BaseSchema(base.SchemaABC):
+         return data
+ 
+     def _invoke_field_validators(self, unmarshal, data, many):
++        if data is None:
++            return
+         for attr_name in self.__processors__[(VALIDATES, False)]:
+             validator = getattr(self, attr_name)
+             validator_kwargs = validator.__marshmallow_kwargs__[(VALIDATES, False)]
++ source /opt/miniconda3/bin/activate
+++ _CONDA_ROOT=/opt/miniconda3
+++ . /opt/miniconda3/etc/profile.d/conda.sh
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ '[' -z x ']'
+++ conda activate
+++ local cmd=activate
+++ case "$cmd" in
+++ __conda_activate activate
+++ '[' -n '' ']'
+++ local ask_conda
++++ PS1='(testbed) '
++++ __conda_exe shell.posix activate
++++ /opt/miniconda3/bin/conda shell.posix activate
+++ ask_conda='PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''3'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_PREFIX_2='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ eval 'PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''3'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_PREFIX_2='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++++ PS1='(base) '
++++ export PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export CONDA_PREFIX=/opt/miniconda3
++++ CONDA_PREFIX=/opt/miniconda3
++++ export CONDA_SHLVL=3
++++ CONDA_SHLVL=3
++++ export CONDA_DEFAULT_ENV=base
++++ CONDA_DEFAULT_ENV=base
++++ export 'CONDA_PROMPT_MODIFIER=(base) '
++++ CONDA_PROMPT_MODIFIER='(base) '
++++ export CONDA_PREFIX_2=/opt/miniconda3/envs/testbed
++++ CONDA_PREFIX_2=/opt/miniconda3/envs/testbed
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ __conda_hashr
+++ '[' -n '' ']'
+++ '[' -n '' ']'
+++ hash -r
++ conda activate testbed
++ local cmd=activate
++ case "$cmd" in
++ __conda_activate activate testbed
++ '[' -n '' ']'
++ local ask_conda
+++ PS1='(base) '
+++ __conda_exe shell.posix activate testbed
+++ /opt/miniconda3/bin/conda shell.posix activate testbed
++ ask_conda='PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''4'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_3='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++ eval 'PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''4'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_3='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ PS1='(testbed) '
+++ export PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ export CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ export CONDA_SHLVL=4
+++ CONDA_SHLVL=4
+++ export CONDA_DEFAULT_ENV=testbed
+++ CONDA_DEFAULT_ENV=testbed
+++ export 'CONDA_PROMPT_MODIFIER=(testbed) '
+++ CONDA_PROMPT_MODIFIER='(testbed) '
+++ export CONDA_PREFIX_3=/opt/miniconda3
+++ CONDA_PREFIX_3=/opt/miniconda3
+++ export CONDA_EXE=/opt/miniconda3/bin/conda
+++ CONDA_EXE=/opt/miniconda3/bin/conda
+++ export _CE_M=
+++ _CE_M=
+++ export _CE_CONDA=
+++ _CE_CONDA=
+++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++ __conda_hashr
++ '[' -n '' ']'
++ '[' -n '' ']'
++ hash -r
++ python -m pip install -e '.[dev]'
+Obtaining file:///testbed
+  Preparing metadata (setup.py): started
+  Preparing metadata (setup.py): finished with status 'done'
+Requirement already satisfied: python-dateutil in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from marshmallow==2.20.0) (2.9.0.post0)
+Requirement already satisfied: simplejson in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from marshmallow==2.20.0) (3.20.1)
+Requirement already satisfied: pytest in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from marshmallow==2.20.0) (8.3.5)
+Requirement already satisfied: pytz in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from marshmallow==2.20.0) (2025.2)
+Requirement already satisfied: flake8==3.7.4 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from marshmallow==2.20.0) (3.7.4)
+Requirement already satisfied: tox in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from marshmallow==2.20.0) (4.25.0)
+Requirement already satisfied: entrypoints<0.4.0,>=0.3.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from flake8==3.7.4->marshmallow==2.20.0) (0.3)
+Requirement already satisfied: pyflakes<2.2.0,>=2.1.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from flake8==3.7.4->marshmallow==2.20.0) (2.1.1)
+Requirement already satisfied: pycodestyle<2.6.0,>=2.5.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from flake8==3.7.4->marshmallow==2.20.0) (2.5.0)
+Requirement already satisfied: mccabe<0.7.0,>=0.6.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from flake8==3.7.4->marshmallow==2.20.0) (0.6.1)
+Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->marshmallow==2.20.0) (1.2.2)
+Requirement already satisfied: iniconfig in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->marshmallow==2.20.0) (2.1.0)
+Requirement already satisfied: packaging in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->marshmallow==2.20.0) (25.0)
+Requirement already satisfied: pluggy<2,>=1.5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->marshmallow==2.20.0) (1.5.0)
+Requirement already satisfied: tomli>=1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->marshmallow==2.20.0) (2.2.1)
+Requirement already satisfied: six>=1.5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from python-dateutil->marshmallow==2.20.0) (1.17.0)
+Requirement already satisfied: cachetools>=5.5.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tox->marshmallow==2.20.0) (5.5.2)
+Requirement already satisfied: chardet>=5.2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tox->marshmallow==2.20.0) (5.2.0)
+Requirement already satisfied: colorama>=0.4.6 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tox->marshmallow==2.20.0) (0.4.6)
+Requirement already satisfied: filelock>=3.16.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tox->marshmallow==2.20.0) (3.18.0)
+Requirement already satisfied: platformdirs>=4.3.6 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tox->marshmallow==2.20.0) (4.3.7)
+Requirement already satisfied: pyproject-api>=1.8 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tox->marshmallow==2.20.0) (1.9.0)
+Requirement already satisfied: typing-extensions>=4.12.2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tox->marshmallow==2.20.0) (4.13.2)
+Requirement already satisfied: virtualenv>=20.29.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tox->marshmallow==2.20.0) (20.31.1)
+Requirement already satisfied: distlib<1,>=0.3.7 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from virtualenv>=20.29.1->tox->marshmallow==2.20.0) (0.3.9)
+Installing collected packages: marshmallow
+  Attempting uninstall: marshmallow
+    Found existing installation: marshmallow 2.20.0
+    Uninstalling marshmallow-2.20.0:
+      Successfully uninstalled marshmallow-2.20.0
+  DEPRECATION: Legacy editable install of marshmallow[dev]==2.20.0 from file:///testbed (setup.py develop) is deprecated. pip 25.3 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457
+  Running setup.py develop for marshmallow
+Successfully installed marshmallow
+WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
++ git checkout 2be2d83a1a9a6d3d9b85804f3ab545cecc409bb0 tests/test_marshalling.py
+Updated 0 paths from a3815758
++ git apply -v -
+Checking patch tests/test_marshalling.py...
+Applied patch tests/test_marshalling.py cleanly.
++ : '>>>>> Start Test Output'
++ pytest -rA tests/test_marshalling.py
+============================= test session starts ==============================
+platform linux -- Python 3.9.21, pytest-8.3.5, pluggy-1.5.0 -- /opt/miniconda3/envs/testbed/bin/python
+cachedir: .pytest_cache
+rootdir: /testbed
+configfile: setup.cfg
+collecting ... collected 25 items
+
+tests/test_marshalling.py::test_missing_is_falsy PASSED                  [  4%]
+tests/test_marshalling.py::TestMarshaller::test_prefix PASSED            [  8%]
+tests/test_marshalling.py::TestMarshaller::test_marshalling_generator PASSED [ 12%]
+tests/test_marshalling.py::TestMarshaller::test_default_to_missing PASSED [ 16%]
+tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_load_only_param PASSED [ 20%]
+tests/test_marshalling.py::TestMarshaller::test_missing_data_are_skipped PASSED [ 24%]
+tests/test_marshalling.py::TestMarshaller::test_serialize_with_load_only_doesnt_validate PASSED [ 28%]
+tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_dump_to_param PASSED [ 32%]
+tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_dump_to_and_prefix_params PASSED [ 36%]
+tests/test_marshalling.py::TestMarshaller::test_stores_indices_of_errors_when_many_equals_true PASSED [ 40%]
+tests/test_marshalling.py::TestMarshaller::test_doesnt_store_errors_when_index_errors_equals_false PASSED [ 44%]
+tests/test_marshalling.py::TestUnmarshaller::test_extra_data_is_ignored PASSED [ 48%]
+tests/test_marshalling.py::TestUnmarshaller::test_stores_errors PASSED   [ 52%]
+tests/test_marshalling.py::TestUnmarshaller::test_stores_indices_of_errors_when_many_equals_true PASSED [ 56%]
+tests/test_marshalling.py::TestUnmarshaller::test_doesnt_store_errors_when_index_errors_equals_false PASSED [ 60%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize PASSED     [ 64%]
+tests/test_marshalling.py::TestUnmarshaller::test_extra_fields PASSED    [ 68%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize_many PASSED [ 72%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize_stores_errors PASSED [ 76%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_attribute_param PASSED [ 80%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_load_from_param PASSED [ 84%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_dump_only_param PASSED [ 88%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_type_root_data PASSED [ 92%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_type_nested_data PASSED [ 96%]
+tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_nested_type_with_validates_method PASSED [100%]
+
+=============================== warnings summary ===============================
+src/marshmallow/__init__.py:19
+  /testbed/src/marshmallow/__init__.py:19: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
+    __version_info__ = tuple(LooseVersion(__version__).version)
+
+tests/test_marshalling.py::TestUnmarshaller::test_extra_data_is_ignored
+  /testbed/src/marshmallow/marshalling.py:253: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
+    if not isinstance(data, collections.Mapping):
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+==================================== PASSES ====================================
+=========================== short test summary info ============================
+PASSED tests/test_marshalling.py::test_missing_is_falsy
+PASSED tests/test_marshalling.py::TestMarshaller::test_prefix
+PASSED tests/test_marshalling.py::TestMarshaller::test_marshalling_generator
+PASSED tests/test_marshalling.py::TestMarshaller::test_default_to_missing
+PASSED tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_load_only_param
+PASSED tests/test_marshalling.py::TestMarshaller::test_missing_data_are_skipped
+PASSED tests/test_marshalling.py::TestMarshaller::test_serialize_with_load_only_doesnt_validate
+PASSED tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_dump_to_param
+PASSED tests/test_marshalling.py::TestMarshaller::test_serialize_fields_with_dump_to_and_prefix_params
+PASSED tests/test_marshalling.py::TestMarshaller::test_stores_indices_of_errors_when_many_equals_true
+PASSED tests/test_marshalling.py::TestMarshaller::test_doesnt_store_errors_when_index_errors_equals_false
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_extra_data_is_ignored
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_stores_errors
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_stores_indices_of_errors_when_many_equals_true
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_doesnt_store_errors_when_index_errors_equals_false
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_extra_fields
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize_many
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize_stores_errors
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_attribute_param
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_load_from_param
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize_fields_with_dump_only_param
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_type_root_data
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_type_nested_data
+PASSED tests/test_marshalling.py::TestUnmarshaller::test_deserialize_wrong_nested_type_with_validates_method
+======================== 25 passed, 2 warnings in 0.05s ========================
++ : '>>>>> End Test Output'
++ git checkout 2be2d83a1a9a6d3d9b85804f3ab545cecc409bb0 tests/test_marshalling.py
+Updated 1 path from a3815758

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/pvlib__pvlib-python-1072/eval.sh
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/pvlib__pvlib-python-1072/eval.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -uxo pipefail
+source /opt/miniconda3/bin/activate
+conda activate testbed
+cd /testbed
+git config --global --add safe.directory /testbed
+cd /testbed
+git status
+git show
+git -c core.fileMode=false diff 04a523fafbd61bc2e49420963b84ed8e2bd1b3cf
+source /opt/miniconda3/bin/activate
+conda activate testbed
+python -m pip install -e .[all]
+git checkout 04a523fafbd61bc2e49420963b84ed8e2bd1b3cf pvlib/tests/test_temperature.py
+git apply -v - <<'EOF_114329324912'
+diff --git a/pvlib/tests/test_temperature.py b/pvlib/tests/test_temperature.py
+--- a/pvlib/tests/test_temperature.py
++++ b/pvlib/tests/test_temperature.py
+@@ -190,3 +190,17 @@ def test_fuentes(filename, inoct):
+     night_difference = expected_tcell[is_night] - actual_tcell[is_night]
+     assert night_difference.max() < 6
+     assert night_difference.min() > 0
++
++
++@pytest.mark.parametrize('tz', [None, 'Etc/GMT+5'])
++def test_fuentes_timezone(tz):
++    index = pd.date_range('2019-01-01', freq='h', periods=3, tz=tz)
++
++    df = pd.DataFrame({'poa_global': 1000, 'temp_air': 20, 'wind_speed': 1},
++                      index)
++
++    out = temperature.fuentes(df['poa_global'], df['temp_air'],
++                              df['wind_speed'], noct_installed=45)
++
++    assert_series_equal(out, pd.Series([47.85, 50.85, 50.85], index=index,
++                                       name='tmod'))
+
+EOF_114329324912
+: '>>>>> Start Test Output'
+pytest -rA pvlib/tests/test_temperature.py
+: '>>>>> End Test Output'
+git checkout 04a523fafbd61bc2e49420963b84ed8e2bd1b3cf pvlib/tests/test_temperature.py

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/pvlib__pvlib-python-1072/patch.diff
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/pvlib__pvlib-python-1072/patch.diff
@@ -1,0 +1,16 @@
+diff --git a/pvlib/temperature.py b/pvlib/temperature.py
+index 1d98736..70d3595 100644
+--- a/pvlib/temperature.py
++++ b/pvlib/temperature.py
+@@ -599,7 +599,10 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
+     # n.b. the way Fuentes calculates the first timedelta makes it seem like
+     # the value doesn't matter -- rather than recreate it here, just assume
+     # it's the same as the second timedelta:
+-    timedelta_hours = np.diff(poa_global.index).astype(float) / 1e9 / 60 / 60
++    # Use .view('int64') to handle tz-aware DatetimeIndex which returns
++    # Timedelta objects instead of timedelta64 with np.diff()
++    timedelta_hours = np.diff(poa_global.index.view('int64')).astype(
++        float) / 1e9 / 60 / 60
+     timedelta_hours = np.append([timedelta_hours[0]], timedelta_hours)
+ 
+     tamb_array = temp_air + 273.15

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/pvlib__pvlib-python-1072/report.json
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/pvlib__pvlib-python-1072/report.json
@@ -1,0 +1,47 @@
+{
+    "pvlib__pvlib-python-1072": {
+        "patch_is_None": false,
+        "patch_exists": true,
+        "patch_successfully_applied": true,
+        "resolved": false,
+        "tests_status": {
+            "FAIL_TO_PASS": {
+                "success": [],
+                "failure": [
+                    "pvlib/tests/test_temperature.py::test_fuentes_timezone[Etc/GMT+5]"
+                ]
+            },
+            "PASS_TO_PASS": {
+                "success": [],
+                "failure": [
+                    "pvlib/tests/test_temperature.py::test_sapm_cell",
+                    "pvlib/tests/test_temperature.py::test_sapm_module",
+                    "pvlib/tests/test_temperature.py::test_sapm_cell_from_module",
+                    "pvlib/tests/test_temperature.py::test_sapm_ndarray",
+                    "pvlib/tests/test_temperature.py::test_sapm_series",
+                    "pvlib/tests/test_temperature.py::test_pvsyst_cell_default",
+                    "pvlib/tests/test_temperature.py::test_pvsyst_cell_kwargs",
+                    "pvlib/tests/test_temperature.py::test_pvsyst_cell_ndarray",
+                    "pvlib/tests/test_temperature.py::test_pvsyst_cell_series",
+                    "pvlib/tests/test_temperature.py::test_faiman_default",
+                    "pvlib/tests/test_temperature.py::test_faiman_kwargs",
+                    "pvlib/tests/test_temperature.py::test_faiman_list",
+                    "pvlib/tests/test_temperature.py::test_faiman_ndarray",
+                    "pvlib/tests/test_temperature.py::test_faiman_series",
+                    "pvlib/tests/test_temperature.py::test__temperature_model_params",
+                    "pvlib/tests/test_temperature.py::test_fuentes[pvwatts_8760_rackmount.csv-45]",
+                    "pvlib/tests/test_temperature.py::test_fuentes[pvwatts_8760_roofmount.csv-49]",
+                    "pvlib/tests/test_temperature.py::test_fuentes_timezone[None]"
+                ]
+            },
+            "FAIL_TO_FAIL": {
+                "success": [],
+                "failure": []
+            },
+            "PASS_TO_FAIL": {
+                "success": [],
+                "failure": []
+            }
+        }
+    }
+}

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/pvlib__pvlib-python-1072/test_output.txt
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/pvlib__pvlib-python-1072/test_output.txt
@@ -1,0 +1,412 @@
++ source /opt/miniconda3/bin/activate
+++ _CONDA_ROOT=/opt/miniconda3
+++ . /opt/miniconda3/etc/profile.d/conda.sh
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ '[' -z '' ']'
++++ export CONDA_SHLVL=0
++++ CONDA_SHLVL=0
++++ '[' -n '' ']'
++++++ dirname /opt/miniconda3/bin/conda
+++++ dirname /opt/miniconda3/bin
++++ PATH=/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export PATH
++++ '[' -z '' ']'
++++ PS1=
+++ conda activate
+++ local cmd=activate
+++ case "$cmd" in
+++ __conda_activate activate
+++ '[' -n '' ']'
+++ local ask_conda
++++ PS1=
++++ __conda_exe shell.posix activate
++++ /opt/miniconda3/bin/conda shell.posix activate
+++ ask_conda='PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''1'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ eval 'PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''1'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++++ PS1='(base) '
++++ export PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export CONDA_PREFIX=/opt/miniconda3
++++ CONDA_PREFIX=/opt/miniconda3
++++ export CONDA_SHLVL=1
++++ CONDA_SHLVL=1
++++ export CONDA_DEFAULT_ENV=base
++++ CONDA_DEFAULT_ENV=base
++++ export 'CONDA_PROMPT_MODIFIER=(base) '
++++ CONDA_PROMPT_MODIFIER='(base) '
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ __conda_hashr
+++ '[' -n '' ']'
+++ '[' -n '' ']'
+++ hash -r
++ conda activate testbed
++ local cmd=activate
++ case "$cmd" in
++ __conda_activate activate testbed
++ '[' -n '' ']'
++ local ask_conda
+++ PS1='(base) '
+++ __conda_exe shell.posix activate testbed
+++ /opt/miniconda3/bin/conda shell.posix activate testbed
++ ask_conda='PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''2'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_1='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++ eval 'PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''2'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_1='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ PS1='(testbed) '
+++ export PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ export CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ export CONDA_SHLVL=2
+++ CONDA_SHLVL=2
+++ export CONDA_DEFAULT_ENV=testbed
+++ CONDA_DEFAULT_ENV=testbed
+++ export 'CONDA_PROMPT_MODIFIER=(testbed) '
+++ CONDA_PROMPT_MODIFIER='(testbed) '
+++ export CONDA_PREFIX_1=/opt/miniconda3
+++ CONDA_PREFIX_1=/opt/miniconda3
+++ export CONDA_EXE=/opt/miniconda3/bin/conda
+++ CONDA_EXE=/opt/miniconda3/bin/conda
+++ export _CE_M=
+++ _CE_M=
+++ export _CE_CONDA=
+++ _CE_CONDA=
+++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++ __conda_hashr
++ '[' -n '' ']'
++ '[' -n '' ']'
++ hash -r
++ cd /testbed
++ git config --global --add safe.directory /testbed
++ cd /testbed
++ git status
+On branch main
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+	modified:   pvlib/temperature.py
+
+no changes added to commit (use "git add" and/or "git commit -a")
++ git show
+commit dc81df76430196d3325871870b952e61df3032e8
+Author: SWE-bench <setup@swebench.config>
+Date:   Tue May 6 23:21:30 2025 +0000
+
+    SWE-bench
++ git -c core.fileMode=false diff 04a523fafbd61bc2e49420963b84ed8e2bd1b3cf
+diff --git a/pvlib/temperature.py b/pvlib/temperature.py
+index 1d98736..70d3595 100644
+--- a/pvlib/temperature.py
++++ b/pvlib/temperature.py
+@@ -599,7 +599,10 @@ def fuentes(poa_global, temp_air, wind_speed, noct_installed, module_height=5,
+     # n.b. the way Fuentes calculates the first timedelta makes it seem like
+     # the value doesn't matter -- rather than recreate it here, just assume
+     # it's the same as the second timedelta:
+-    timedelta_hours = np.diff(poa_global.index).astype(float) / 1e9 / 60 / 60
++    # Use .view('int64') to handle tz-aware DatetimeIndex which returns
++    # Timedelta objects instead of timedelta64 with np.diff()
++    timedelta_hours = np.diff(poa_global.index.view('int64')).astype(
++        float) / 1e9 / 60 / 60
+     timedelta_hours = np.append([timedelta_hours[0]], timedelta_hours)
+ 
+     tamb_array = temp_air + 273.15
++ source /opt/miniconda3/bin/activate
+++ _CONDA_ROOT=/opt/miniconda3
+++ . /opt/miniconda3/etc/profile.d/conda.sh
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ '[' -z x ']'
+++ conda activate
+++ local cmd=activate
+++ case "$cmd" in
+++ __conda_activate activate
+++ '[' -n '' ']'
+++ local ask_conda
++++ PS1='(testbed) '
++++ __conda_exe shell.posix activate
++++ /opt/miniconda3/bin/conda shell.posix activate
+++ ask_conda='PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''3'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_PREFIX_2='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ eval 'PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''3'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_PREFIX_2='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++++ PS1='(base) '
++++ export PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export CONDA_PREFIX=/opt/miniconda3
++++ CONDA_PREFIX=/opt/miniconda3
++++ export CONDA_SHLVL=3
++++ CONDA_SHLVL=3
++++ export CONDA_DEFAULT_ENV=base
++++ CONDA_DEFAULT_ENV=base
++++ export 'CONDA_PROMPT_MODIFIER=(base) '
++++ CONDA_PROMPT_MODIFIER='(base) '
++++ export CONDA_PREFIX_2=/opt/miniconda3/envs/testbed
++++ CONDA_PREFIX_2=/opt/miniconda3/envs/testbed
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ __conda_hashr
+++ '[' -n '' ']'
+++ '[' -n '' ']'
+++ hash -r
++ conda activate testbed
++ local cmd=activate
++ case "$cmd" in
++ __conda_activate activate testbed
++ '[' -n '' ']'
++ local ask_conda
+++ PS1='(base) '
+++ __conda_exe shell.posix activate testbed
+++ /opt/miniconda3/bin/conda shell.posix activate testbed
++ ask_conda='PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''4'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_3='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++ eval 'PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''4'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_3='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ PS1='(testbed) '
+++ export PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ export CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ export CONDA_SHLVL=4
+++ CONDA_SHLVL=4
+++ export CONDA_DEFAULT_ENV=testbed
+++ CONDA_DEFAULT_ENV=testbed
+++ export 'CONDA_PROMPT_MODIFIER=(testbed) '
+++ CONDA_PROMPT_MODIFIER='(testbed) '
+++ export CONDA_PREFIX_3=/opt/miniconda3
+++ CONDA_PREFIX_3=/opt/miniconda3
+++ export CONDA_EXE=/opt/miniconda3/bin/conda
+++ CONDA_EXE=/opt/miniconda3/bin/conda
+++ export _CE_M=
+++ _CE_M=
+++ export _CE_CONDA=
+++ _CE_CONDA=
+++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++ __conda_hashr
++ '[' -n '' ']'
++ '[' -n '' ']'
++ hash -r
++ python -m pip install -e '.[all]'
+Obtaining file:///testbed
+  Preparing metadata (setup.py): started
+  Preparing metadata (setup.py): finished with status 'done'
+Requirement already satisfied: numpy>=1.12.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (2.0.2)
+Requirement already satisfied: pandas>=0.22.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (2.2.3)
+Requirement already satisfied: pytz in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (2024.1)
+Requirement already satisfied: requests in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (2.32.3)
+Requirement already satisfied: scipy>=1.2.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (1.13.1)
+Requirement already satisfied: cftime>=1.1.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (1.6.4.post1)
+Requirement already satisfied: cython in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (3.0.12)
+Requirement already satisfied: docutils==0.15.2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (0.15.2)
+Requirement already satisfied: ephem in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (4.2)
+Requirement already satisfied: ipython in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (8.18.1)
+Requirement already satisfied: matplotlib in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (3.9.4)
+Requirement already satisfied: netcdf4 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (1.7.2)
+Requirement already satisfied: nose in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (1.3.7)
+Requirement already satisfied: nrel-pysam in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (7.0.0)
+Requirement already satisfied: numba in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (0.60.0)
+Requirement already satisfied: pillow in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (11.2.1)
+Requirement already satisfied: pvfactors in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (1.5.1)
+Requirement already satisfied: pytest in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (8.3.5)
+Requirement already satisfied: pytest-cov in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (6.1.1)
+Requirement already satisfied: pytest-mock in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (3.14.0)
+Requirement already satisfied: pytest-remotedata in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (0.4.1)
+Requirement already satisfied: pytest-rerunfailures in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (15.0)
+Requirement already satisfied: pytest-timeout in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (2.4.0)
+Requirement already satisfied: siphon in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (0.9)
+Requirement already satisfied: sphinx==1.8.5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (1.8.5)
+Requirement already satisfied: sphinx-gallery in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (0.11.0)
+Requirement already satisfied: sphinx_rtd_theme in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (1.3.0)
+Requirement already satisfied: statsmodels in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (0.14.4)
+Requirement already satisfied: tables in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvlib==0.8.0+3.gdc81df7.dirty) (3.9.2)
+Requirement already satisfied: six>=1.5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (1.17.0)
+Requirement already satisfied: Jinja2>=2.3 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (3.1.6)
+Requirement already satisfied: Pygments>=2.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (2.19.1)
+Requirement already satisfied: snowballstemmer>=1.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (2.2.0)
+Requirement already satisfied: babel!=2.0,>=1.3 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (2.17.0)
+Requirement already satisfied: alabaster<0.8,>=0.7 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (0.7.16)
+Requirement already satisfied: imagesize in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (1.4.1)
+Requirement already satisfied: setuptools in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (72.1.0)
+Requirement already satisfied: packaging in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (25.0)
+Requirement already satisfied: sphinxcontrib-websupport in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (1.2.4)
+Requirement already satisfied: MarkupSafe>=2.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from Jinja2>=2.3->sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (3.0.2)
+Requirement already satisfied: python-dateutil>=2.8.2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pandas>=0.22.0->pvlib==0.8.0+3.gdc81df7.dirty) (2.9.0.post0)
+Requirement already satisfied: tzdata>=2022.7 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pandas>=0.22.0->pvlib==0.8.0+3.gdc81df7.dirty) (2025.2)
+Requirement already satisfied: charset-normalizer<4,>=2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from requests->pvlib==0.8.0+3.gdc81df7.dirty) (3.4.2)
+Requirement already satisfied: idna<4,>=2.5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from requests->pvlib==0.8.0+3.gdc81df7.dirty) (3.10)
+Requirement already satisfied: urllib3<3,>=1.21.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from requests->pvlib==0.8.0+3.gdc81df7.dirty) (2.4.0)
+Requirement already satisfied: certifi>=2017.4.17 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from requests->pvlib==0.8.0+3.gdc81df7.dirty) (2025.4.26)
+Requirement already satisfied: decorator in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (5.2.1)
+Requirement already satisfied: jedi>=0.16 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (0.19.2)
+Requirement already satisfied: matplotlib-inline in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (0.1.7)
+Requirement already satisfied: prompt-toolkit<3.1.0,>=3.0.41 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (3.0.51)
+Requirement already satisfied: stack-data in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (0.6.3)
+Requirement already satisfied: traitlets>=5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (5.14.3)
+Requirement already satisfied: typing-extensions in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (4.13.2)
+Requirement already satisfied: exceptiongroup in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (1.2.2)
+Requirement already satisfied: pexpect>4.3 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from ipython->pvlib==0.8.0+3.gdc81df7.dirty) (4.9.0)
+Requirement already satisfied: wcwidth in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from prompt-toolkit<3.1.0,>=3.0.41->ipython->pvlib==0.8.0+3.gdc81df7.dirty) (0.2.13)
+Requirement already satisfied: parso<0.9.0,>=0.8.4 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from jedi>=0.16->ipython->pvlib==0.8.0+3.gdc81df7.dirty) (0.8.4)
+Requirement already satisfied: ptyprocess>=0.5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pexpect>4.3->ipython->pvlib==0.8.0+3.gdc81df7.dirty) (0.7.0)
+Requirement already satisfied: contourpy>=1.0.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from matplotlib->pvlib==0.8.0+3.gdc81df7.dirty) (1.3.0)
+Requirement already satisfied: cycler>=0.10 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from matplotlib->pvlib==0.8.0+3.gdc81df7.dirty) (0.12.1)
+Requirement already satisfied: fonttools>=4.22.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from matplotlib->pvlib==0.8.0+3.gdc81df7.dirty) (4.57.0)
+Requirement already satisfied: kiwisolver>=1.3.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from matplotlib->pvlib==0.8.0+3.gdc81df7.dirty) (1.4.7)
+Requirement already satisfied: pyparsing>=2.3.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from matplotlib->pvlib==0.8.0+3.gdc81df7.dirty) (3.2.3)
+Requirement already satisfied: importlib-resources>=3.2.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from matplotlib->pvlib==0.8.0+3.gdc81df7.dirty) (6.5.2)
+Requirement already satisfied: zipp>=3.1.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from importlib-resources>=3.2.0->matplotlib->pvlib==0.8.0+3.gdc81df7.dirty) (3.21.0)
+Requirement already satisfied: llvmlite<0.44,>=0.43.0dev0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from numba->pvlib==0.8.0+3.gdc81df7.dirty) (0.43.0)
+Requirement already satisfied: shapely>=1.6.4.post2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvfactors->pvlib==0.8.0+3.gdc81df7.dirty) (2.0.7)
+Requirement already satisfied: future in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pvfactors->pvlib==0.8.0+3.gdc81df7.dirty) (1.0.0)
+Requirement already satisfied: iniconfig in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->pvlib==0.8.0+3.gdc81df7.dirty) (2.1.0)
+Requirement already satisfied: pluggy<2,>=1.5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->pvlib==0.8.0+3.gdc81df7.dirty) (1.5.0)
+Requirement already satisfied: tomli>=1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->pvlib==0.8.0+3.gdc81df7.dirty) (2.2.1)
+Requirement already satisfied: coverage>=7.5 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from coverage[toml]>=7.5->pytest-cov->pvlib==0.8.0+3.gdc81df7.dirty) (7.8.0)
+Requirement already satisfied: protobuf>=3.0.0a3 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from siphon->pvlib==0.8.0+3.gdc81df7.dirty) (6.31.0rc2)
+Requirement already satisfied: beautifulsoup4>=4.6 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from siphon->pvlib==0.8.0+3.gdc81df7.dirty) (4.13.4)
+Requirement already satisfied: soupsieve>1.2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from beautifulsoup4>=4.6->siphon->pvlib==0.8.0+3.gdc81df7.dirty) (2.7)
+Requirement already satisfied: sphinxcontrib-jquery<5,>=4 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinx_rtd_theme->pvlib==0.8.0+3.gdc81df7.dirty) (4.1)
+Requirement already satisfied: sphinxcontrib-serializinghtml in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sphinxcontrib-websupport->sphinx==1.8.5->pvlib==0.8.0+3.gdc81df7.dirty) (2.0.0)
+Requirement already satisfied: executing>=1.2.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from stack-data->ipython->pvlib==0.8.0+3.gdc81df7.dirty) (2.2.0)
+Requirement already satisfied: asttokens>=2.1.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from stack-data->ipython->pvlib==0.8.0+3.gdc81df7.dirty) (3.0.0)
+Requirement already satisfied: pure-eval in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from stack-data->ipython->pvlib==0.8.0+3.gdc81df7.dirty) (0.2.3)
+Requirement already satisfied: patsy>=0.5.6 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from statsmodels->pvlib==0.8.0+3.gdc81df7.dirty) (1.0.1)
+Requirement already satisfied: numexpr>=2.6.2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tables->pvlib==0.8.0+3.gdc81df7.dirty) (2.10.1)
+Requirement already satisfied: py-cpuinfo in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tables->pvlib==0.8.0+3.gdc81df7.dirty) (9.0.0)
+Requirement already satisfied: blosc2>=2.3.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from tables->pvlib==0.8.0+3.gdc81df7.dirty) (2.5.1)
+Requirement already satisfied: ndindex>=1.4 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from blosc2>=2.3.0->tables->pvlib==0.8.0+3.gdc81df7.dirty) (1.9.2)
+Requirement already satisfied: msgpack in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from blosc2>=2.3.0->tables->pvlib==0.8.0+3.gdc81df7.dirty) (1.1.0)
+Installing collected packages: pvlib
+  Attempting uninstall: pvlib
+    Found existing installation: pvlib 0.8.0+2.g04a523f
+    Uninstalling pvlib-0.8.0+2.g04a523f:
+      Successfully uninstalled pvlib-0.8.0+2.g04a523f
+  DEPRECATION: Legacy editable install of pvlib[all]==0.8.0+3.gdc81df7.dirty from file:///testbed (setup.py develop) is deprecated. pip 25.3 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457
+  Running setup.py develop for pvlib
+Successfully installed pvlib
+WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
++ git checkout 04a523fafbd61bc2e49420963b84ed8e2bd1b3cf pvlib/tests/test_temperature.py
+Updated 0 paths from 6b8d479
++ git apply -v -
+Checking patch pvlib/tests/test_temperature.py...
+Applied patch pvlib/tests/test_temperature.py cleanly.
++ : '>>>>> Start Test Output'
++ pytest -rA pvlib/tests/test_temperature.py
+ImportError while loading conftest '/testbed/pvlib/tests/conftest.py'.
+pvlib/tests/conftest.py:10: in <module>
+    import pvlib
+pvlib/__init__.py:10: in <module>
+    from pvlib import ivtools  # noqa: F401
+pvlib/ivtools/__init__.py:7: in <module>
+    from pvlib.ivtools import sde, sdm, utils  # noqa: F401
+pvlib/ivtools/sdm.py:15: in <module>
+    from pvlib.pvsystem import singlediode, v_from_i
+pvlib/pvsystem.py:16: in <module>
+    from pvlib import (atmosphere, iam, inverter, irradiance,
+pvlib/singlediode.py:59: in <module>
+    NsVbi=np.Inf, breakdown_factor=0., breakdown_voltage=-5.5,
+/opt/miniconda3/envs/testbed/lib/python3.9/site-packages/numpy/__init__.py:397: in __getattr__
+    raise AttributeError(
+E   AttributeError: `np.Inf` was removed in the NumPy 2.0 release. Use `np.inf` instead.
++ : '>>>>> End Test Output'
++ git checkout 04a523fafbd61bc2e49420963b84ed8e2bd1b3cf pvlib/tests/test_temperature.py
+Updated 1 path from 6b8d479

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/sqlfluff__sqlfluff-2419/eval.sh
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/sqlfluff__sqlfluff-2419/eval.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -uxo pipefail
+source /opt/miniconda3/bin/activate
+conda activate testbed
+cd /testbed
+git config --global --add safe.directory /testbed
+cd /testbed
+git status
+git show
+git -c core.fileMode=false diff f1dba0e1dd764ae72d67c3d5e1471cf14d3db030
+source /opt/miniconda3/bin/activate
+conda activate testbed
+python -m pip install -e .
+git checkout f1dba0e1dd764ae72d67c3d5e1471cf14d3db030 
+git apply -v - <<'EOF_114329324912'
+diff --git a/test/rules/std_L060_test.py b/test/rules/std_L060_test.py
+new file mode 100644
+--- /dev/null
++++ b/test/rules/std_L060_test.py
+@@ -0,0 +1,12 @@
++"""Tests the python routines within L060."""
++import sqlfluff
++
++
++def test__rules__std_L060_raised() -> None:
++    """L060 is raised for use of ``IFNULL`` or ``NVL``."""
++    sql = "SELECT\n\tIFNULL(NULL, 100),\n\tNVL(NULL,100);"
++    result = sqlfluff.lint(sql, rules=["L060"])
++
++    assert len(result) == 2
++    assert result[0]["description"] == "Use 'COALESCE' instead of 'IFNULL'."
++    assert result[1]["description"] == "Use 'COALESCE' instead of 'NVL'."
+
+EOF_114329324912
+: '>>>>> Start Test Output'
+pytest -rA test/rules/std_L060_test.py
+: '>>>>> End Test Output'
+git checkout f1dba0e1dd764ae72d67c3d5e1471cf14d3db030 

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/sqlfluff__sqlfluff-2419/patch.diff
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/sqlfluff__sqlfluff-2419/patch.diff
@@ -1,0 +1,14 @@
+diff --git a/src/sqlfluff/rules/L060.py b/src/sqlfluff/rules/L060.py
+index 836941e..ce55e4e 100644
+--- a/src/sqlfluff/rules/L060.py
++++ b/src/sqlfluff/rules/L060.py
+@@ -59,4 +59,8 @@ class Rule_L060(BaseRule):
+             ],
+         )
+ 
+-        return LintResult(context.segment, [fix])
++        return LintResult(
++        context.segment,
++        [fix],
++        description=f"Use 'COALESCE' instead of '{context.segment.raw_upper}'.",
++    )

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/sqlfluff__sqlfluff-2419/report.json
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/sqlfluff__sqlfluff-2419/report.json
@@ -1,0 +1,28 @@
+{
+    "sqlfluff__sqlfluff-2419": {
+        "patch_is_None": false,
+        "patch_exists": true,
+        "patch_successfully_applied": true,
+        "resolved": true,
+        "tests_status": {
+            "FAIL_TO_PASS": {
+                "success": [
+                    "test/rules/std_L060_test.py::test__rules__std_L060_raised"
+                ],
+                "failure": []
+            },
+            "PASS_TO_PASS": {
+                "success": [],
+                "failure": []
+            },
+            "FAIL_TO_FAIL": {
+                "success": [],
+                "failure": []
+            },
+            "PASS_TO_FAIL": {
+                "success": [],
+                "failure": []
+            }
+        }
+    }
+}

--- a/experiments/swebench_lite/leaderboard_submission/logs_smoke3/sqlfluff__sqlfluff-2419/test_output.txt
+++ b/experiments/swebench_lite/leaderboard_submission/logs_smoke3/sqlfluff__sqlfluff-2419/test_output.txt
@@ -1,0 +1,430 @@
++ source /opt/miniconda3/bin/activate
+++ _CONDA_ROOT=/opt/miniconda3
+++ . /opt/miniconda3/etc/profile.d/conda.sh
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ '[' -z '' ']'
++++ export CONDA_SHLVL=0
++++ CONDA_SHLVL=0
++++ '[' -n '' ']'
++++++ dirname /opt/miniconda3/bin/conda
+++++ dirname /opt/miniconda3/bin
++++ PATH=/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export PATH
++++ '[' -z '' ']'
++++ PS1=
+++ conda activate
+++ local cmd=activate
+++ case "$cmd" in
+++ __conda_activate activate
+++ '[' -n '' ']'
+++ local ask_conda
++++ PS1=
++++ __conda_exe shell.posix activate
++++ /opt/miniconda3/bin/conda shell.posix activate
+++ ask_conda='PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''1'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ eval 'PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''1'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++++ PS1='(base) '
++++ export PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export CONDA_PREFIX=/opt/miniconda3
++++ CONDA_PREFIX=/opt/miniconda3
++++ export CONDA_SHLVL=1
++++ CONDA_SHLVL=1
++++ export CONDA_DEFAULT_ENV=base
++++ CONDA_DEFAULT_ENV=base
++++ export 'CONDA_PROMPT_MODIFIER=(base) '
++++ CONDA_PROMPT_MODIFIER='(base) '
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ __conda_hashr
+++ '[' -n '' ']'
+++ '[' -n '' ']'
+++ hash -r
++ conda activate testbed
++ local cmd=activate
++ case "$cmd" in
++ __conda_activate activate testbed
++ '[' -n '' ']'
++ local ask_conda
+++ PS1='(base) '
+++ __conda_exe shell.posix activate testbed
+++ /opt/miniconda3/bin/conda shell.posix activate testbed
++ ask_conda='PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''2'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_1='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++ eval 'PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''2'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_1='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ PS1='(testbed) '
+++ export PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ export CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ export CONDA_SHLVL=2
+++ CONDA_SHLVL=2
+++ export CONDA_DEFAULT_ENV=testbed
+++ CONDA_DEFAULT_ENV=testbed
+++ export 'CONDA_PROMPT_MODIFIER=(testbed) '
+++ CONDA_PROMPT_MODIFIER='(testbed) '
+++ export CONDA_PREFIX_1=/opt/miniconda3
+++ CONDA_PREFIX_1=/opt/miniconda3
+++ export CONDA_EXE=/opt/miniconda3/bin/conda
+++ CONDA_EXE=/opt/miniconda3/bin/conda
+++ export _CE_M=
+++ _CE_M=
+++ export _CE_CONDA=
+++ _CE_CONDA=
+++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++ __conda_hashr
++ '[' -n '' ']'
++ '[' -n '' ']'
++ hash -r
++ cd /testbed
++ git config --global --add safe.directory /testbed
++ cd /testbed
++ git status
+On branch main
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+	modified:   src/sqlfluff/rules/L060.py
+
+no changes added to commit (use "git add" and/or "git commit -a")
++ git show
+commit f1dba0e1dd764ae72d67c3d5e1471cf14d3db030
+Author: Barry Pollard <barry@tunetheweb.com>
+Date:   Sat Jan 22 12:35:28 2022 +0000
+
+    Fix code formatting in Rule docs (#2418)
+
+diff --git a/src/sqlfluff/rules/L041.py b/src/sqlfluff/rules/L041.py
+index d33c7c281..1196a738b 100644
+--- a/src/sqlfluff/rules/L041.py
++++ b/src/sqlfluff/rules/L041.py
+@@ -10,7 +10,7 @@ from sqlfluff.core.rules.functional import sp
+ 
+ @document_fix_compatible
+ class Rule_L041(BaseRule):
+-    """``SELECT`` modifiers (e.g.``DISTINCT``) must be on the same line as ``SELECT``.
++    """``SELECT`` modifiers (e.g. ``DISTINCT``) must be on the same line as ``SELECT``.
+ 
+     | **Anti-pattern**
+ 
+diff --git a/src/sqlfluff/rules/L043.py b/src/sqlfluff/rules/L043.py
+index 7cbeadd7b..13cf2a96f 100644
+--- a/src/sqlfluff/rules/L043.py
++++ b/src/sqlfluff/rules/L043.py
+@@ -30,7 +30,7 @@ class Rule_L043(BaseRule):
+             end as is_fab
+         from fancy_table
+ 
+-        -- This rule can also simplify ``CASE`` statements
++        -- This rule can also simplify CASE statements
+         -- that aim to fill NULL values.
+ 
+         select
+@@ -60,13 +60,13 @@ class Rule_L043(BaseRule):
+             coalesce(fab > 0, false) as is_fab
+         from fancy_table
+ 
+-        -- To fill ``NULL`` values.
++        -- To fill NULL values.
+ 
+         select
+             coalesce(fab, 0) as fab_clean
+         from fancy_table
+ 
+-        -- ``NULL`` filling ``NULL``.
++        -- NULL filling NULL.
+ 
+         select fab as fab_clean
+         from fancy_table
+diff --git a/src/sqlfluff/rules/L047.py b/src/sqlfluff/rules/L047.py
+index 98c94e64e..0db6f80fe 100644
+--- a/src/sqlfluff/rules/L047.py
++++ b/src/sqlfluff/rules/L047.py
+@@ -31,7 +31,7 @@ class Rule_L047(BaseRule):
+     So by default, SQLFluff enforces the consistent use of ``COUNT(*)``.
+ 
+     If the SQL engine you work with, or your team, prefers ``COUNT(1)`` or
+-    ``COUNT(0)``cover ``COUNT(*)``, you can configure this rule to consistently
++    ``COUNT(0)`` over ``COUNT(*)``, you can configure this rule to consistently
+     enforce your preference.
+ 
+     .. _ANSI-92: http://msdn.microsoft.com/en-us/library/ms175997.aspx
+diff --git a/src/sqlfluff/rules/L056.py b/src/sqlfluff/rules/L056.py
+index 4e0057832..a2975e24c 100644
+--- a/src/sqlfluff/rules/L056.py
++++ b/src/sqlfluff/rules/L056.py
+@@ -37,7 +37,7 @@ class Rule_L056(BaseRule):
+             CaseOutput
+         FROM table1
+ 
+-        -- Alternatively prefix with ``USP_`` to
++        -- Alternatively prefix with USP_ to
+         -- indicate a user-defined stored procedure.
+ 
+         CREATE PROCEDURE dbo.usp_pull_data
++ git -c core.fileMode=false diff f1dba0e1dd764ae72d67c3d5e1471cf14d3db030
++ source /opt/miniconda3/bin/activate
+diff --git a/src/sqlfluff/rules/L060.py b/src/sqlfluff/rules/L060.py
+index 836941edc..ce55e4e52 100644
+--- a/src/sqlfluff/rules/L060.py
++++ b/src/sqlfluff/rules/L060.py
+@@ -59,4 +59,8 @@ class Rule_L060(BaseRule):
+             ],
+         )
+ 
+-        return LintResult(context.segment, [fix])
++        return LintResult(
++        context.segment,
++        [fix],
++        description=f"Use 'COALESCE' instead of '{context.segment.raw_upper}'.",
++    )
+++ _CONDA_ROOT=/opt/miniconda3
+++ . /opt/miniconda3/etc/profile.d/conda.sh
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ '[' -z x ']'
+++ conda activate
+++ local cmd=activate
+++ case "$cmd" in
+++ __conda_activate activate
+++ '[' -n '' ']'
+++ local ask_conda
++++ PS1='(testbed) '
++++ __conda_exe shell.posix activate
++++ /opt/miniconda3/bin/conda shell.posix activate
+++ ask_conda='PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''3'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_PREFIX_2='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ eval 'PS1='\''(base) '\''
+export PATH='\''/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3'\''
+export CONDA_SHLVL='\''3'\''
+export CONDA_DEFAULT_ENV='\''base'\''
+export CONDA_PROMPT_MODIFIER='\''(base) '\''
+export CONDA_PREFIX_2='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++++ PS1='(base) '
++++ export PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ PATH=/opt/miniconda3/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++++ export CONDA_PREFIX=/opt/miniconda3
++++ CONDA_PREFIX=/opt/miniconda3
++++ export CONDA_SHLVL=3
++++ CONDA_SHLVL=3
++++ export CONDA_DEFAULT_ENV=base
++++ CONDA_DEFAULT_ENV=base
++++ export 'CONDA_PROMPT_MODIFIER=(base) '
++++ CONDA_PROMPT_MODIFIER='(base) '
++++ export CONDA_PREFIX_2=/opt/miniconda3/envs/testbed
++++ CONDA_PREFIX_2=/opt/miniconda3/envs/testbed
++++ export CONDA_EXE=/opt/miniconda3/bin/conda
++++ CONDA_EXE=/opt/miniconda3/bin/conda
++++ export _CE_M=
++++ _CE_M=
++++ export _CE_CONDA=
++++ _CE_CONDA=
++++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ __conda_hashr
+++ '[' -n '' ']'
+++ '[' -n '' ']'
+++ hash -r
++ conda activate testbed
++ local cmd=activate
++ case "$cmd" in
++ __conda_activate activate testbed
++ '[' -n '' ']'
++ local ask_conda
+++ PS1='(base) '
+++ __conda_exe shell.posix activate testbed
+++ /opt/miniconda3/bin/conda shell.posix activate testbed
++ ask_conda='PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''4'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_3='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
++ eval 'PS1='\''(testbed) '\''
+export PATH='\''/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'\''
+export CONDA_PREFIX='\''/opt/miniconda3/envs/testbed'\''
+export CONDA_SHLVL='\''4'\''
+export CONDA_DEFAULT_ENV='\''testbed'\''
+export CONDA_PROMPT_MODIFIER='\''(testbed) '\''
+export CONDA_PREFIX_3='\''/opt/miniconda3'\''
+export CONDA_EXE='\''/opt/miniconda3/bin/conda'\''
+export _CE_M='\'''\''
+export _CE_CONDA='\'''\''
+export CONDA_PYTHON_EXE='\''/opt/miniconda3/bin/python'\'''
+++ PS1='(testbed) '
+++ export PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:/opt/miniconda3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+++ export CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ CONDA_PREFIX=/opt/miniconda3/envs/testbed
+++ export CONDA_SHLVL=4
+++ CONDA_SHLVL=4
+++ export CONDA_DEFAULT_ENV=testbed
+++ CONDA_DEFAULT_ENV=testbed
+++ export 'CONDA_PROMPT_MODIFIER=(testbed) '
+++ CONDA_PROMPT_MODIFIER='(testbed) '
+++ export CONDA_PREFIX_3=/opt/miniconda3
+++ CONDA_PREFIX_3=/opt/miniconda3
+++ export CONDA_EXE=/opt/miniconda3/bin/conda
+++ CONDA_EXE=/opt/miniconda3/bin/conda
+++ export _CE_M=
+++ _CE_M=
+++ export _CE_CONDA=
+++ _CE_CONDA=
+++ export CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
+++ CONDA_PYTHON_EXE=/opt/miniconda3/bin/python
++ __conda_hashr
++ '[' -n '' ']'
++ '[' -n '' ']'
++ hash -r
++ python -m pip install -e .
+Obtaining file:///testbed
+  Preparing metadata (setup.py): started
+  Preparing metadata (setup.py): finished with status 'done'
+Requirement already satisfied: appdirs in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (1.4.4)
+Requirement already satisfied: chardet in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (5.2.0)
+Requirement already satisfied: click>=7.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (8.1.7)
+Requirement already satisfied: colorama>=0.3 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (0.4.6)
+Requirement already satisfied: diff-cover>=2.5.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (9.2.0)
+Requirement already satisfied: Jinja2 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (3.1.4)
+Requirement already satisfied: pathspec in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (0.12.1)
+Requirement already satisfied: pytest in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (8.3.3)
+Requirement already satisfied: pyyaml>=5.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (6.0.2)
+Requirement already satisfied: regex in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (2024.11.6)
+Requirement already satisfied: tblib in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (3.0.0)
+Requirement already satisfied: toml in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (0.10.2)
+Requirement already satisfied: tqdm in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (4.67.0)
+Requirement already satisfied: typing_extensions in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from sqlfluff==0.9.1) (4.12.2)
+Requirement already satisfied: Pygments<3.0.0,>=2.9.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from diff-cover>=2.5.0->sqlfluff==0.9.1) (2.18.0)
+Requirement already satisfied: pluggy<2,>=0.13.1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from diff-cover>=2.5.0->sqlfluff==0.9.1) (1.5.0)
+Requirement already satisfied: MarkupSafe>=2.0 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from Jinja2->sqlfluff==0.9.1) (3.0.2)
+Requirement already satisfied: iniconfig in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->sqlfluff==0.9.1) (2.0.0)
+Requirement already satisfied: packaging in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->sqlfluff==0.9.1) (24.2)
+Requirement already satisfied: exceptiongroup>=1.0.0rc8 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->sqlfluff==0.9.1) (1.2.2)
+Requirement already satisfied: tomli>=1 in /opt/miniconda3/envs/testbed/lib/python3.9/site-packages (from pytest->sqlfluff==0.9.1) (1.2.3)
+Installing collected packages: sqlfluff
+  Attempting uninstall: sqlfluff
+    Found existing installation: sqlfluff 0.9.1
+    Uninstalling sqlfluff-0.9.1:
+      Successfully uninstalled sqlfluff-0.9.1
+  DEPRECATION: Legacy editable install of sqlfluff==0.9.1 from file:///testbed (setup.py develop) is deprecated. pip 25.0 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457
+  Running setup.py develop for sqlfluff
+Successfully installed sqlfluff
+WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
++ git checkout f1dba0e1dd764ae72d67c3d5e1471cf14d3db030
+Note: switching to 'f1dba0e1dd764ae72d67c3d5e1471cf14d3db030'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at f1dba0e1d Fix code formatting in Rule docs (#2418)
+M	src/sqlfluff/rules/L060.py
++ git apply -v -
+Checking patch test/rules/std_L060_test.py...
+Applied patch test/rules/std_L060_test.py cleanly.
++ : '>>>>> Start Test Output'
++ pytest -rA test/rules/std_L060_test.py
+============================= test session starts ==============================
+platform linux -- Python 3.9.20, pytest-8.3.3, pluggy-1.5.0
+rootdir: /testbed
+configfile: pytest.ini
+plugins: sugar-1.0.0, cov-5.0.0, hypothesis-6.119.3, xdist-3.6.1
+collected 1 item
+
+test/rules/std_L060_test.py .                                            [100%]
+
+==================================== PASSES ====================================
+=========================== short test summary info ============================
+PASSED test/rules/std_L060_test.py::test__rules__std_L060_raised
+============================== 1 passed in 0.55s ===============================
++ : '>>>>> End Test Output'
++ git checkout f1dba0e1dd764ae72d67c3d5e1471cf14d3db030
+HEAD is now at f1dba0e1d Fix code formatting in Rule docs (#2418)
+M	src/sqlfluff/rules/L060.py


### PR DESCRIPTION
## Summary

3-instance smoke of the local SWE-bench harness (PR #69 runner) exposed a Docker-image drift bug in swebench 4.1.0 that affects pvlib instances. Our patches are byte-identical to sb-cli's graded-resolved patches; the local harness grades them wrong because the testbed Docker image ships NumPy 2.0+ and pvlib's `singlediode.py` still uses the removed `np.Inf` alias, so `import pvlib` fails at collection time.

## Smoke outcome

| Instance | Local harness | sb-cli |
|---|---|---|
| marshmallow-code__marshmallow-1343 | resolved=True ✓ | resolved=True ✓ |
| sqlfluff__sqlfluff-2419 | resolved=True ✓ | resolved=True ✓ |
| pvlib__pvlib-python-1072 | **resolved=False ✗** | **resolved=True ✓** |

## Evidence

- Patches for pvlib-1072 in our merged predictions vs predictions_e1_kimi.jsonl are byte-identical (verified by direct comparison)
- \`test_output.txt\` shows \`AttributeError: 'np.Inf' was removed in the NumPy 2.0 release. Use 'np.inf' instead\` — failure precedes our patch's effect
- All \`test_temperature.py\` tests fail on collection import, not on our change

## Implications

- ~5/23 dev-23 instances are pvlib. Full local harness run would produce 4-5 fewer "resolved" than sb-cli's correct cloud grading.
- Committing to local numbers would **misrepresent** the result downward.
- sb-cli cloud reports remain authoritative — **10/23 = 43.5% stands** as the headline.
- \`logs/\` gap stays open until sb-cli dev quota resets OR upstream fixes the pvlib Docker image's NumPy pin.

## Changes

- \`leaderboard_submission/README.md\` — new "⚠️ Environmental caveat" subsection documenting symptom, root cause, blast radius, and recommendation
- \`leaderboard_submission/logs_smoke3/\` — the 3 smoke instances' per-instance artifacts (\`patch.diff\`, \`report.json\`, \`test_output.txt\`, \`eval.sh\`, \`run_instance.log\`) committed verbatim so reviewers can audit directly

## Test plan

- [x] Smoke ran end-to-end on this machine in 41s (warm Docker cache)
- [x] pvlib-1072 patch byte-compared to e1_kimi's — identical
- [x] Per-instance artifacts from smoke match SWE-bench/experiments \`logs/\` format expectations
- [ ] CI lint/test — THIS PR (docs + bash artifacts only; should be green)

## Not in this PR

- Full local harness run (declined: would produce wrong numbers due to above)
- Upstream fix to swebench's pvlib Docker image NumPy pin (out of scope)
- sb-cli re-verification of merged predictions (blocked on quota reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)