### PR TITLE
chore(deps): ignore pydantic + python-dotenv dependabot (LiteLLM pins them)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # LiteLLM pins pydantic==2.12.5 strictly (BerriAI/litellm);
+      # Dependabot bumps to 2.13.x create unresolvable deps.
+      # Un-ignore once LiteLLM relaxes the pin. See PR #55 discussion.
+      - dependency-name: "pydantic"
+      # LiteLLM also pins python-dotenv==1.0.1 strictly; 1.2.x causes
+      # the same resolution conflict. CVE-2026-28684 is suppressed in
+      # ci.yml pip-audit pending litellm relaxation.
+      - dependency-name: "python-dotenv"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Summary

LiteLLM pins two transitive dependencies strictly, causing Dependabot bumps to repeatedly fail with resolution conflicts:

- \`pydantic==2.12.5\` — blocked PR #55 (bump to 2.13.x, see diagnosis in that thread)
- \`python-dotenv==1.0.1\` — blocked an earlier PR + forced a CVE suppression

Rather than continuously rejecting these Dependabot PRs, add them to the pip \`ignore\` list. When LiteLLM relaxes its pins, remove the ignore rules.

## Changes

- \`.github/dependabot.yml\` — \`ignore:\` block with both package names and a comment pointing at PR #55 for context

## Effect

- Dependabot stops opening PRs for these two packages
- Other dependency updates continue unchanged
- No code / behavior changes

## Test plan

- [x] YAML validates
- [ ] CI lint/test — THIS PR (yaml-only; should be green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)