### PR TITLE
fix(tools,cli): post-edit syntax gate + Windows UTF-8 stdio

### DIFF
--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import io
 import logging
 import shutil
 import subprocess
@@ -16,6 +17,42 @@ from uuid import uuid4
 import click
 
 from godspeed import __version__
+
+
+def _force_utf8_stdio() -> None:
+    """Make stdout/stderr survive non-ASCII output on legacy consoles.
+
+    Default stdout encoding on Windows is often cp1252, which cannot encode
+    common agent output characters (arrows, em-dashes, smart quotes) and
+    crashes with UnicodeEncodeError after the agent already finished real
+    work — masking success with a nonzero exit. We rewrap stdout/stderr in
+    UTF-8 with errors='replace' so stray high-bit chars become '?' instead
+    of crashing. Idempotent; only rewraps when the current encoding is not
+    already utf-8.
+    """
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        if stream is None or not hasattr(stream, "buffer"):
+            continue
+        enc = (getattr(stream, "encoding", "") or "").lower().replace("-", "")
+        if enc == "utf8":
+            continue
+        try:
+            setattr(
+                sys,
+                name,
+                io.TextIOWrapper(
+                    stream.buffer,
+                    encoding="utf-8",
+                    errors="replace",
+                    line_buffering=True,
+                ),
+            )
+        except (AttributeError, OSError):
+            continue
+
+
+_force_utf8_stdio()
 
 logger = logging.getLogger(__name__)
 

--- a/src/godspeed/tools/file_edit.py
+++ b/src/godspeed/tools/file_edit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+import json
 import logging
 from difflib import SequenceMatcher
 from typing import Any
@@ -13,6 +15,56 @@ logger = logging.getLogger(__name__)
 
 # Minimum similarity ratio for fuzzy matching
 FUZZY_THRESHOLD = 0.8
+
+# Extensions for which we run a post-edit syntax gate. If the edit changes
+# the file from parseable to unparseable, we revert and surface the error —
+# protecting against the "looks mostly right but actually broken" failure
+# mode observed with multi-line edits that drop indentation.
+_SYNTAX_GATED_EXTS = frozenset({".py", ".pyi"})
+
+
+def _syntax_check(path_ext: str, before_content: str, after_content: str) -> str | None:
+    """Return an error message if the edit broke syntax that previously parsed.
+
+    Currently covers Python (.py, .pyi) via ast.parse and JSON via json.loads.
+    Returns None if the edit is safe — either the file type is not gated, or
+    the file was already broken before the edit (we don't blame the edit for
+    pre-existing breakage), or the new content still parses.
+    """
+    ext = path_ext.lower()
+
+    if ext in _SYNTAX_GATED_EXTS:
+        parser = ast.parse
+    elif ext == ".json":
+
+        def parser(s: str) -> object:
+            return json.loads(s)
+
+    else:
+        return None
+
+    # Skip the gate if the pre-edit content already didn't parse — the edit
+    # isn't responsible for pre-existing breakage, and a blocked revert would
+    # prevent the agent from fixing the underlying issue.
+    try:
+        parser(before_content)
+    except (SyntaxError, ValueError):
+        return None
+
+    try:
+        parser(after_content)
+    except SyntaxError as exc:
+        return (
+            f"Post-edit syntax check failed — the edit would leave the file unparseable. "
+            f"Line {exc.lineno}: {exc.msg}. "
+            "This commonly means a multi-line replacement dropped indentation. "
+            "Re-read the file and include enough surrounding context in old_string "
+            "to preserve whitespace in new_string."
+        )
+    except ValueError as exc:
+        return f"Post-edit JSON parse failed — the edit would produce invalid JSON: {exc}."
+
+    return None
 
 
 class FileEditTool(Tool):
@@ -140,6 +192,18 @@ class FileEditTool(Tool):
                 match_line,
                 file_path_str,
             )
