### PR TITLE
docs(v3.3): troubleshooting + Windows quickstart + demo recording guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ An AI coding agent that treats security as a first-class concern -- not an after
 
 ---
 
+## What's new in v3.3.0
+
+Five UX-focused additions on top of the security-first core. Every one
+shipped with tests + CI-green.
+
+| Area | What changed | Why |
+|---|---|---|
+| **Mid-turn cancel** | `Ctrl+C` now stops the agent mid-streaming-chunk, not at iteration boundary. Second press within 1 s hard-interrupts. | Previously you had to wait for the whole turn if the model went off-track. Cursor / Claude Code pattern — table stakes for a coding agent. |
+| **Diff approve-before-write** | `file_edit` / `file_write` / `diff_apply` now prompt with a side-by-side diff before hitting disk. `(y)es · (n)o · (a)lways` keys. | Two independent axes of consent: `PermissionEvaluator` ("may this tool run?") + `DiffReviewer` ("apply THIS specific diff?"). |
+| **Per-turn cost HUD** | Compact status line after every turn: `· 1,234 in + 567 out · $0.0024 · model · 3 turns`. Tints WARNING when budget < 20%. | `/stats` is great for a deep check but you want continuous awareness without typing. |
+| **Post-edit syntax gate** (v3.2.x) | `.py` / `.pyi` / `.json` edits that break parse are rejected before write. | Caught a multi-line-replace indentation bug surfaced by the production audit. See `docs/production_audit.md`. |
+| **Windows UTF-8 stdio** (v3.2.x) | CLI auto-wraps stdout/stderr with `errors='replace'` at startup. | Fixes `UnicodeEncodeError` on default cp1252 consoles when the agent emits arrows/em-dashes/smart quotes. |
+
+For the background on each — including the 6-task daily-use benchmark
+that surfaced the first two fixes — see
+`docs/production_audit.md` (once committed to the repo; currently on
+`C:\Users\ttimm\Desktop\godspeed_benchmark\production_audit.md`) and
+`docs/troubleshooting.md`.
+
+**Platform docs:** Windows users should read [`docs/quickstart_windows.md`](docs/quickstart_windows.md) for
+platform-specific setup (Miniconda, `PYTHONIOENCODING`, WSL for SWE-bench).
+
 ## Why
 
 Every open-source coding agent gives an LLM the ability to read files, write code, and run shell commands. None of them ship with a deny-first permission engine, a tamper-evident audit trail, or multi-layer secret protection out of the box. You are expected to bolt security on yourself, or trust the model not to `rm -rf /`.

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,86 @@
+# Recording the Godspeed demo (asciinema → GIF)
+
+The README hero showcases a ~45-60 s animated demo of a realistic
+Godspeed task. This doc captures the instructions for re-recording
+it so the demo can stay fresh across releases.
+
+## Tools
+
+```bash
+# Ubuntu / WSL (recommended: recordings are cleaner on a real terminal)
+sudo apt install asciinema
+cargo install --git https://github.com/asciinema/agg    # converter to GIF
+
+# macOS
+brew install asciinema
+brew install --HEAD asciinema-agg                       # or cargo install --git ...
+```
+
+## Record
+
+```bash
+# From the repo root:
+cd ~/Documents/Project\ Portfolio/godspeed
+
+asciinema rec docs/demo.cast \
+    --title "Godspeed v3.3 — 60-second demo" \
+    --idle-time-limit 2 \
+    --command "bash -c 'cd /tmp && mkdir -p godspeed_demo && cd godspeed_demo && godspeed'"
+```
+
+Inside the recording session, type a realistic task. Suggested prompt
+(mirrors benchmark T2 which finishes in ~50 s cleanly):
+
+```
+Create utils.py with uppercase and count_vowels functions, plus a test
+for each in tests/test_utils.py. Use type hints.
+```
+
+Let the agent complete. Press Ctrl+D or type `/quit` to exit. The
+recording saves to `docs/demo.cast`.
+
+## Convert to GIF
+
+```bash
+agg --theme monokai --font-size 14 --cols 120 --rows 30 \
+    docs/demo.cast docs/demo.gif
+```
+
+Target size: ≤ 1.5 MB (README embed stays responsive). If the GIF is
+larger, trim:
+
+- Re-record with `--idle-time-limit 1`
+- Pre-trim with `asciinema-edit cut docs/demo.cast --from 0 --to 60`
+  (requires the `asciinema-edit` tool)
+
+## Embed in README
+
+```markdown
+<p align="center">
+  <img src="docs/demo.gif" alt="Godspeed v3.3 demo — add a function, add tests, ~50 seconds." width="780" />
+</p>
+```
+
+## Alternative: asciinema player embed
+
+If the GIF gets too large, embed the interactive player instead:
+
+```markdown
+<a href="https://asciinema.org/a/<ID>" target="_blank">
+  <img src="https://asciinema.org/a/<ID>.svg" alt="Godspeed v3.3 demo" />
+</a>
+```
+
+Upload via `asciinema upload docs/demo.cast` → you get a shareable URL.
+
+## Checklist before committing the GIF
+
+- [ ] Recording is 45-75 s (too short feels demoey; too long loses
+      attention)
+- [ ] Shows ONE realistic task, not a kitchen-sink demo
+- [ ] Task actually completes successfully (not a demo of errors)
+- [ ] No secrets / personal paths visible (`$HOME`, API keys in env)
+- [ ] Terminal dimensions are readable at embedded size
+      (cols=120, font-size=14 is a good default)
+- [ ] File size ≤ 1.5 MB
+- [ ] README hero block updated to reference the new GIF path

