### PR TITLE
feat(tools,tui): diff approve-before-write gate (v3.3.0 Phase 1.2)

### DIFF
--- a/src/godspeed/tools/base.py
+++ b/src/godspeed/tools/base.py
@@ -120,6 +120,40 @@ class LLMInvoker(Protocol):
         ...
 
 
+@runtime_checkable
+class DiffReviewer(Protocol):
+    """Optional hook that lets a human approve / reject a concrete diff
+    BEFORE a file is written.
+
+    Permission (``PermissionEvaluator``) answers the question "is this
+    tool allowed to run at all?" It fires once per tool invocation.
+
+    ``DiffReviewer`` answers the question "should THIS specific change be
+    applied?" It fires once per pending write, with the actual before /
+    after content in hand. Two independent axes of consent.
+
+    When ``ToolContext.diff_reviewer`` is ``None``, diff-producing tools
+    write without review (headless / CI default). When present, the TUI
+    (or a test double) implements the Protocol to prompt the user.
+    """
+
+    async def review(
+        self,
+        *,
+        tool_name: str,
+        path: str,
+        before: str,
+        after: str,
+    ) -> str:
+        """Return ``"accept"`` to apply the change or ``"reject"`` to skip it.
+
+        Future return values (``"edit"``, etc) are reserved; implementations
+        should treat anything other than ``"accept"`` as a reject for forward
+        compatibility.
+        """
+        ...
+
+
 class ToolContext(BaseModel):
     """Execution context passed to every tool."""
 
@@ -128,6 +162,7 @@ class ToolContext(BaseModel):
     permissions: PermissionEvaluator | None = None
     audit: AuditRecorder | None = None
     llm_client: LLMInvoker | None = None
+    diff_reviewer: DiffReviewer | None = None
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -139,6 +174,12 @@ class Tool(abc.ABC):
     The same protocol is used for built-in tools, MCP tools, and future
     computer-use tools.
     """
+
+    #: When True, the tool writes a file whose before/after content should be
+    #: gated through ``ToolContext.diff_reviewer`` (if one is configured)
+    #: before the write actually happens. Default False — read-only tools and
+    #: shell-like tools opt out. File edit / write / diff-apply tools opt in.
+    produces_diff: bool = False
 
     @property
     @abc.abstractmethod

--- a/src/godspeed/tools/diff_apply.py
+++ b/src/godspeed/tools/diff_apply.py
@@ -285,6 +285,8 @@ class DiffApplyTool(Tool):
     when exact position doesn't match.
     """
 
+    produces_diff = True
+
     @property
     def name(self) -> str:
         return "diff_apply"
@@ -334,6 +336,31 @@ class DiffApplyTool(Tool):
 
         if not file_diffs:
             return ToolResult.failure("No file diffs found in the provided diff content")
+
+        # Diff review gate: when a reviewer is attached (typically the TUI)
+        # and this is not a dry_run, let the human accept or reject the whole
+        # multi-file diff before anything is written. One review call covers
+        # the whole operation — diff_apply is treated as atomic from the
+        # user's perspective. Dry runs skip the gate since nothing is written.
+        if context.diff_reviewer is not None and not dry_run:
+            path_summary = ", ".join(fd.new_path for fd in file_diffs[:5])
+            if len(file_diffs) > 5:
+                path_summary += f", ... ({len(file_diffs) - 5} more)"
+            decision = await context.diff_reviewer.review(
+                tool_name=self.name,
+                path=path_summary,
+                before="",  # raw diff IS the before/after delta — shown verbatim
+                after=diff_text,
+            )
+            if decision != "accept":
+                logger.info(
+                    "diff_apply rejected by diff_reviewer: files=%d decision=%s",
+                    len(file_diffs),
+                    decision,
+                )
+                return ToolResult.failure(
+                    f"Diff rejected by reviewer ({len(file_diffs)} files) — no changes written."
+                )
 
         total_hunks = 0
         total_fuzzy = 0

