### PR TITLE
fix(cli): auto-load ~/.godspeed/.env.local on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-load `~/.godspeed/.env.local` on startup** (`cli._load_env_files`).
+  API keys in `~/.godspeed/.env` / `.env.local` (and the project's
+  `.godspeed/.env` / `.env.local`) are now injected into `os.environ`
+  before LiteLLM runs, so `NVIDIA_NIM_API_KEY=... godspeed` one-offs
+  AND long-lived `~/.godspeed/.env.local` files both work without
+  extra shell plumbing. Precedence: project/.env.local >
+  project/.env > global/.env.local > global/.env; **shell env wins
+  over all of them** so per-run overrides keep working. Matches
+  dotenv/Vite/Next convention: `.env.local` is the gitignored local
+  override. Log messages contain key names only, never values.
+  Closes the "first-run auth error" UX paper cut that required users
+  to remember to `$env:NVIDIA_NIM_API_KEY = ...` every shell.
+- Troubleshooting doc: new "AuthenticationError: api_key client
+  option must be set" section in `docs/troubleshooting.md` with the
+  fix + the pre-v3.5.0 workaround.
+
 ## [3.4.0] — 2026-04-22
 
 Phase 2 of the world-class UX push. Two independent additions on top

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,6 +31,57 @@ Persist it by adding to `~/.bashrc` / `~/.zshrc` / PowerShell profile.
 
 ---
 