--- a/docs/quickstart_windows.md
+++ b/docs/quickstart_windows.md
@@ -1,0 +1,173 @@
+# Godspeed on Windows — quickstart
+
+Godspeed ships on Windows, macOS, and Linux. This guide is the
+Windows-specific path from zero to "agent completed its first
+task" in under 2 minutes. For other platforms see the main
+`README.md`.
+
+---
+
+## Prerequisites
+
+- **Windows 10 / 11**
+- **Python 3.11+** (3.13 recommended; Godspeed's CI matrix covers
+  3.11 / 3.12 / 3.13)
+- **Git** — for git-bash (Godspeed's shell tool uses it for shell
+  command execution on Windows) and for cloning constituent repos
+  when running benchmarks
+
+Optional but recommended:
+- **Ollama** for a free local model fallback (~3 GB VRAM for qwen3:4b)
+- **WSL2 + Docker Desktop** if you want to run SWE-bench benchmarks
+  locally (POSIX-only harness)
+
+---
+
+## 1. Install
+
+The lowest-friction path uses Miniconda for isolation:
+
+```powershell
+# 1. Install Miniconda (one-time, if not already):
+# https://docs.conda.io/en/latest/miniconda.html
+
+# 2. Create + activate an env
+conda create -n godspeed python=3.13 -y
+conda activate godspeed
+
+# 3. Install Godspeed
+pip install godspeed-coding-agent
+```
+
+Alternatives:
+- `pipx install godspeed-coding-agent` — isolated tool-install, no conda
+- `uv pip install godspeed-coding-agent` — if you use `uv`
+
+---
+
+## 2. First-time config
+
+```powershell
+godspeed init
+```
+
+Creates `~/.godspeed/settings.yaml` with a default model pointing at a
+free-tier NVIDIA NIM driver (requires `NVIDIA_NIM_API_KEY`) and a
+fallback chain to local Ollama.
+
+Open `~/.godspeed/settings.yaml` and either:
+1. **Add an API key** for a paid provider (recommended for sustained
+   use — NIM free tier is 40 RPM shared across all users):
+   ```yaml
+   model: anthropic/claude-opus-4-7
+   ```
+   Set the env var:
+   ```powershell
+   setx ANTHROPIC_API_KEY "sk-ant-..."    # persistent; open a new shell after
+   ```
+
+2. **Or use Ollama locally** (free, no cloud):
+   ```powershell
+   # Install Ollama from https://ollama.com then:
+   ollama serve
+   ollama pull qwen3:4b
+   ```
+   Godspeed will auto-start Ollama on first launch if it's installed.
+
+---
+
+## 3. Environment variables for Windows
+
+Godspeed's TUI renders non-ASCII characters (arrows, em-dashes).
+Set UTF-8 encoding to prevent `UnicodeEncodeError` crashes on
+legacy `cp1252` consoles:
+
+```powershell
+# Persistent across sessions (PowerShell):
+[Environment]::SetEnvironmentVariable('PYTHONIOENCODING', 'utf-8', 'User')
+
+# Or for one-off sessions (cmd.exe):
+set PYTHONIOENCODING=utf-8
+```
+
+> Godspeed v3.3.0+ self-wraps stdout/stderr to UTF-8 at startup, so
+> this is only needed on older installs. Still a good global to set.
+
+Restart your terminal after `setx` / `[Environment]::Set...`.
+
+---
+
+## 4. Run your first task
+
+```powershell
+godspeed run "Create hello.py with a function greet(name) that returns 'Hello, <name>!'"
+```
+
+Expected: ~20-30 seconds, `hello.py` appears in the current directory,
+exit code 0.
+
+For interactive mode:
+
+```powershell
+godspeed
+```
+
+Launches the TUI. Type a task at the prompt, watch the agent work
+live, Ctrl+C to cancel mid-turn (v3.3.0+).
+
+---
+
+## 5. WSL for SWE-bench benchmarks
+
+If you want to run the SWE-bench local evaluation harness (for
+reproducing benchmark numbers or generating leaderboard-submission
+logs), the harness is POSIX-only and must run inside WSL:
+
+```powershell
+# Install WSL Ubuntu (one-time)
+wsl --install -d Ubuntu
+
+# Inside Ubuntu:
+sudo apt update && sudo apt install -y python3-pip docker.io
+pip install swebench
+```
+
+Docker Desktop must be running with WSL integration enabled
+(Settings → Resources → WSL Integration → enable Ubuntu).
+
+Once set up, Godspeed's runner script handles the path translation:
+
+```powershell
+# From a Windows terminal, inside the godspeed repo:
+bash experiments/swebench_lite/leaderboard_submission/run_local_swebench_eval.sh --dry-run
+```
+
+The `--dry-run` flag validates prereqs without actually running the
+eval. Remove it for a real run (~1-2 hours + 20-50 GB of Docker
+images).
+
+---
+
+## Common Windows-specific issues
+
+See `docs/troubleshooting.md`. The top three for new Windows users:
+
+1. **`UnicodeEncodeError`** — set `PYTHONIOENCODING=utf-8`
+2. **Ctrl+C doesn't cancel mid-turn** — only in TUI; on the
+   `ProactorEventLoop` (default), cancel works via the standard
+   KeyboardInterrupt path which requires a cancel point to be hit
+3. **`psutil not available`** — reinstall from a fresh pip env
+
+---
+
+## Next steps
+
+- Read `README.md` → Features for the full tool surface
+- Read `GODSPEED_ARCHITECTURE.md` for the agent loop, tool system,
+  permission engine, and audit trail design
+- `godspeed models` — shows preconfigured model options + env-var
+  requirements for each
+- `godspeed audit verify` — confirms your session's audit trail is
+  unbroken
+
+All glory to God. Happy shipping.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,241 @@
+# Godspeed — troubleshooting guide
+
+Common issues and their fixes, in order from most-hit to least-hit.
+
+---
+
+## Windows: `UnicodeEncodeError` on exit
+
+**Symptom:** Agent finishes the task, then the CLI crashes just as it's about
+to print the final summary:
+
+```
+UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in
+position 126: character maps to <undefined>
+```
+
+**Cause:** the default Windows console encoding is `cp1252`, which can't
+encode arrows (`→`), em-dashes (`—`), or smart quotes. The agent already
+finished its real work — it's just the final write that crashes.
+
+**Fix (v3.3.0+):** the CLI now force-wraps stdout/stderr in UTF-8 at
+startup. If you're on an older install, set the environment variable:
+
+```bash
+export PYTHONIOENCODING=utf-8            # bash / zsh / git-bash
+set PYTHONIOENCODING=utf-8               # cmd.exe
+$env:PYTHONIOENCODING="utf-8"            # PowerShell
+```
+
+Persist it by adding to `~/.bashrc` / `~/.zshrc` / PowerShell profile.
+
+---
+
+## NVIDIA NIM free-tier: 40 RPM rate limit hits during long runs
+
+**Symptom:** `litellm.Timeout: APITimeoutError - Request timed out` after
+~40 calls in a minute, often during SWE-Bench evaluation or heavy refactors.
+
+**Cause:** the NIM free tier caps concurrent usage at 40 requests per
+minute *shared across all users*. Other users' traffic can push you
+over even if your own rate is low.
+
+**Mitigations:**
+
+1. **Configure a fallback chain** in `~/.godspeed/settings.yaml`:
+   ```yaml
+   model: nvidia_nim/moonshotai/kimi-k2.5
+   fallback_models:
+     - ollama/qwen3:4b   # local fallback, always available
+   ```
+   When NIM returns 429, Godspeed's built-in retry / fallback loop
+   drops to the next model automatically.
+
+2. **Enable instance-cooldown** for benchmark runs:
+   ```bash
+   python experiments/swebench_lite/run.py --instance-cooldown 90
+   ```
+   Inserts a 90 s sleep between instances so the RPM window resets.
+
+3. **Use paid direct API** for sustained load:
+   ```yaml
+   model: moonshot/kimi-k2.5     # requires MOONSHOT_API_KEY
+   ```
+
+---
+
+## WSL + Docker for SWE-Bench harness
+
+**Symptom:** `python -m swebench.harness.run_evaluation` on Windows raises:
+```
+ModuleNotFoundError: No module named 'resource'
+```
+
+**Cause:** the SWE-bench harness uses Python's `resource` module, which
+is POSIX-only.
+
+**Fix:** run the harness inside WSL Ubuntu. Godspeed's runner script
+handles this automatically:
+
+```bash
+bash experiments/swebench_lite/leaderboard_submission/run_local_swebench_eval.sh --dry-run
+bash experiments/swebench_lite/leaderboard_submission/run_local_swebench_eval.sh --max-workers 4
+```
+
+The script converts Windows paths to `/mnt/c/...`, invokes the harness
+via `wsl -d Ubuntu`, and copies per-instance artifacts back into the
+leaderboard submission dir.
+
+**Known bug (upstream):** swebench 4.1.0's pvlib testbed image ships
+NumPy 2.0+ which breaks pvlib's `np.Inf` usage. Our audit caught this;
+see `experiments/swebench_lite/leaderboard_submission/README.md`
+"⚠ Environmental caveat" for the full analysis. Don't use local
+harness numbers as the leaderboard submission until upstream fixes;
+use sb-cli cloud-graded reports instead.
+
+---
+
+## Audit trail: verify session integrity
+
+Every Godspeed session records a hash-chained audit log at
+`~/.godspeed/audit/<session_id>.audit.jsonl`. Each record links to the
+previous via `prev_hash`, forming a cryptographically tamper-evident
+chain.
+
+```bash
+# Verify one session
+godspeed audit verify 9e320a20-fbde-4004-b9cc-4fbc94601a05
+
+# Verify every session in the audit dir
+godspeed audit verify
+```
+
+Expected output: `VALID -- Chain verified: N records`.
+
+If `verify` reports a break, the log has been tampered with between
+the listed record and the next — or a file-system corruption event
+occurred. The records up to the break are still valid history; the
+remainder should be discarded.
+
+---
+
+## Ollama first run: model not installed
+
+**Symptom:**
+```
+connection refused: http://localhost:11434
+```
+or
+```
+model 'qwen3:4b' not found
+```
+
+**Fix:**
+
+```bash
+# Install ollama (https://ollama.com) then:
+ollama serve                 # in a separate terminal
+ollama pull qwen3:4b         # ~2.5 GB download, one-time
+```
+
+Then point Godspeed at it:
+
+```yaml
+# ~/.godspeed/settings.yaml
+model: ollama/qwen3:4b
+```
+
+Godspeed's CLI `init` command will auto-start Ollama on session
+launch if it's installed but not running. The 15-second startup
+timeout is controlled by `OLLAMA_STARTUP_TIMEOUT` in `src/godspeed/cli.py`.
+
+---
+
+## `file_edit` rejected by post-edit syntax gate
+
+**Symptom (v3.3.0+):** an edit that looked like it should work returns:
+```
+Post-edit syntax check failed — the edit would leave the file
+unparseable. Line N: <reason>.
+```
+
+**Cause:** the fuzzy matcher found your edit location, but the
+`new_string` dropped indentation or introduced a syntax error. The
+gate is protecting you from silently writing a broken .py / .pyi /
+.json file.
+
+**Fix:** re-read the file first (so you have exact whitespace context),
+then include enough surrounding lines in `old_string` that the
+replacement `new_string` will preserve proper indentation.
+
+---
+
+## Diff reviewer: accept/reject the proposed edit
+
+**Symptom (v3.3.0+):** the TUI prompts
+```
+Review proposed edit
+  file_edit  src/main.py
+  +2 -1 lines
+  @@ ... @@
+  Apply? (y)es · (n)o
+```
+
+**Usage:**
+- **y / yes / ⏎ (empty)** — apply the change
+- **n / no** — reject; file stays unchanged, agent gets a "rejected"
+  ToolResult and will typically retry with a different approach
+- **a / always** — accept *and* suppress future review prompts for
+  the rest of the session (useful when you trust a refactor)
+
+The reviewer is TUI-only. Headless mode (`godspeed run`) never asks
+— it auto-accepts so CI stays deterministic.
+
+---
+
+## Mid-turn cancel (v3.3.0+): Ctrl+C to interrupt
+
+**Symptom:** agent is heading in the wrong direction and you want
+to redirect without waiting for the turn to finish.
+
+**Fix:**
+- **First Ctrl+C** — cancels the current turn cleanly. The agent
+  unwinds at the next checkpoint (between streaming chunks). You
+  see: `Agent cancelled. Send another prompt or /quit.`
+- **Second Ctrl+C within 1 s** — hard interrupt
+  (KeyboardInterrupt). Use if the first press didn't take effect
+  (rare; happens if the agent is mid-non-cancellable IO).
+
+Windows note: on the `ProactorEventLoop`, the first-press handler
+isn't installable via `asyncio.add_signal_handler`. Ctrl+C still
+works via the standard KeyboardInterrupt path.
+
+---
+
+## psutil not installed on a custom conda env
+
+**Symptom:**
+```
+psutil not available; cannot force-kill process tree for pid=NNN
+```
+
+**Cause:** `psutil` is declared as a core dep, but a custom conda env
+may not have installed it.
+
+**Fix:**
+```bash
+conda run -n <env> pip install 'psutil>=5.9,<8.0'
+# or:
+pip install godspeed-coding-agent --force-reinstall
+```
+
+Without psutil, Godspeed's shell tool can't kill grandchildren when
+a timeout fires — a long-running subprocess may orphan.
+
+---
+
+## Getting help / reporting a bug
+
+- Issues: https://github.com/omnipotence-eth/godspeed-coding-agent/issues
+- Architecture reference: `GODSPEED_ARCHITECTURE.md`
+- Full-flow walkthrough: `README.md` → Getting Started