--- a/src/godspeed/tools/file_edit.py
+++ b/src/godspeed/tools/file_edit.py
@@ -77,6 +77,8 @@ class FileEditTool(Tool):
     to whitespace drift.
     """
 
+    produces_diff = True
+
     @property
     def name(self) -> str:
         return "file_edit"
@@ -205,6 +207,27 @@ class FileEditTool(Tool):
                 syntax_err,
             )
             return ToolResult.failure(syntax_err)
+
+        # Diff review gate: when a diff_reviewer is attached to the context
+        # (typically the TUI), let the human accept or reject this specific
+        # change before it hits disk. Headless / CI: diff_reviewer is None →
+        # auto-accept, preserving backward-compatible behavior.
+        if context.diff_reviewer is not None:
+            decision = await context.diff_reviewer.review(
+                tool_name=self.name,
+                path=file_path_str,
+                before=content,
+                after=new_content,
+            )
+            if decision != "accept":
+                logger.info(
+                    "Edit rejected by diff_reviewer: path=%s decision=%s",
+                    file_path_str,
+                    decision,
+                )
+                return ToolResult.failure(
+                    f"Edit rejected by reviewer for {file_path_str} — no changes written."
+                )
 
         resolved.write_text(new_content, encoding="utf-8")
         logger.info(

--- a/src/godspeed/tools/file_write.py
+++ b/src/godspeed/tools/file_write.py
@@ -18,6 +18,8 @@ class FileWriteTool(Tool):
     Use file_write only for creating new files or complete rewrites.
     """
 
+    produces_diff = True
+
     @property
     def name(self) -> str:
         return "file_write"
@@ -65,6 +67,31 @@ class FileWriteTool(Tool):
             resolved = resolve_tool_path(file_path_str, context.cwd)
         except ValueError as exc:
             return ToolResult.failure(str(exc))
+
+        # Diff review gate: when a diff_reviewer is attached to the context
+        # (typically the TUI), let the human accept or reject this specific
+        # write before it hits disk. Read current content for the diff if the
+        # file already exists; for new files, the "before" is empty string.
+        if context.diff_reviewer is not None:
+            try:
+                before = resolved.read_text(encoding="utf-8") if resolved.exists() else ""
+            except UnicodeDecodeError:
+                before = "<binary>"
+            decision = await context.diff_reviewer.review(
+                tool_name=self.name,
+                path=file_path_str,
+                before=before,
+                after=content,
+            )
+            if decision != "accept":
+                logger.info(
+                    "Write rejected by diff_reviewer: path=%s decision=%s",
+                    file_path_str,
+                    decision,
+                )
+                return ToolResult.failure(
+                    f"Write rejected by reviewer for {file_path_str} — no changes written."
+                )
 
         try:
             # Create parent directories

--- a/src/godspeed/tui/app.py
+++ b/src/godspeed/tui/app.py
@@ -25,6 +25,7 @@ from godspeed.tui.completions import GodspeedCompleter
 from godspeed.tui.output import (
     console,
     format_assistant_text,
+    format_diff_review_prompt,
     format_error,
     format_parallel_results,
     format_parallel_tool_calls,
@@ -140,6 +141,13 @@ class TUIApp:
                 permission_engine,
                 approval_tracker=self._approval_tracker,
             )
+
+        # Diff-review gate: diff-producing tools (file_edit, file_write,
+        # diff_apply) consult this reviewer just before writing. TUI only —
+        # headless/CI path leaves diff_reviewer None so writes proceed as
+        # before.
+        self._diff_reviewer = _InteractiveDiffReviewer()
+        tool_context.diff_reviewer = self._diff_reviewer
 
     async def run(self) -> None:
         """Run the main TUI loop."""
@@ -545,3 +553,48 @@ class _InteractivePermissionProxy:
                     f"  [{WARNING}]Could not persist rule. Added for this session only.[/{WARNING}]"
                 )
                 self._engine.grant_session_permission(pattern)
