### PR TITLE
chore(release): v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] — 2026-04-22
+
+Phase 2 of the world-class UX push. Two independent additions on top
+of v3.3.0, both landed with full test coverage and CI-green across
+Python 3.11 / 3.12 / 3.13. Zero breaking changes — every default
+behaves identically to v3.3.0 until you opt in.
+
 ### Added
 
 - **`/remember` slash command** for persisting permission rules without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed"
-version = "3.3.0"
+version = "3.4.0"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"


### PR DESCRIPTION
## Summary

Version bump + CHANGELOG for v3.4.0 — bundles Phase 2 of the world-class UX push (two already-merged feature PRs) into a tagged release.

## What's in this release

- feat(llm): **task-aware model routing** — cheap/strong split (#84, commit `396f898`)
- feat(security): **`/remember` slash command** persists permission rules (#85, commit `0b706b5`)

Both PRs shipped with full test coverage (48 new tests across the two) and CI-green on 8 checks across Python 3.11 / 3.12 / 3.13. Zero breaking changes — every default behaves identically to v3.3.0 until you opt in.

## Changes in this PR

- `pyproject.toml`: `version = "3.3.0"` → `"3.4.0"`
- `src/godspeed/__init__.py`: `__version__ = "3.3.0"` → `"3.4.0"`
- `CHANGELOG.md`: new `[3.4.0] — 2026-04-22` section carrying the Unreleased entries

## Test plan

- [x] Full suite already green on main (#84 and #85 both merged with 8/8 CI)
- [x] `ruff check .` and `ruff format --check .` — clean
- [x] Release branch cut from current main tip (`0b706b5`)

## Next steps (after merge)

1. Tag `v3.4.0` on the squashed commit
2. `gh release create v3.4.0 --generate-notes` seeded from CHANGELOG
3. Publish to PyPI via the existing release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)