### PR TITLE
fix: handle inaccessible files in glob_search and grep_search on Windows

### DIFF
--- a/src/godspeed/tools/glob_search.py
+++ b/src/godspeed/tools/glob_search.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from pathlib import Path
 from typing import Any
@@ -87,17 +88,23 @@ class GlobSearchTool(Tool):
 
         logger.info("glob_search pattern=%r root=%s", pattern, search_root)
 
+        def _safe_filter(p: Path) -> bool:
+            """Filter a path, skipping inaccessible files."""
+            try:
+                if not p.is_file():
+                    return False
+                return not is_excluded(p.relative_to(search_root))
+            except (OSError, PermissionError, ValueError):
+                return False
+
         try:
-            matches = [
-                p
-                for p in search_root.glob(pattern)
-                if p.is_file() and not is_excluded(p.relative_to(search_root))
-            ]
+            matches = [p for p in search_root.glob(pattern) if _safe_filter(p)]
         except ValueError as exc:
             return ToolResult.failure(f"Invalid glob pattern: {exc}")
 
-        # Sort by modification time, newest first
-        matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        # Sort by modification time, newest first (skip inaccessible files)
+        with contextlib.suppress(OSError):
+            matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
 
         if not matches:
             return ToolResult.success(f"No files found matching '{pattern}'")

--- a/src/godspeed/tools/grep_search.py
+++ b/src/godspeed/tools/grep_search.py
@@ -164,15 +164,21 @@ class GrepSearchTool(Tool):
         logger.info("grep_search pattern=%r path=%s glob=%r", pattern, search_path, file_glob)
 
         # Collect files to search
-        if search_path.is_file():
-            files = [search_path]
-        else:
-            glob_pattern = file_glob if file_glob else "**/*"
-            files = [
-                p
-                for p in search_path.glob(glob_pattern)
-                if p.is_file() and not is_excluded(p.relative_to(search_path))
-            ]
+        try:
+            if search_path.is_file():
+                files = [search_path]
+            else:
+                glob_pattern = file_glob if file_glob else "**/*"
+
+                def _safe_filter(p: Path) -> bool:
+                    try:
+                        return p.is_file() and not is_excluded(p.relative_to(search_path))
+                    except (OSError, PermissionError, ValueError):
+                        return False
+
+                files = [p for p in search_path.glob(glob_pattern) if _safe_filter(p)]
+        except OSError:
+            files = []
 
         # Search files and collect results
         total_matches = 0


### PR DESCRIPTION
Windows junctions/symlinks (e.g. .venv/lib64) raise OSError 1920 when stat() is called. Wrap is_file() and stat() in try/except to skip inaccessible files gracefully.