+
+
+class _InteractiveDiffReviewer:
+    """Implements `ToolContext.DiffReviewer` by prompting the human via the TUI.
+
+    Distinct from `_InteractivePermissionProxy` — permission answers
+    "should this tool run?" once; the reviewer answers "should THIS
+    specific diff be applied?" per pending write.
+
+    Current decision vocabulary: `"accept"` / `"reject"`. Future:
+    `"edit"` (open the patch in $EDITOR before apply). Unknown values
+    degrade to reject by the calling tool.
+    """
+
+    def __init__(self) -> None:
+        # Session-scoped "accept all" bypass. Set by the user answering "a".
+        self._always_accept = False
+
+    async def review(
+        self,
+        *,
+        tool_name: str,
+        path: str,
+        before: str,
+        after: str,
+    ) -> str:
+        if self._always_accept:
+            return "accept"
+
+        # Render the diff (Rich `console.input` is sync; run in a thread so
+        # we don't block the asyncio loop while waiting for keystrokes).
+        format_diff_review_prompt(tool_name, path, before, after)
+        try:
+            answer = await asyncio.to_thread(
+                lambda: console.input(f"[{BOLD_WARNING}]  > [/{BOLD_WARNING}]").strip().lower()
+            )
+        except (KeyboardInterrupt, EOFError):
+            answer = "n"
+
+        if answer in ("y", "yes", ""):
+            return "accept"
+        if answer in ("a", "always"):
+            self._always_accept = True
+            return "accept"
+        return "reject"

--- a/src/godspeed/tui/output.py
+++ b/src/godspeed/tui/output.py
@@ -425,6 +425,61 @@ def format_permission_denied(tool_name: str, reason: str) -> None:
     console.print(f"  {marker} {styled('Blocked:', BOLD_ERROR)} {tool_name} -- {reason}")
 
 
+def format_diff_review_prompt(
+    tool_name: str,
+    path: str,
+    before: str,
+    after: str,
+) -> None:
+    """Render a pending-edit diff and prompt text.
+
+    Called by the TUI's DiffReviewer just before the write. Distinct from
+    ``format_permission_prompt``: that one asks whether the tool should run
+    at all; this one asks whether THIS specific diff should be applied.
+
+    For ``diff_apply`` the ``after`` is the raw unified diff (``before`` is
+    empty) — we render it verbatim via the ``diff`` syntax lexer so the
+    user sees exactly what will be applied.
+    """
+    import difflib
+
+    console.print()
+    marker = styled(MARKER_WARNING, WARNING)
+    header = styled("Review proposed edit", BOLD_WARNING)
+    console.print(f"  {marker}  {header}")
+    console.print()
+    console.print(f"    {styled(tool_name, BOLD_PRIMARY)}  {path}")
+
+    # For diff_apply: "before" is empty, "after" is the raw unified diff text.
+    if (not before and after.startswith("diff --git")) or after.startswith("---"):
+        diff_text = after
+    else:
+        before_lines = before.splitlines()
+        after_lines = after.splitlines()
+        added = sum(1 for line in difflib.ndiff(before_lines, after_lines) if line.startswith("+ "))
+        removed = sum(
+            1 for line in difflib.ndiff(before_lines, after_lines) if line.startswith("- ")
+        )
+        console.print(f"    {styled(f'+{added} -{removed} lines', DIM)}")
+        diff_lines = list(
+            difflib.unified_diff(
+                before_lines,
+                after_lines,
+                fromfile="before",
+                tofile="after",
+                lineterm="",
+                n=3,
+            )
+        )
+        diff_content = diff_lines[2:] if len(diff_lines) > 2 else diff_lines
+        diff_text = "\n".join(diff_content[:80])
+        if len(diff_content) > 80:
+            diff_text += f"\n... ({len(diff_content) - 80} more lines)"
+
+    console.print(Syntax(diff_text, "diff", theme=SYNTAX_THEME, word_wrap=True))
+    console.print(f"    {styled('Apply?', WARNING)} {styled(f'(y)es {SEPARATOR_DOT} (n)o', DIM)}")
+
+
 def format_stats(
     input_tokens: int,
     output_tokens: int,

--- a/tests/test_tools/test_file_edit.py
+++ b/tests/test_tools/test_file_edit.py
@@ -324,3 +324,109 @@ class TestPostEditSyntaxGate:
         )
         assert not result.is_error
         assert '{"a": 2}' in f.read_text(encoding="utf-8")