+## `AuthenticationError: api_key client option must be set`
+
+**Symptom:** First prompt at the `⚡ godspeed>` shell returns:
+
+```
+litellm.AuthenticationError: AuthenticationError: Nvidia_nimException -
+The api_key client option must be set either by passing api_key to the
+client or by setting the NVIDIA_NIM_API_KEY environment variable
+```
+
+(Or the equivalent for `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
+
+**Cause:** LiteLLM reads API keys from `os.environ`. Your key is
+saved to `~/.godspeed/.env.local` but nothing had loaded that file
+into the process environment before LiteLLM ran.
+
+**Fix (v3.5.0+):** Godspeed auto-loads env files on CLI startup in
+this priority order (later wins, shell env always wins overall):
+
+1. `~/.godspeed/.env`
+2. `~/.godspeed/.env.local`
+3. `<project>/.godspeed/.env`
+4. `<project>/.godspeed/.env.local`
+
+Put your key in `~/.godspeed/.env.local` (gitignore-safe) once:
+
+```ini
+# ~/.godspeed/.env.local
+NVIDIA_NIM_API_KEY=nvapi-...
+```
+
+**Pre-v3.5.0 workaround:** set the env var explicitly before launching:
+
+```powershell
+# PowerShell — one-off
+$env:NVIDIA_NIM_API_KEY = "nvapi-..."
+godspeed
+
+# Persist for all future PowerShell sessions
+setx NVIDIA_NIM_API_KEY "nvapi-..."
+# close + reopen PowerShell for setx to take effect
+```
+
+```bash
+# bash / zsh / git-bash
+export NVIDIA_NIM_API_KEY=nvapi-...
+godspeed
+```
+
+---
+
 ## NVIDIA NIM free-tier: 40 RPM rate limit hits during long runs
 
 **Symptom:** `litellm.Timeout: APITimeoutError - Request timed out` after

--- a/src/godspeed/cli.py
+++ b/src/godspeed/cli.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import io
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -17,6 +18,7 @@ from uuid import uuid4
 import click
 
 from godspeed import __version__
+from godspeed.config import DEFAULT_GLOBAL_DIR
 
 
 def _force_utf8_stdio() -> None:
@@ -58,6 +60,123 @@ logger = logging.getLogger(__name__)
 
 OLLAMA_URL = "http://localhost:11434/api/tags"
 OLLAMA_STARTUP_TIMEOUT = 15  # seconds to wait for ollama to come up
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a simple ``KEY=value`` env file into a dict.
+
+    Supports:
+    - ``# ...`` comments (line must start with ``#``; inline comments aren't stripped)
+    - Blank lines
+    - Optional surrounding ``"..."`` or ``'...'`` quotes on values
+
+    Malformed lines (no ``=``, empty key) are silently skipped — an env
+    file should never crash startup. Returns an empty dict if the file
+    is missing or unreadable.
+    """
+    result: dict[str, str] = {}
+    if not path.exists():
+        return result
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        # OSError: permissions / transient FS issue.
+        # UnicodeDecodeError: someone wrote a binary blob or cp1252 file
+        # into .env.local — log and skip rather than crash the CLI.
+        logger.debug("Could not read env file %s: %s", path, exc)
+        return result
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        # Strip a matching pair of surrounding quotes so
+        # ``KEY="value with spaces"`` works as expected.
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+def _load_env_files(project_dir: Path | None = None) -> list[tuple[Path, list[str]]]:
+    """Load env files from standard locations into ``os.environ``.
+
+    Precedence (highest to lowest):
+
+    1. **Shell environment** — always wins. Keys already in ``os.environ``
+       are never overwritten. This keeps ``$env:NVIDIA_NIM_API_KEY = ...;
+       godspeed`` one-offs working and matches every ``.env`` library's
+       convention.
+    2. ``<project_dir>/.godspeed/.env.local`` — project-scoped override
+    3. ``<project_dir>/.godspeed/.env`` — project-scoped defaults
+    4. ``~/.godspeed/.env.local`` — user-wide override
+    5. ``~/.godspeed/.env`` — user-wide defaults
+
+    Files are merged in low-to-high priority order so higher-priority
+    files overwrite lower-priority ones BEFORE the single shell-env
+    check. In-file semantics mirror dotenv / Vite / Next: ``.env.local``
+    is the gitignored local override, ``.env`` is the checked-in default.
+
+    Returns a list of ``(path, injected_keys)`` pairs for each file
+    that contributed at least one variable — used by the caller to log
+    which files the session picked up. Never raises; bad files are
+    silently skipped so a malformed ``.env.local`` can't brick the CLI.
+    """
+
+    # Lowest priority first so later files overwrite earlier ones in
+    # the merged dict. Shell-env wins is applied at the very end.
+    candidates: list[Path] = [
+        DEFAULT_GLOBAL_DIR / ".env",
+        DEFAULT_GLOBAL_DIR / ".env.local",
+    ]
+    if project_dir is not None:
+        candidates.extend(
+            [
+                project_dir / ".godspeed" / ".env",
+                project_dir / ".godspeed" / ".env.local",
+            ]
+        )
+
+    resolved: dict[str, str] = {}
+    contributions: list[tuple[Path, list[str]]] = []
+    for path in candidates:
+        parsed = _parse_env_file(path)
+        if not parsed:
+            continue
+        # Record which keys this file will contribute to the merged view.
+        # (The actual injection into os.environ happens after the full
+        # merge; shell-env wins over everything below.)
+        contributions.append((path, sorted(parsed.keys())))
+        resolved.update(parsed)
+
+    loaded: list[tuple[Path, list[str]]] = []
+    injected_keys: set[str] = set()
+    for key, value in resolved.items():
+        if key in os.environ:
+            continue
+        os.environ[key] = value
+        injected_keys.add(key)
+
+    # Re-project contributions onto actually-injected keys, so the log
+    # reflects what the session ended up with after shell-env overrides.
+    for path, keys in contributions:
+        effective = [k for k in keys if k in injected_keys]
+        if not effective:
+            continue
+        loaded.append((path, effective))
+        logger.info(
+            "Loaded %d env var(s) from %s: %s",
+            len(effective),
+            path,
+            ", ".join(effective),
+        )
+    return loaded
 
 
 def _setup_logging(verbose: bool) -> None:
@@ -515,6 +634,12 @@ def main(
     """Godspeed -- Security-first open-source coding agent."""
     _setup_logging(verbose)
 
+    # Auto-load env files so API keys in ~/.godspeed/.env.local (and the
+    # project's .godspeed/.env.local) reach LiteLLM without requiring
+    # per-shell env configuration. Shell env still wins — see
+    # _load_env_files for the precedence rules.
+    _load_env_files(project_dir=project_dir)
+
     # Store params for subcommands
     ctx.ensure_object(dict)
     ctx.obj["model"] = model
@@ -560,7 +685,6 @@ def audit_verify(session_id: str | None, audit_dir: Path | None) -> None:
     from rich.console import Console as RichConsole
 
     from godspeed.audit.trail import AuditTrail
-    from godspeed.config import DEFAULT_GLOBAL_DIR
     from godspeed.tui.theme import DIM, ERROR, SUCCESS
 
     c = RichConsole()
@@ -603,7 +727,6 @@ def init() -> None:
 
     from rich.console import Console as RichConsole
 
-    from godspeed.config import DEFAULT_GLOBAL_DIR
     from godspeed.tui.theme import ACCENT, BOLD_PRIMARY, DIM, SUCCESS
 
     c = RichConsole()
@@ -1104,7 +1227,6 @@ def export_training(
     """
     from rich.console import Console as RichConsole
 
-    from godspeed.config import DEFAULT_GLOBAL_DIR
     from godspeed.training.exporter import ExportFilters, TrainingExporter
     from godspeed.tui.theme import DIM, ERROR, SUCCESS
 

--- a/tests/test_cli_env_loading.py
+++ b/tests/test_cli_env_loading.py
@@ -1,0 +1,195 @@
+"""Tests for the CLI's .env / .env.local auto-loading on startup."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from godspeed.cli import _load_env_files, _parse_env_file
+
+
+class TestParseEnvFile:
+    """Parser for ``KEY=value`` env files."""
+
+    def test_parses_basic_key_value(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("FOO=bar\nBAZ=qux\n")
+        result = _parse_env_file(env)
+        assert result == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_skips_comments(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("# this is a comment\nFOO=bar\n# another\nBAZ=qux\n")
+        assert _parse_env_file(env) == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_skips_blank_lines(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("\n\nFOO=bar\n\n\nBAZ=qux\n\n")
+        assert _parse_env_file(env) == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_strips_double_quotes(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text('FOO="value with spaces"\n')
+        assert _parse_env_file(env) == {"FOO": "value with spaces"}
+
+    def test_strips_single_quotes(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("FOO='value with spaces'\n")
+        assert _parse_env_file(env) == {"FOO": "value with spaces"}
+
+    def test_leaves_mismatched_quotes_alone(self, tmp_path: Path) -> None:
+        # ``"foo'`` (mismatched) — don't strip.
+        env = tmp_path / ".env"
+        env.write_text("FOO=\"foo'\n")
+        assert _parse_env_file(env) == {"FOO": "\"foo'"}
+
+    def test_preserves_equals_in_value(self, tmp_path: Path) -> None:
+        # partition() splits on the FIRST = so key=a=b=c gives value="a=b=c".
+        env = tmp_path / ".env"
+        env.write_text("NVIDIA_NIM_API_KEY=nvapi-abc=def=ghi\n")
+        assert _parse_env_file(env) == {"NVIDIA_NIM_API_KEY": "nvapi-abc=def=ghi"}
+
+    def test_skips_malformed_lines(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("FOO=bar\nthis line has no equals sign\n=value_with_no_key\nBAZ=qux\n")
+        assert _parse_env_file(env) == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_missing_file_returns_empty_dict(self, tmp_path: Path) -> None:
+        assert _parse_env_file(tmp_path / "does_not_exist") == {}
+
+    def test_trims_whitespace_around_key_and_value(self, tmp_path: Path) -> None:
+        env = tmp_path / ".env"
+        env.write_text("  FOO  =  bar  \n")
+        assert _parse_env_file(env) == {"FOO": "bar"}
+
+
+class TestLoadEnvFiles:
+    """End-to-end loader that injects parsed values into os.environ."""
+
+    def _clean_env(self, keys: list[str]) -> None:
+        for k in keys:
+            os.environ.pop(k, None)
+
+    def test_loads_global_env_local(self, tmp_path: Path) -> None:
+        # Simulate ~/.godspeed/.env.local by pointing DEFAULT_GLOBAL_DIR.
+        global_dir = tmp_path / "home_godspeed"
+        global_dir.mkdir()
+        (global_dir / ".env.local").write_text("NVIDIA_NIM_API_KEY=nvapi-from-global\n")
+
+        self._clean_env(["NVIDIA_NIM_API_KEY"])
+        try:
+            with patch("godspeed.cli.DEFAULT_GLOBAL_DIR", global_dir):
+                loaded = _load_env_files(project_dir=None)
+            assert os.environ["NVIDIA_NIM_API_KEY"] == "nvapi-from-global"
+            # One file loaded, one key injected.
+            assert len(loaded) == 1
+            assert loaded[0][1] == ["NVIDIA_NIM_API_KEY"]
+        finally:
+            self._clean_env(["NVIDIA_NIM_API_KEY"])
+
+    def test_shell_env_wins_over_file(self, tmp_path: Path) -> None:
+        global_dir = tmp_path / "home_godspeed"
+        global_dir.mkdir()
+        (global_dir / ".env.local").write_text("NVIDIA_NIM_API_KEY=from-file\n")
+
+        self._clean_env(["NVIDIA_NIM_API_KEY"])
+        os.environ["NVIDIA_NIM_API_KEY"] = "from-shell"
+        try:
+            with patch("godspeed.cli.DEFAULT_GLOBAL_DIR", global_dir):
+                _load_env_files(project_dir=None)
+            # Shell value must still be present — file never overwrites it.
+            assert os.environ["NVIDIA_NIM_API_KEY"] == "from-shell"
+        finally:
+            self._clean_env(["NVIDIA_NIM_API_KEY"])
+
+    def test_project_env_overrides_global(self, tmp_path: Path) -> None:
+        # Precedence: project/.env.local > global/.env.local for the
+        # same key. Matches Vite/Next/dotenv convention.
+        global_dir = tmp_path / "home_godspeed"
+        global_dir.mkdir()
+        (global_dir / ".env.local").write_text("SHARED_KEY=global-value\n")
+
+        project_dir = tmp_path / "project"
+        (project_dir / ".godspeed").mkdir(parents=True)
+        (project_dir / ".godspeed" / ".env.local").write_text(
+            "SHARED_KEY=project-value\nPROJECT_ONLY=x\n"
+        )
+
+        self._clean_env(["SHARED_KEY", "PROJECT_ONLY"])
+        try:
+            with patch("godspeed.cli.DEFAULT_GLOBAL_DIR", global_dir):
+                _load_env_files(project_dir=project_dir)
+            # Project's value wins over global's for the same key.
+            assert os.environ["SHARED_KEY"] == "project-value"
+            # And keys only in project are injected too.
+            assert os.environ["PROJECT_ONLY"] == "x"
+        finally:
+            self._clean_env(["SHARED_KEY", "PROJECT_ONLY"])
+
+    def test_env_precedence_local_wins_over_env(self, tmp_path: Path) -> None:
+        # Within the same directory: .env.local overrides .env.
+        # Matches dotenv convention — .env.local is the gitignored override.
+        global_dir = tmp_path / "home_godspeed"
+        global_dir.mkdir()
+        (global_dir / ".env").write_text("KEY_ONLY_IN_ENV=env-value\nSHARED=from-env\n")
+        (global_dir / ".env.local").write_text("KEY_ONLY_IN_LOCAL=local-value\nSHARED=from-local\n")
+
+        self._clean_env(["KEY_ONLY_IN_ENV", "KEY_ONLY_IN_LOCAL", "SHARED"])
+        try:
+            with patch("godspeed.cli.DEFAULT_GLOBAL_DIR", global_dir):
+                _load_env_files(project_dir=None)
+            assert os.environ["KEY_ONLY_IN_ENV"] == "env-value"
+            assert os.environ["KEY_ONLY_IN_LOCAL"] == "local-value"
+            # .env.local wins for overlapping keys.
+            assert os.environ["SHARED"] == "from-local"
+        finally:
+            self._clean_env(["KEY_ONLY_IN_ENV", "KEY_ONLY_IN_LOCAL", "SHARED"])
+
+    def test_missing_global_dir_is_no_op(self, tmp_path: Path) -> None:
+        # Fresh install with no ~/.godspeed yet — must not crash.
+        global_dir = tmp_path / "does_not_exist"
+        loaded = None
+        with patch("godspeed.cli.DEFAULT_GLOBAL_DIR", global_dir):
+            loaded = _load_env_files(project_dir=None)
+        assert loaded == []
+
+    def test_malformed_file_does_not_raise(self, tmp_path: Path) -> None:
+        # A binary-looking .env.local shouldn't crash startup.
+        global_dir = tmp_path / "home_godspeed"
+        global_dir.mkdir()
+        (global_dir / ".env.local").write_bytes(b"\x00\x01\x02\xff\xfe")
+        with patch("godspeed.cli.DEFAULT_GLOBAL_DIR", global_dir):
+            # Must not raise; caller gets either empty or whatever the
+            # parser salvaged.
+            _load_env_files(project_dir=None)
+
+
+class TestLoadEnvFilesNoValueLeakInLogs:
+    """Guardrail: values must never appear in the info-level log message."""
+
+    def test_log_message_contains_key_not_value(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        global_dir = tmp_path / "home_godspeed"
+        global_dir.mkdir()
+        secret_value = "nvapi-super-secret-do-not-leak-me"
+        (global_dir / ".env.local").write_text(f"NVIDIA_NIM_API_KEY={secret_value}\n")
+
+        os.environ.pop("NVIDIA_NIM_API_KEY", None)
+        try:
+            import logging as _logging
+
+            with (
+                caplog.at_level(_logging.INFO, logger="godspeed.cli"),
+                patch("godspeed.cli.DEFAULT_GLOBAL_DIR", global_dir),
+            ):
+                _load_env_files(project_dir=None)
+
+            full_log = caplog.text
+            assert "NVIDIA_NIM_API_KEY" in full_log  # key logged
+            assert secret_value not in full_log  # value NEVER logged
+        finally:
+            os.environ.pop("NVIDIA_NIM_API_KEY", None)


### PR DESCRIPTION
## Summary

Real root-cause fix for the recurring "first-run auth error" paper cut. API keys saved to `~/.godspeed/.env.local` (or the project's `.godspeed/.env.local`) now reach LiteLLM automatically — no per-shell env configuration required.

## Precedence (highest to lowest)

1. **Shell environment** — always wins. Keys already in `os.environ` are never overwritten. `$env:NVIDIA_NIM_API_KEY = "..."; godspeed` one-offs keep working.
2. `<project>/.godspeed/.env.local`
3. `<project>/.godspeed/.env`
4. `~/.godspeed/.env.local`
5. `~/.godspeed/.env`

Matches dotenv/Vite/Next convention: `.env.local` is the gitignored local override; `.env` is the checked-in default.

## Safety

- Malformed files (binary blob, bad encoding, permission denied) silently skipped — a corrupt `.env.local` cannot brick the CLI.
- **Log messages contain only KEY NAMES, never values.** Regression-tested via `TestLoadEnvFilesNoValueLeakInLogs`.
- Parser handles quoted values, comments, blank lines, whitespace-padded `KEY = value` lines, and values with embedded equals signs (`NVIDIA_NIM_API_KEY=nvapi-a=b=c` works).

## Test plan

- [x] `pytest tests/test_cli_env_loading.py` — 17 new tests pass (parser + loader + shell-wins + precedence + malformed-file safety + no-value-leak-in-logs)
- [x] `pytest tests/test_cli_headless.py tests/test_config.py tests/test_llm_client.py tests/test_agent_loop.py` — 113 passed
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean

## Docs

New section in `docs/troubleshooting.md`: "AuthenticationError: api_key client option must be set" with both the v3.5.0+ fix and the pre-v3.5.0 workaround.

## Files

- Modified: `src/godspeed/cli.py` (new `_parse_env_file` + `_load_env_files`, wired into `main()`), `docs/troubleshooting.md`, `CHANGELOG.md`
- New: `tests/test_cli_env_loading.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)