### PR DESCRIPTION
## Summary

**Phase 1.5 of v3.3.0.** Documents the fixes and features landed across PRs #78–#81 so new users (and future-me) can find them without reading source.

## New docs

### \`docs/troubleshooting.md\` (220+ lines)
Top issues surfaced by today's production audit:
- Windows \`UnicodeEncodeError\` (fixed in v3.3.0; env-var fallback for older)
- NVIDIA NIM 40 RPM rate-limit mitigations (fallback chain, instance-cooldown, paid direct API)
- WSL + Docker for SWE-bench harness (with swebench 4.1.0 pvlib NumPy bug caveat)
- Audit trail \`verify\` workflow + what a break means
- Ollama first-run install / serve / pull
- Post-edit syntax gate rejections
- Diff reviewer y/n/a keys
- Mid-turn Ctrl+C cancel semantics (Windows ProactorEventLoop caveat)
- psutil missing in custom conda envs

### \`docs/quickstart_windows.md\`
Five-minute path from zero to \"agent completed its first task\" on Windows 10/11: Miniconda → pip → \`godspeed init\` → \`PYTHONIOENCODING=utf-8\` → first task → optional WSL+Docker for SWE-bench.

### \`docs/demo.md\`
Step-by-step instructions to re-record the README hero GIF with asciinema + agg. Includes realistic prompt (mirrors benchmark T2), pre-commit checklist (size ≤1.5 MB, no secrets, ~60 s runtime). Demo recording is user-gated — requires a real interactive terminal — so this captures the recipe for when ready.

### \`README.md\` — \"What's new in v3.3.0\" section
5-row summary table: mid-turn cancel, diff review, cost HUD, syntax gate, Windows UTF-8. Cross-links troubleshooting + quickstart_windows.

## No source changes

**300/300 tests pass** (tui_output + agent_loop + tools). Docs + README only.

## Not in this PR

Phase 1.6: CHANGELOG [3.3.0] + version bump to 3.3.0 + release tag. Final Phase 1 PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)