+
+
+class TestDiffReviewerGate:
+    """Diff-review gate: an attached `diff_reviewer` can accept or reject
+    a proposed edit BEFORE it hits disk.
+
+    Uses a test double that records each call and returns a scripted
+    decision. The production implementation lives in the TUI.
+    """
+
+    @pytest.mark.asyncio
+    async def test_file_edit_declares_produces_diff(self, tool: FileEditTool) -> None:
+        """Class attribute must be True so the loop knows to gate this tool."""
+        assert FileEditTool.produces_diff is True
+
+    @pytest.mark.asyncio
+    async def test_accept_allows_write(self, tool: FileEditTool, tool_context: ToolContext) -> None:
+        from godspeed.tools.base import DiffReviewer
+
+        seen: list[dict[str, str]] = []
+
+        class AcceptingReviewer(DiffReviewer):
+            async def review(self, *, tool_name: str, path: str, before: str, after: str) -> str:
+                seen.append(
+                    {
+                        "tool_name": tool_name,
+                        "path": path,
+                        "before": before,
+                        "after": after,
+                    }
+                )
+                return "accept"
+
+        f = tool_context.cwd / "ok.py"
+        f.write_text("x = 1\n", encoding="utf-8")
+        tool_context.diff_reviewer = AcceptingReviewer()
+
+        result = await tool.execute(
+            {"file_path": "ok.py", "old_string": "x = 1", "new_string": "x = 2"},
+            tool_context,
+        )
+        assert not result.is_error
+        assert f.read_text(encoding="utf-8") == "x = 2\n"
+        assert len(seen) == 1
+        assert seen[0]["tool_name"] == "file_edit"
+        assert seen[0]["before"].strip() == "x = 1"
+        assert seen[0]["after"].strip() == "x = 2"
+
+    @pytest.mark.asyncio
+    async def test_reject_blocks_write(self, tool: FileEditTool, tool_context: ToolContext) -> None:
+        from godspeed.tools.base import DiffReviewer
+
+        class RejectingReviewer(DiffReviewer):
+            async def review(self, *, tool_name: str, path: str, before: str, after: str) -> str:
+                return "reject"
+
+        f = tool_context.cwd / "ok.py"
+        original = "x = 1\n"
+        f.write_text(original, encoding="utf-8")
+        tool_context.diff_reviewer = RejectingReviewer()
+
+        result = await tool.execute(
+            {"file_path": "ok.py", "old_string": "x = 1", "new_string": "x = 2"},
+            tool_context,
+        )
+        assert result.is_error
+        assert "rejected by reviewer" in (result.error or "").lower()
+        assert f.read_text(encoding="utf-8") == original
+
+    @pytest.mark.asyncio
+    async def test_no_reviewer_preserves_baseline(
+        self, tool: FileEditTool, tool_context: ToolContext
+    ) -> None:
+        """diff_reviewer=None → headless / CI default → write proceeds."""
+        f = tool_context.cwd / "ok.py"
+        f.write_text("x = 1\n", encoding="utf-8")
+        assert tool_context.diff_reviewer is None
+
+        result = await tool.execute(
+            {"file_path": "ok.py", "old_string": "x = 1", "new_string": "x = 2"},
+            tool_context,
+        )
+        assert not result.is_error
+        assert f.read_text(encoding="utf-8") == "x = 2\n"
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_decision_treated_as_reject(
+        self, tool: FileEditTool, tool_context: ToolContext
+    ) -> None:
+        """Forward-compatibility: any non-'accept' return value is a reject."""
+        from godspeed.tools.base import DiffReviewer
+
+        class EditingReviewer(DiffReviewer):
+            async def review(self, *, tool_name: str, path: str, before: str, after: str) -> str:
+                return "edit"  # future feature, not yet implemented
+
+        f = tool_context.cwd / "ok.py"
+        f.write_text("x = 1\n", encoding="utf-8")
+        tool_context.diff_reviewer = EditingReviewer()
+
+        result = await tool.execute(
+            {"file_path": "ok.py", "old_string": "x = 1", "new_string": "x = 2"},
+            tool_context,
+        )
+        assert result.is_error
+        assert f.read_text(encoding="utf-8") == "x = 1\n"