+
+        # Post-edit syntax gate: for .py / .pyi / .json, refuse edits that
+        # would turn a parseable file into an unparseable one. Catches the
+        # "multi-line replace drops indentation" failure mode.
+        syntax_err = _syntax_check(resolved.suffix, content, new_content)
+        if syntax_err is not None:
+            logger.warning(
+                "Rejected edit on %s — post-edit syntax gate failed: %s",
+                file_path_str,
+                syntax_err,
+            )
+            return ToolResult.failure(syntax_err)
 
         resolved.write_text(new_content, encoding="utf-8")
         logger.info(

--- a/src/godspeed/tools/file_edit.py
+++ b/src/godspeed/tools/file_edit.py
@@ -33,26 +33,27 @@ def _syntax_check(path_ext: str, before_content: str, after_content: str) -> str
     """
     ext = path_ext.lower()
 
-    if ext in _SYNTAX_GATED_EXTS:
-        parser = ast.parse
-    elif ext == ".json":
-
-        def parser(s: str) -> object:
-            return json.loads(s)
-
-    else:
+    if ext not in _SYNTAX_GATED_EXTS and ext != ".json":
         return None
+
+    is_python = ext in _SYNTAX_GATED_EXTS
+
+    def _parse(source: str) -> None:
+        if is_python:
+            ast.parse(source)
+        else:
+            json.loads(source)
 
     # Skip the gate if the pre-edit content already didn't parse — the edit
     # isn't responsible for pre-existing breakage, and a blocked revert would
     # prevent the agent from fixing the underlying issue.
     try:
-        parser(before_content)
+        _parse(before_content)
     except (SyntaxError, ValueError):
         return None
 
     try:
-        parser(after_content)
+        _parse(after_content)
     except SyntaxError as exc:
         return (
             f"Post-edit syntax check failed — the edit would leave the file unparseable. "

--- a/tests/test_tools/test_file_edit.py
+++ b/tests/test_tools/test_file_edit.py
@@ -311,9 +311,7 @@ class TestPostEditSyntaxGate:
         assert f.read_text(encoding="utf-8") == '{"a": 1, "b": 2}\n'
 
     @pytest.mark.asyncio
-    async def test_json_valid_allowed(
-        self, tool: FileEditTool, tool_context: ToolContext
-    ) -> None:
+    async def test_json_valid_allowed(self, tool: FileEditTool, tool_context: ToolContext) -> None:
         f = tool_context.cwd / "config.json"
         f.write_text('{"a": 1}\n', encoding="utf-8")
         result = await tool.execute(

--- a/tests/test_tools/test_file_edit.py
+++ b/tests/test_tools/test_file_edit.py
@@ -194,3 +194,135 @@ class TestConfidenceReporting:
         assert "match=fuzzy" in result.output
         assert "confidence=" in result.output
         assert "line=" in result.output
+
+
+class TestPostEditSyntaxGate:
+    """Syntax gate: edits that break a previously-parseable file must be rejected.
+
+    Protects against the "multi-line replace drops indentation" failure mode
+    observed in the daily-use benchmark (benchmark T4: user_id -> account_id
+    rename de-indented function body and produced a SyntaxError).
+    """
+
+    @pytest.mark.asyncio
+    async def test_py_indent_strip_rejected(
+        self, tool: FileEditTool, tool_context: ToolContext
+    ) -> None:
+        """Fuzzy-match edit that drops indentation on a .py file must be rejected."""
+        f = tool_context.cwd / "api.py"
+        f.write_text(
+            'def handle(req):\n    uid = req["user_id"]\n    return uid\n',
+            encoding="utf-8",
+        )
+        # Agent provides new_string without the leading 4-space indent.
+        # Fuzzy match will still find it (whitespace drift), but writing
+        # would produce an IndentationError. The gate must reject.
+        result = await tool.execute(
+            {
+                "file_path": "api.py",
+                "old_string": '    uid = req["user_id"]\n    return uid',
+                "new_string": 'uid = req["account_id"]\nreturn uid',
+            },
+            tool_context,
+        )
+        assert result.is_error, f"expected reject, got: {result.output}"
+        assert "syntax" in (result.error or "").lower()
+        # File content must be unchanged
+        assert f.read_text(encoding="utf-8").count("user_id") == 1
+
+    @pytest.mark.asyncio
+    async def test_py_correctly_indented_replacement_allowed(
+        self, tool: FileEditTool, tool_context: ToolContext
+    ) -> None:
+        """A properly-indented replacement passes the gate."""
+        f = tool_context.cwd / "api.py"
+        f.write_text(
+            'def handle(req):\n    uid = req["user_id"]\n    return uid\n',
+            encoding="utf-8",
+        )
+        result = await tool.execute(
+            {
+                "file_path": "api.py",
+                "old_string": '    uid = req["user_id"]\n    return uid',
+                "new_string": '    uid = req["account_id"]\n    return uid',
+            },
+            tool_context,
+        )
+        assert not result.is_error, f"expected success, got: {result.error}"
+        assert 'req["account_id"]' in f.read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_py_already_broken_allows_edit(
+        self, tool: FileEditTool, tool_context: ToolContext
+    ) -> None:
+        """If file was already broken, gate doesn't block an edit (agent may be fixing it)."""
+        f = tool_context.cwd / "broken.py"
+        f.write_text("def foo(:\n    return 1\n", encoding="utf-8")  # pre-existing syntax error
+        result = await tool.execute(
+            {
+                "file_path": "broken.py",
+                "old_string": "def foo(:",
+                "new_string": "def foo():",
+            },
+            tool_context,
+        )
+        assert not result.is_error
+        # After the fix, file should parse
+        import ast
+
+        ast.parse(f.read_text(encoding="utf-8"))
+
+    @pytest.mark.asyncio
+    async def test_non_py_file_skips_gate(
+        self, tool: FileEditTool, tool_context: ToolContext
+    ) -> None:
+        """Non-.py files are not gated — an edit that would break Python syntax
+        in a .txt file should still go through."""
+        f = tool_context.cwd / "notes.txt"
+        f.write_text("def foo():\n    return 1\n", encoding="utf-8")
+        result = await tool.execute(
+            {
+                "file_path": "notes.txt",
+                "old_string": "return 1",
+                "new_string": "return 1 +",  # would be Python-invalid
+            },
+            tool_context,
+        )
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_json_broken_rejected(
+        self, tool: FileEditTool, tool_context: ToolContext
+    ) -> None:
+        f = tool_context.cwd / "config.json"
+        f.write_text('{"a": 1, "b": 2}\n', encoding="utf-8")
+        # Drop the closing quote on a key — breaks JSON
+        result = await tool.execute(
+            {
+                "file_path": "config.json",
+                "old_string": '"b": 2',
+                "new_string": '"b: 2',
+            },
+            tool_context,
+        )
+        assert result.is_error
+        assert "JSON" in (result.error or "")
+        # Content unchanged
+        assert f.read_text(encoding="utf-8") == '{"a": 1, "b": 2}\n'
+
+    @pytest.mark.asyncio
+    async def test_json_valid_allowed(
+        self, tool: FileEditTool, tool_context: ToolContext
+    ) -> None:
+        f = tool_context.cwd / "config.json"
+        f.write_text('{"a": 1}\n', encoding="utf-8")
+        result = await tool.execute(
+            {
+                "file_path": "config.json",
+                "old_string": '{"a": 1}',
+                "new_string": '{"a": 2}',
+            },
+            tool_context,
+        )
+        assert not result.is_error
+        assert '{"a": 2}' in f.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Two production bugs surfaced by a 4-task daily-use benchmark on Godspeed v2.10.0. Both fixed.

## Bug 1 — `file_edit` silently corrupts indentation on multi-line replace

**Symptom:** Benchmark T4 (user_id → account_id rename across 2 files). The fuzzy matcher found the right location but the agent's \`new_string\` dropped the leading 4-space indent. The file was written anyway, producing a syntactically-broken Python file that looked *mostly right* in a diff but raised \`IndentationError\` on import.

**Fix:** post-edit syntax gate in \`file_edit.py\`:
- \`.py\` / \`.pyi\` → \`ast.parse(new_content)\`
- \`.json\` → \`json.loads(new_content)\`

If parse fails AND the pre-edit content was valid, reject with a message asking the agent to include more context. Pre-broken files pass through so the agent can fix them.

**Re-tested T4 post-fix:** gate caught 4 successive bad edit attempts; agent pivoted to \`file_write\` with complete content; final output syntactically valid and correctly renamed. Zero silent corruption.

## Bug 2 — CLI \`UnicodeEncodeError\` on Windows cp1252

**Symptom:** \`cli.py:~965\` writes the final summary with \`sys.stdout.write\`. Default Windows console encoding is cp1252, which cannot encode \`→\` (U+2192), em-dashes, smart quotes. Agent completes real work; final write crashes; exit code nonzero, masking success.

**Fix:** \`_force_utf8_stdio()\` at module load rewraps \`sys.stdout\` and \`sys.stderr\` in a \`TextIOWrapper\` with \`encoding='utf-8'\`, \`errors='replace'\`. Idempotent — skips already-utf8 streams.

## Tests

New \`TestPostEditSyntaxGate\` class with 6 tests:
- \`py_indent_strip_rejected\` (core regression test from T4)
- \`py_correctly_indented_replacement_allowed\` (no false-positive)
- \`py_already_broken_allows_edit\` (lets agent fix pre-existing breakage)
- \`non_py_file_skips_gate\`
- \`json_broken_rejected\`
- \`json_valid_allowed\`

21/21 file_edit tests pass (6 new). 1873/1873 rest of suite unaffected (10 flaky system_optimizer tests pre-exist on this machine; confirmed identical behavior with/without these changes).

## Not in this PR

- Version bump (these are bug fixes, will go out in next release)
- Changelog entry (will add on main merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)