### PR TITLE
fix: expand ~ home directory in glob_search, grep_search, and resolve_tool_path

### DIFF
--- a/src/godspeed/tools/glob_search.py
+++ b/src/godspeed/tools/glob_search.py
@@ -69,7 +69,7 @@ class GlobSearchTool(Tool):
         search_root = context.cwd
         path_arg = arguments.get("path")
         if path_arg:
-            candidate = Path(path_arg)
+            candidate = Path(path_arg).expanduser()
             search_root = (
                 candidate.resolve()
                 if candidate.is_absolute()

--- a/src/godspeed/tools/grep_search.py
+++ b/src/godspeed/tools/grep_search.py
@@ -146,7 +146,7 @@ class GrepSearchTool(Tool):
         search_path = context.cwd
         path_arg = arguments.get("path")
         if path_arg:
-            candidate = Path(path_arg)
+            candidate = Path(path_arg).expanduser()
             search_path = (
                 candidate.resolve()
                 if candidate.is_absolute()

--- a/src/godspeed/tools/path_utils.py
+++ b/src/godspeed/tools/path_utils.py
@@ -24,7 +24,7 @@ def resolve_tool_path(file_path: str, cwd: Path) -> Path:
             f"which is outside the project directory '{cwd.resolve()}'"
         )
 
-    path = Path(file_path)
+    path = Path(file_path).expanduser()
     resolved = path.resolve() if path.is_absolute() else (cwd / path).resolve()
     cwd_resolved = cwd.resolve()
 


### PR DESCRIPTION
Path(~) on Windows creates a literal ~ folder instead of expanding to the user's home directory. Added .expanduser() to path resolution in glob_search, grep_search, and resolve_tool_path.