### PR DESCRIPTION
## Summary

**Phase 1.2 of v3.3.0.** Adds an independent diff-review gate on top of the existing permission system: diff-producing tools (file_edit / file_write / diff_apply) now consult an optional \`DiffReviewer\` just before writing, giving the human veto power over THIS specific change separate from the general permission-to-run decision.

## Two axes of consent

| | Permission | Diff review (new) |
|---|---|---|
| Question | \"May this tool run?\" | \"Should THIS specific diff be applied?\" |
| Fires | Once per tool call | Once per pending write |
| Inputs | Tool name, args pattern | Pre/post-patch content |
| State | Session-cached, pattern-matched | Per-pending-write |

## Non-invasive architecture

- **\`DiffReviewer\` Protocol** (runtime-checkable) — \`async review(*, tool_name, path, before, after) -> str\`
- **\`ToolContext.diff_reviewer: DiffReviewer | None = None\`** — same pattern as existing \`permissions\` field. None = headless / CI default, writes proceed as before.
- **\`Tool.produces_diff: bool = False\`** class attribute, overridden to \`True\` on file_edit / file_write / diff_apply.
- Each diff-producing tool's \`execute()\` now calls \`await context.diff_reviewer.review(...)\` right before write.

## TUI integration

- **\`format_diff_review_prompt\`** renders a unified diff via Rich's \`Syntax(\"diff\")\` lexer with a +N/-N line-count summary and \`(y)es · (n)o\` prompt.
- **\`_InteractiveDiffReviewer\`** wraps Rich \`console.input\` in \`asyncio.to_thread\` (keeps event loop responsive). Session-scoped \`(a)lways\` bypass for common \"approve whole work session\" pattern. KeyboardInterrupt → reject.
- **\`TUIApp.__init__\`** instantiates the reviewer + assigns to \`tool_context.diff_reviewer\`.

## Tests

\`TestDiffReviewerGate\` (5 new, 26/26 file_edit tests pass):
1. \`produces_diff\` declared \`True\` on FileEditTool
2. Accepting reviewer: write proceeds + before/after passed through
3. Rejecting reviewer: write blocked, file unchanged
4. No reviewer (None): baseline behavior preserved
5. Unrecognized decision value: treated as reject (forward compat)

**235/235 non-environment tests pass** (190 tool + 40 agent loop + 5 new gate).

## Files changed

- \`src/godspeed/tools/base.py\` — \`DiffReviewer\` Protocol, \`ToolContext.diff_reviewer\`, \`Tool.produces_diff\` (+45)
- \`src/godspeed/tools/file_edit.py\` — \`produces_diff=True\` + gate call (+21)
- \`src/godspeed/tools/file_write.py\` — \`produces_diff=True\` + gate call with pre-read (+27)
- \`src/godspeed/tools/diff_apply.py\` — \`produces_diff=True\` + atomic diff review (+28)
- \`src/godspeed/tui/output.py\` — \`format_diff_review_prompt\` (+61)
- \`src/godspeed/tui/app.py\` — \`_InteractiveDiffReviewer\` + wire-up (+55)
- \`tests/test_tools/test_file_edit.py\` — \`TestDiffReviewerGate\` (+95)

## Not in this PR

Phase 1.3+: cost/token HUD, animated README demo, VS Code extension, task-aware routing. Each is a separate PR per the approved plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)