### PR TITLE
fix(security): resolve ReDoS and quality alerts

### DIFF
--- a/src/godspeed/security/dangerous.py
+++ b/src/godspeed/security/dangerous.py
@@ -12,7 +12,7 @@ import re
 # Compiled patterns for dangerous commands
 DANGEROUS_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # Filesystem destruction
-    (re.compile(r"rm\s+(-[a-zA-Z]*[rf][a-zA-Z]*\s+)*[/~]"), "recursive delete from root/home"),
+    (re.compile(r"rm\s+(?:-[a-zA-Z]{1,20}\s+){0,5}[/~]"), "recursive delete from root/home"),
     (re.compile(r"rm\s+-[a-zA-Z]*[rf]"), "recursive/force delete"),
     (re.compile(r"rm\s+(?:--recursive|--force|--dir)"), "recursive/force delete (long flags)"),
     (re.compile(r"rm\s+-r\s+-f\b"), "recursive force delete (separate flags)"),

--- a/tests/test_memory/test_user_memory.py
+++ b/tests/test_memory/test_user_memory.py
@@ -35,11 +35,13 @@ class TestPreferences:
 
     def test_delete_existing(self, memory: UserMemory) -> None:
         memory.set("key", "value")
-        assert memory.delete("key") is True
+        deleted = memory.delete("key")
+        assert deleted is True
         assert memory.get("key") is None
 
     def test_delete_missing(self, memory: UserMemory) -> None:
-        assert memory.delete("nonexistent") is False
+        deleted = memory.delete("nonexistent")
+        assert deleted is False
 
     def test_list_preferences(self, memory: UserMemory) -> None:
         memory.set("a", "1")


### PR DESCRIPTION
## Security Fixes

### HIGH Severity
- **Fix ReDoS vulnerability** in src/godspeed/security/dangerous.py (Alert #1)
  - Regex m\s+(-[a-zA-Z]*[rf][a-zA-Z]*\s+)*[/~] had exponential backtracking risk
  - Replaced with bounded repetition: m\s+(?:-[a-zA-Z]{1,20}\s+){0,5}[/~]
  - Limits: max 5 flag groups, each flag max 20 characters

### Quality Fixes
- **Fix side-effect asserts** in 	ests/test_memory/test_user_memory.py (Alerts #12-13)
  - Extract return values before asserting to avoid side effects in assert statements

### Notes
- Alerts #2-11 (ineffectual statements) are false positives - ... is valid Python syntax for Protocol/abstract methods
- Alert #14 (import of mutable attribute) was already fixed in previous PR