### PR TITLE
feat(agent,tui): mid-turn cancellation via cancel_event + Ctrl+C handler

### DIFF
--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from typing import Any
 
 from godspeed.agent.conversation import Conversation
-from godspeed.agent.result import AgentCancelled, AgentMetrics, ExitReason
+from godspeed.agent.result import AgentCancelledError, AgentMetrics, ExitReason
 from godspeed.llm.client import ChatResponse, LLMClient
 from godspeed.tools.base import ToolCall, ToolContext, ToolResult
 from godspeed.tools.registry import ToolRegistry
@@ -104,7 +104,7 @@ async def agent_loop(
         pause_event: Optional asyncio.Event for pause/resume. When cleared,
             the loop waits at the top of each iteration until set again.
         cancel_event: Optional asyncio.Event for mid-turn cancellation.
-            When set, the loop raises AgentCancelled at the next safe
+            When set, the loop raises AgentCancelledError at the next safe
             checkpoint — between streaming chunks, before an LLM call,
             or before dispatching tools — so the user can interrupt a
             long-running turn immediately instead of waiting for the
@@ -132,7 +132,7 @@ async def agent_loop(
 
     for iteration in range(iteration_limit):
         # Cancel check: before pause check, so a cancel delivered during a
-        # pause doesn't strand the loop. Raises AgentCancelled; caller unwinds.
+        # pause doesn't strand the loop. Raises AgentCancelledError; caller unwinds.
         _check_cancel(cancel_event)
 
         # Pause/resume: if pause_event exists and is cleared, wait for it
@@ -168,7 +168,7 @@ async def agent_loop(
                     messages=conversation.messages,
                     tools=tool_schemas if tool_schemas else None,
                 )
-        except AgentCancelled:
+        except AgentCancelledError:
             # Finalize with INTERRUPTED and unwind — don't wrap in LLM_ERROR.
             logger.info("Agent loop cancelled mid-turn at iteration=%d", iteration)
             if metrics is not None:
@@ -868,14 +868,14 @@ async def _compact_conversation(conversation: Conversation, llm_client: LLMClien
 
 
 def _check_cancel(cancel_event: asyncio.Event | None) -> None:
-    """Raise AgentCancelled if the event has been set.
+    """Raise AgentCancelledError if the event has been set.
 
     Called at checkpoint boundaries inside the agent loop: top of
     iteration, between streaming chunks, before tool dispatch. Cheap
     (single atomic is_set() read) — safe to sprinkle liberally.
     """
     if cancel_event is not None and cancel_event.is_set():
-        raise AgentCancelled("cancel_event set by caller")
+        raise AgentCancelledError("cancel_event set by caller")
 
 
 async def _streaming_call(
@@ -896,7 +896,7 @@ async def _streaming_call(
     main loop can await them instead of re-dispatching.
 
     When cancel_event is provided, the chunk loop checks it between each
-    yielded chunk and raises AgentCancelled — closing the underlying
+    yielded chunk and raises AgentCancelledError — closing the underlying
     litellm stream promptly (its aclose() fires on generator cleanup).
 
     Returns the final complete ChatResponse for conversation history.
@@ -919,7 +919,7 @@ async def _streaming_call(
             # Cancel checkpoint: between chunks. If the caller (TUI signal
             # handler, headless SIGINT) set cancel_event during the last
             # chunk's on_chunk callback — or any time before now — we raise
-            # AgentCancelled here. The generator cleanup path in `finally`
+            # AgentCancelledError here. The generator cleanup path in `finally`
             # closes the underlying HTTP stream.
             _check_cancel(cancel_event)
     finally:

--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -7,6 +7,7 @@ and Claude Code. The model decides when to stop. No framework overhead.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
@@ -15,7 +16,7 @@ from collections.abc import Callable
 from typing import Any
 
 from godspeed.agent.conversation import Conversation
-from godspeed.agent.result import AgentMetrics, ExitReason
+from godspeed.agent.result import AgentCancelled, AgentMetrics, ExitReason
 from godspeed.llm.client import ChatResponse, LLMClient
 from godspeed.tools.base import ToolCall, ToolContext, ToolResult
 from godspeed.tools.registry import ToolRegistry
@@ -66,6 +67,7 @@ async def agent_loop(
     on_assistant_chunk: OnChunk | None = None,
     max_iterations: int | None = None,
     pause_event: asyncio.Event | None = None,
+    cancel_event: asyncio.Event | None = None,
     hook_executor: Any | None = None,
     parallel_tool_calls: bool = True,
     skip_user_message: bool = False,
@@ -101,6 +103,12 @@ async def agent_loop(
         max_iterations: Override the default iteration limit (MAX_ITERATIONS).
         pause_event: Optional asyncio.Event for pause/resume. When cleared,
             the loop waits at the top of each iteration until set again.
+        cancel_event: Optional asyncio.Event for mid-turn cancellation.
+            When set, the loop raises AgentCancelled at the next safe
+            checkpoint — between streaming chunks, before an LLM call,
+            or before dispatching tools — so the user can interrupt a
+            long-running turn immediately instead of waiting for the
+            iteration boundary. The TUI binds Ctrl+C to set this event.
         parallel_tool_calls: Execute multiple tool calls concurrently when True
             (default). Falls back to sequential when False or for single calls.
 
@@ -123,11 +131,18 @@ async def agent_loop(
     speculative_cache: dict[str, asyncio.Task[ToolResult]] = {}
 
     for iteration in range(iteration_limit):
+        # Cancel check: before pause check, so a cancel delivered during a
+        # pause doesn't strand the loop. Raises AgentCancelled; caller unwinds.
+        _check_cancel(cancel_event)
+
         # Pause/resume: if pause_event exists and is cleared, wait for it
         if pause_event is not None and not pause_event.is_set():
             logger.info("Agent loop paused at iteration=%d", iteration)
             await pause_event.wait()
             logger.info("Agent loop resumed at iteration=%d", iteration)
+
+        # Cancel check #2: may have been set while we were paused.
+        _check_cancel(cancel_event)
 
         logger.debug("Agent loop iteration=%d tokens=%d", iteration, conversation.token_count)
 
@@ -146,12 +161,20 @@ async def agent_loop(
                     tool_registry=tool_registry,
                     tool_context=tool_context,
                     speculative_cache=speculative_cache,
+                    cancel_event=cancel_event,
                 )
             else:
                 response = await llm_client.chat(
                     messages=conversation.messages,
                     tools=tool_schemas if tool_schemas else None,
                 )
+        except AgentCancelled:
+            # Finalize with INTERRUPTED and unwind — don't wrap in LLM_ERROR.
+            logger.info("Agent loop cancelled mid-turn at iteration=%d", iteration)
+            if metrics is not None:
+                metrics.iterations_used = iteration
+                metrics.finalize(ExitReason.INTERRUPTED)
+            raise
         except Exception as exc:
             # Import here to avoid circular import at module level
             from godspeed.llm.client import BudgetExceededError
@@ -844,6 +867,17 @@ async def _compact_conversation(conversation: Conversation, llm_client: LLMClien
         # Don't crash — just warn and continue with full history
 
 
+def _check_cancel(cancel_event: asyncio.Event | None) -> None:
+    """Raise AgentCancelled if the event has been set.
+
+    Called at checkpoint boundaries inside the agent loop: top of
+    iteration, between streaming chunks, before tool dispatch. Cheap
+    (single atomic is_set() read) — safe to sprinkle liberally.
+    """
+    if cancel_event is not None and cancel_event.is_set():
+        raise AgentCancelled("cancel_event set by caller")
+
+
 async def _streaming_call(
     llm_client: LLMClient,
     messages: list[dict[str, Any]],
@@ -852,6 +886,7 @@ async def _streaming_call(
     tool_registry: ToolRegistry | None = None,
     tool_context: ToolContext | None = None,
     speculative_cache: dict[str, asyncio.Task[ToolResult]] | None = None,
+    cancel_event: asyncio.Event | None = None,
 ) -> ChatResponse:
     """Make a streaming LLM call, invoking on_chunk for each text delta.
 
@@ -860,17 +895,40 @@ async def _streaming_call(
     main loop processes them. Results are stored in speculative_cache so the
     main loop can await them instead of re-dispatching.
 
+    When cancel_event is provided, the chunk loop checks it between each
+    yielded chunk and raises AgentCancelled — closing the underlying
+    litellm stream promptly (its aclose() fires on generator cleanup).
+
     Returns the final complete ChatResponse for conversation history.
     """
     final_response: ChatResponse | None = None
 
-    async for chunk in llm_client.stream_chat(messages=messages, tools=tools):
-        if chunk.finish_reason is None and chunk.content:
-            # Intermediate chunk — stream text to caller
-            on_chunk(chunk.content)
-        elif chunk.finish_reason is not None:
-            # Final aggregated response
-            final_response = chunk
+    stream = llm_client.stream_chat(messages=messages, tools=tools)
+    try:
+        async for chunk in stream:
+            if chunk.finish_reason is None and chunk.content:
+                # Intermediate chunk — stream text to caller first, THEN
+                # check cancel. This way the user sees the text the model
+                # already produced before we unwind — a cleaner UX than
+                # cutting off mid-word.
+                on_chunk(chunk.content)
+            elif chunk.finish_reason is not None:
+                # Final aggregated response
+                final_response = chunk
+
+            # Cancel checkpoint: between chunks. If the caller (TUI signal
+            # handler, headless SIGINT) set cancel_event during the last
+            # chunk's on_chunk callback — or any time before now — we raise
+            # AgentCancelled here. The generator cleanup path in `finally`
+            # closes the underlying HTTP stream.
+            _check_cancel(cancel_event)
+    finally:
+        # Ensure the underlying async generator is closed on cancel OR on
+        # any exception. aclose() is idempotent and cheap.
+        aclose = getattr(stream, "aclose", None)
+        if aclose is not None:
+            with contextlib.suppress(Exception):
+                await aclose()
 
     if final_response is None:
         # Stream ended without a finish_reason — shouldn't happen but be safe

--- a/src/godspeed/agent/result.py
+++ b/src/godspeed/agent/result.py
@@ -58,11 +58,11 @@ EXIT_REASON_TO_CODE: dict[ExitReason, ExitCode] = {
 }
 
 
-class AgentCancelled(Exception):
+class AgentCancelledError(Exception):
     """Raised inside the agent loop when an external cancel_event is set.
 
     Distinct from KeyboardInterrupt so that:
-      - Callers can catch AgentCancelled specifically without catching
+      - Callers can catch AgentCancelledError specifically without catching
         unrelated KeyboardInterrupts (prompt-toolkit, stdin reads, etc).
       - The loop can unwind cleanly: stop the current streaming call,
         record partial assistant text, finalize metrics with

--- a/src/godspeed/agent/result.py
+++ b/src/godspeed/agent/result.py
@@ -58,6 +58,20 @@ EXIT_REASON_TO_CODE: dict[ExitReason, ExitCode] = {
 }
 
 
+class AgentCancelled(Exception):
+    """Raised inside the agent loop when an external cancel_event is set.
+
+    Distinct from KeyboardInterrupt so that:
+      - Callers can catch AgentCancelled specifically without catching
+        unrelated KeyboardInterrupts (prompt-toolkit, stdin reads, etc).
+      - The loop can unwind cleanly: stop the current streaming call,
+        record partial assistant text, finalize metrics with
+        ExitReason.INTERRUPTED, and return.
+      - The TUI's "first Ctrl+C cancels the turn; second Ctrl+C exits"
+        UX works without the signal racing with prompt-toolkit reads.
+    """
+
+
 @dataclasses.dataclass(slots=True)
 class ToolCallRecord:
     """One tool invocation, as seen by the loop."""

--- a/src/godspeed/tui/app.py
+++ b/src/godspeed/tui/app.py
@@ -14,7 +14,7 @@ from prompt_toolkit.keys import Keys
 
 from godspeed.agent.conversation import Conversation
 from godspeed.agent.loop import agent_loop
-from godspeed.agent.result import AgentCancelled
+from godspeed.agent.result import AgentCancelledError
 from godspeed.audit.trail import AuditTrail
 from godspeed.llm.client import LLMClient
 from godspeed.security.permissions import ALLOW, ASK, PermissionDecision, PermissionEngine
@@ -283,7 +283,7 @@ class TUIApp:
 
             # Install a SIGINT handler on the running loop. First Ctrl+C
             # sets cancel_event (the loop's next checkpoint raises
-            # AgentCancelled and unwinds cleanly). Second Ctrl+C within 1s
+            # AgentCancelledError and unwinds cleanly). Second Ctrl+C within 1s
             # raises KeyboardInterrupt for a hard exit — matches the
             # Jupyter "press twice" pattern most developers expect.
             self._last_sigint_monotonic = 0.0
@@ -309,7 +309,7 @@ class TUIApp:
             except (NotImplementedError, RuntimeError):
                 # Windows: asyncio.ProactorEventLoop does not support
                 # add_signal_handler. Fall back to the default KeyboardInterrupt
-                # path and the AgentCancelled will still fire if _cancel_event
+                # path and the AgentCancelledError will still fire if _cancel_event
                 # is set via another mechanism (e.g. /cancel slash command).
                 pass
 
@@ -336,7 +336,7 @@ class TUIApp:
                     on_thinking=_on_thinking,
                 )
                 console.print()  # End streaming output with newline
-            except AgentCancelled:
+            except AgentCancelledError:
                 console.print(f"\n  [{DIM}]Agent cancelled. Send another prompt or /quit.[/{DIM}]")
             except KeyboardInterrupt:
                 # Hard interrupt: user pressed Ctrl+C twice (or the loop-level

--- a/src/godspeed/tui/app.py
+++ b/src/godspeed/tui/app.py
@@ -14,6 +14,7 @@ from prompt_toolkit.keys import Keys
 
 from godspeed.agent.conversation import Conversation
 from godspeed.agent.loop import agent_loop
+from godspeed.agent.result import AgentCancelled
 from godspeed.audit.trail import AuditTrail
 from godspeed.llm.client import LLMClient
 from godspeed.security.permissions import ALLOW, ASK, PermissionDecision, PermissionEngine
@@ -94,6 +95,11 @@ class TUIApp:
         # Pause/resume event for human-in-the-loop
         self._pause_event = asyncio.Event()
         self._pause_event.set()  # Start in running state
+
+        # Mid-turn cancel: set by Ctrl+C while the agent is running. Cleared
+        # each time a new turn starts. Distinct from _pause_event — pause
+        # stalls at iteration boundary, cancel unwinds immediately.
+        self._cancel_event = asyncio.Event()
 
         self._commands = Commands(
             conversation=conversation,
@@ -272,6 +278,41 @@ class TUIApp:
                 format_thinking(text)
                 _s.start()
 
+            # Fresh cancel state per turn
+            self._cancel_event.clear()
+
+            # Install a SIGINT handler on the running loop. First Ctrl+C
+            # sets cancel_event (the loop's next checkpoint raises
+            # AgentCancelled and unwinds cleanly). Second Ctrl+C within 1s
+            # raises KeyboardInterrupt for a hard exit — matches the
+            # Jupyter "press twice" pattern most developers expect.
+            self._last_sigint_monotonic = 0.0
+
+            def _on_sigint(self_ref: TUIApp = self) -> None:
+                now = time.monotonic()
+                if (
+                    self_ref._cancel_event.is_set()
+                    and (now - self_ref._last_sigint_monotonic) < 1.0
+                ):
+                    # Second press within 1s → escalate to hard interrupt.
+                    raise KeyboardInterrupt
+                self_ref._last_sigint_monotonic = now
+                self_ref._cancel_event.set()
+
+            running_loop = asyncio.get_running_loop()
+            _sigint_installed = False
+            try:
+                import signal as _signal
+
+                running_loop.add_signal_handler(_signal.SIGINT, _on_sigint)
+                _sigint_installed = True
+            except (NotImplementedError, RuntimeError):
+                # Windows: asyncio.ProactorEventLoop does not support
+                # add_signal_handler. Fall back to the default KeyboardInterrupt
+                # path and the AgentCancelled will still fire if _cancel_event
+                # is set via another mechanism (e.g. /cancel slash command).
+                pass
+
             try:
                 spinner.start()
                 await agent_loop(
@@ -287,6 +328,7 @@ class TUIApp:
                     on_assistant_chunk=spinner.wrap(_on_assistant_chunk),
                     max_iterations=self._commands.max_iterations,
                     pause_event=self._pause_event,
+                    cancel_event=self._cancel_event,
                     hook_executor=self._hook_executor,
                     skip_user_message=not effective_input,
                     on_parallel_start=_track_parallel_start,
@@ -294,13 +336,28 @@ class TUIApp:
                     on_thinking=_on_thinking,
                 )
                 console.print()  # End streaming output with newline
+            except AgentCancelled:
+                console.print(f"\n  [{DIM}]Agent cancelled. Send another prompt or /quit.[/{DIM}]")
             except KeyboardInterrupt:
+                # Hard interrupt: user pressed Ctrl+C twice (or the loop-level
+                # signal handler wasn't installed on this platform). Treat
+                # same as cancel for display, but surface the distinct reason.
                 console.print(f"\n  [{DIM}]Agent interrupted.[/{DIM}]")
             except Exception as exc:
                 logger.error("Agent loop error: %s", exc, exc_info=True)
                 format_error(f"Agent error: {exc}")
             finally:
                 spinner.stop()
+                if _sigint_installed:
+                    # Restore default SIGINT handling while we're waiting for
+                    # the next prompt — otherwise a Ctrl+C at the prompt would
+                    # silently set an unused cancel_event and swallow the key.
+                    try:
+                        import signal as _signal
+
+                        running_loop.remove_signal_handler(_signal.SIGINT)
+                    except (NotImplementedError, RuntimeError, ValueError):
+                        pass
 
         # Session summary on exit
         duration = time.monotonic() - start_time

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -685,15 +685,15 @@ class TestCancelEvent:
     """Mid-turn cancellation: the agent loop must unwind on cancel_event.
 
     Exercises the cancel checkpoints at (a) top of iteration,
-    (b) between streaming chunks, and (c) the AgentCancelled unwind path.
+    (b) between streaming chunks, and (c) the AgentCancelledError unwind path.
     """
 
     @pytest.mark.asyncio
     async def test_cancel_before_first_iteration(self) -> None:
-        """cancel_event set before loop start → AgentCancelled raised immediately."""
+        """cancel_event set before loop start → AgentCancelledError raised immediately."""
         import asyncio
 
-        from godspeed.agent.result import AgentCancelled
+        from godspeed.agent.result import AgentCancelledError
 
         cancel = asyncio.Event()
         cancel.set()
@@ -704,7 +704,7 @@ class TestCancelEvent:
         conv = Conversation(system_prompt="x")
         reg = ToolRegistry()
 
-        with pytest.raises(AgentCancelled):
+        with pytest.raises(AgentCancelledError):
             await agent_loop(
                 user_input="hi",
                 conversation=conv,
@@ -721,7 +721,7 @@ class TestCancelEvent:
         """cancel_event set mid-stream → chunk loop stops; stream.aclose() called."""
         import asyncio
 
-        from godspeed.agent.result import AgentCancelled
+        from godspeed.agent.result import AgentCancelledError
 
         cancel = asyncio.Event()
 
@@ -763,7 +763,7 @@ class TestCancelEvent:
         conv = Conversation(system_prompt="x")
         reg = ToolRegistry()
 
-        with pytest.raises(AgentCancelled):
+        with pytest.raises(AgentCancelledError):
             await agent_loop(
                 user_input="hi",
                 conversation=conv,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -679,3 +679,143 @@ class TestTokenCounter:
 
         count = count_tokens("")
         assert count == 0
+
+
+class TestCancelEvent:
+    """Mid-turn cancellation: the agent loop must unwind on cancel_event.
+
+    Exercises the cancel checkpoints at (a) top of iteration,
+    (b) between streaming chunks, and (c) the AgentCancelled unwind path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancel_before_first_iteration(self) -> None:
+        """cancel_event set before loop start → AgentCancelled raised immediately."""
+        import asyncio
+
+        from godspeed.agent.result import AgentCancelled
+
+        cancel = asyncio.Event()
+        cancel.set()
+
+        llm = AsyncMock(spec=LLMClient)
+        llm.chat = AsyncMock()  # must never be called
+
+        conv = Conversation(system_prompt="x")
+        reg = ToolRegistry()
+
+        with pytest.raises(AgentCancelled):
+            await agent_loop(
+                user_input="hi",
+                conversation=conv,
+                llm_client=llm,
+                tool_registry=reg,
+                tool_context=None,  # type: ignore[arg-type]
+                cancel_event=cancel,
+            )
+
+        llm.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_between_streaming_chunks(self) -> None:
+        """cancel_event set mid-stream → chunk loop stops; stream.aclose() called."""
+        import asyncio
+
+        from godspeed.agent.result import AgentCancelled
+
+        cancel = asyncio.Event()
+
+        aclose_calls: list[int] = []
+
+        class FakeStream:
+            def __init__(self, chunks: list[ChatResponse]) -> None:
+                self._chunks = list(chunks)
+
+            def __aiter__(self) -> FakeStream:
+                return self
+
+            async def __anext__(self) -> ChatResponse:
+                if not self._chunks:
+                    raise StopAsyncIteration
+                chunk = self._chunks.pop(0)
+                # After the first chunk is delivered, set cancel
+                if chunk.content == "first":
+                    cancel.set()
+                return chunk
+
+            async def aclose(self) -> None:
+                aclose_calls.append(1)
+
+        chunks = [
+            ChatResponse(content="first", tool_calls=[], finish_reason=None),
+            ChatResponse(content="second", tool_calls=[], finish_reason=None),
+            ChatResponse(content="", tool_calls=[], finish_reason="stop"),
+        ]
+
+        llm = AsyncMock(spec=LLMClient)
+        llm.stream_chat = lambda **_: FakeStream(chunks)
+
+        got_chunks: list[str] = []
+
+        def on_chunk(text: str) -> None:
+            got_chunks.append(text)
+
+        conv = Conversation(system_prompt="x")
+        reg = ToolRegistry()
+
+        with pytest.raises(AgentCancelled):
+            await agent_loop(
+                user_input="hi",
+                conversation=conv,
+                llm_client=llm,
+                tool_registry=reg,
+                tool_context=None,  # type: ignore[arg-type]
+                on_assistant_chunk=on_chunk,
+                cancel_event=cancel,
+            )
+
+        # First chunk was delivered (before cancel fired); second chunk was
+        # never processed (cancel checkpoint raises before on_chunk runs).
+        assert got_chunks == ["first"]
+        # aclose was called on the underlying stream.
+        assert aclose_calls == [1]
+
+    @pytest.mark.asyncio
+    async def test_cancel_event_unset_does_not_cancel(self) -> None:
+        """Event object provided but never set → loop runs normally."""
+        import asyncio
+
+        cancel = asyncio.Event()  # never set
+        llm = AsyncMock(spec=LLMClient)
+        llm.chat = AsyncMock(return_value=_make_text_response("hello"))
+
+        conv = Conversation(system_prompt="x")
+        reg = ToolRegistry()
+
+        result = await agent_loop(
+            user_input="hi",
+            conversation=conv,
+            llm_client=llm,
+            tool_registry=reg,
+            tool_context=None,  # type: ignore[arg-type]
+            cancel_event=cancel,
+        )
+        assert result == "hello"
+
+    @pytest.mark.asyncio
+    async def test_cancel_none_preserves_existing_behavior(self) -> None:
+        """cancel_event=None (default) must not affect baseline behavior."""
+        llm = AsyncMock(spec=LLMClient)
+        llm.chat = AsyncMock(return_value=_make_text_response("hello"))
+
+        conv = Conversation(system_prompt="x")
+        reg = ToolRegistry()
+
+        result = await agent_loop(
+            user_input="hi",
+            conversation=conv,
+            llm_client=llm,
+            tool_registry=reg,
+            tool_context=None,  # type: ignore[arg-type]
+        )
+        assert result == "hello"


### PR DESCRIPTION
## Summary

**Phase 1.1 of the v3.3.0 world-class UX push.** First biggest-ROI daily-use pain from the production audit: the agent's streaming tokens would print but Ctrl+C couldn't interrupt mid-response. \`pause_event\` only stopped at the iteration boundary — so you had to wait for the entire turn to finish, even if the model was obviously off-track.

This PR adds a proper mid-turn cancel path distinct from pause.

## Changes

### \`agent.result.AgentCancelled\` (new exception)
Distinct from KeyboardInterrupt so callers can handle cancel vs stdin-read vs tool-level Ctrl+C separately. Metrics finalize with \`ExitReason.INTERRUPTED\`.

### \`agent.loop.agent_loop(cancel_event=...)\`
New parameter. Loop checks the event at THREE checkpoints per iteration:
1. Top of loop (before the old pause check)
2. Right after pause releases (caller may have cancelled while paused)
3. Between streaming chunks inside \`_streaming_call\`

### \`_streaming_call\` — explicit stream lifecycle
On cancel OR any exception, the underlying async generator's \`aclose()\` fires in the finally block — closes the httpx stream promptly instead of waiting for garbage collection. Cancel check fires AFTER \`on_chunk\` so the user sees the partial text the model already generated (cleaner UX than cutting off mid-word).

### \`tui.app.TUIApp._cancel_event\` + SIGINT handler
- Fresh event per turn, cleared at start.
- On Linux/macOS, installs an asyncio signal handler via \`add_signal_handler(SIGINT, ...)\`. First Ctrl+C sets \`cancel_event\`; second within 1s escalates to \`KeyboardInterrupt\` (Jupyter-style "press twice" pattern).
- On Windows, \`ProactorEventLoop\` doesn't support \`add_signal_handler\` — degrades gracefully to the existing \`KeyboardInterrupt\` path. The cancel_event remains addressable via a future \`/cancel\` slash command.
- Handler is uninstalled in the turn's \`finally\` so Ctrl+C at the prompt still behaves like prompt-toolkit expects.

## Tests

4 new tests in \`TestCancelEvent\`:
- \`test_cancel_before_first_iteration\` — event set before start → \`AgentCancelled\` raised immediately, LLM never called
- \`test_cancel_between_streaming_chunks\` — verifies \`aclose()\` is invoked on the underlying stream, first chunk delivered before cancel fires
- \`test_cancel_event_unset_does_not_cancel\` — baseline
- \`test_cancel_none_preserves_existing_behavior\` — \`cancel_event=None\` unchanged

**40/40 \`test_agent_loop.py\` pass. 1861/1861 full suite pass** (excluding 10 pre-existing environmental \`system_optimizer\` flakies + 1 psutil-dependent shell test, both unrelated — confirmed identical behavior with/without this change).

## Files changed

- \`src/godspeed/agent/result.py\` (+14 lines) — \`AgentCancelled\`
- \`src/godspeed/agent/loop.py\` (+63 lines) — param + three checkpoints + \`_streaming_call\` lifecycle
- \`src/godspeed/tui/app.py\` (+57 lines) — SIGINT handler + escalate-on-double-press
- \`tests/test_agent_loop.py\` (+140 lines) — \`TestCancelEvent\` class

## Not in this PR

Phase 1.2+ of the world-class push: diff approve-before-write gate, cost/token HUD, animated README demo, VS Code extension, task-aware routing. Each lands as a separate focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)