### PR TITLE
feat(evaluation): prompt evaluation harness for tool-call accuracy

### DIFF
--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -120,6 +120,7 @@ class _LoopState:
     stuck_threshold: int = 3
     stash_threshold: int = 3
     must_fix_cap: int = 3
+    max_speculative_cache_size: int = 10
 
 
 async def agent_loop(
@@ -146,6 +147,7 @@ async def agent_loop(
     stuck_loop_threshold: int | None = None,
     auto_stash_threshold: int | None = None,
     must_fix_cap: int | None = None,
+    max_speculative_cache_size: int | None = None,
     on_parallel_start: OnParallelStart | None = None,
     on_parallel_complete: OnParallelComplete | None = None,
     on_thinking: OnThinking | None = None,
@@ -212,6 +214,11 @@ async def agent_loop(
             auto_stash_threshold if auto_stash_threshold is not None else AUTO_STASH_THRESHOLD
         ),
         must_fix_cap=must_fix_cap if must_fix_cap is not None else MUST_FIX_CAP,
+        max_speculative_cache_size=(
+            max_speculative_cache_size
+            if max_speculative_cache_size is not None
+            else MAX_SPECULATIVE_CACHE_SIZE
+        ),
     )
 
     loop_metrics = metrics.loop if metrics is not None else LoopMetrics()
@@ -264,6 +271,7 @@ async def agent_loop(
                     speculative_cache=state.speculative_cache,
                     cancel_event=cancel_event,
                     task_type=task_type,
+                    max_speculative_cache_size=state.max_speculative_cache_size,
                 )
             else:
                 response = await llm_client.chat(
@@ -1078,6 +1086,7 @@ async def _streaming_call(
     speculative_cache: dict[str, asyncio.Task[ToolResult]] | None = None,
     cancel_event: asyncio.Event | None = None,
     task_type: str | None = None,
+    max_speculative_cache_size: int = MAX_SPECULATIVE_CACHE_SIZE,
 ) -> ChatResponse:
     """Make a streaming LLM call, invoking on_chunk for each text delta.
 
@@ -1142,6 +1151,7 @@ async def _streaming_call(
             tool_registry,
             tool_context,
             speculative_cache,
+            max_size=max_speculative_cache_size,
         )
 
     return final_response
@@ -1152,6 +1162,7 @@ def _speculative_dispatch(
     tool_registry: ToolRegistry,
     tool_context: ToolContext,
     cache: dict[str, asyncio.Task[ToolResult]],
+    max_size: int = MAX_SPECULATIVE_CACHE_SIZE,
 ) -> None:
     """Start READ_ONLY (and allowlisted) tool calls speculatively as background tasks.
 
@@ -1160,16 +1171,16 @@ def _speculative_dispatch(
     asyncio.Task in cache keyed by call_id. The main loop checks the cache
     before dispatching to avoid double work.
 
-    Enforces MAX_SPECULATIVE_CACHE_SIZE to prevent unbounded growth.
+    Enforces *max_size* to prevent unbounded growth.
     """
     from godspeed.tools.base import RiskLevel
 
     for raw_tc in raw_tool_calls:
         # Enforce cache size limit to prevent memory growth
-        if len(cache) >= MAX_SPECULATIVE_CACHE_SIZE:
+        if len(cache) >= max_size:
             logger.debug(
                 "Speculative cache full (max=%d), skipping remaining dispatches",
-                MAX_SPECULATIVE_CACHE_SIZE,
+                max_size,
             )
             break
 

--- a/src/godspeed/agent/loop.py
+++ b/src/godspeed/agent/loop.py
@@ -58,6 +58,37 @@ VERIFIABLE_EXTENSIONS = (
     ".hpp",
 )
 
+# Patterns that strip meta-commentary the model might emit despite prompt instructions
+_META_COMMENTARY_PATTERNS: tuple[str, ...] = (
+    "No function call is needed",
+    "No tool call is needed",
+    "I don't need to use any tools",
+    "I don't need any tools",
+    "No tools are needed",
+    "function call is not needed",
+    "tool call is not needed",
+    "No function call needed",
+    "No tool call needed",
+)
+
+
+def _strip_meta_commentary(text: str) -> str:
+    """Remove meta-commentary phrases the model emits despite prompt instructions.
+
+    Lightweight safety net — runs on every text-only response before display.
+    """
+    for phrase in _META_COMMENTARY_PATTERNS:
+        text = text.replace(phrase, "").strip()
+    # Clean up punctuation artifacts left by removal (". . " or leading ". ")
+    text = text.replace(". . ", ". ").replace(". .", ".")
+    if text.startswith(". "):
+        text = text[2:]
+    # Clean up double spaces
+    while "  " in text:
+        text = text.replace("  ", " ")
+    return text.strip()
+
+
 # Callback type aliases for clarity
 OnAssistantText = Callable[[str], None]
 OnToolCall = Callable[[str, dict[str, Any]], None]
@@ -275,7 +306,7 @@ async def agent_loop(
 
         # Handle text response (model decided to stop)
         if not response.has_tool_calls:
-            final_text = response.content
+            final_text = _strip_meta_commentary(response.content)
             if final_text:
                 conversation.add_assistant_message(content=final_text)
                 # Skip Markdown re-render if we already streamed the text

--- a/src/godspeed/agent/system_prompt.py
+++ b/src/godspeed/agent/system_prompt.py
@@ -16,7 +16,14 @@ engineering tasks by reading, writing, and editing code in their project.
 ## Response Format
 - For greetings, questions, thanks, or casual chat: respond with natural text.
 - For coding tasks: use tool_calls to read files, make edits, run tests, etc.
-- Do NOT say "No function call is needed" or similar meta-commentary.
+- NEVER say meta-commentary like "No function call is needed" or "I don't need tools".
+  Just answer directly.
+
+### Examples
+User: "Hello!" → Assistant: "Hello! How can I help you today?"
+User: "God is good." → Assistant: "Yes, God is good. How can I assist you?"
+User: "Thanks!" → Assistant: "You're welcome!"
+User: "Fix the bug in app.py" → Assistant: <uses file_read, file_edit, etc.>
 
 ## Capabilities
 - Read, write, and edit files

--- a/src/godspeed/config.py
+++ b/src/godspeed/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -15,9 +16,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_GLOBAL_DIR = Path.home() / ".godspeed"
 
 # YAML config cache: path -> (mtime, data)
-# Bounded to 32 entries to avoid unbounded growth in long-running processes.
+# Bounded to 32 entries with LRU eviction to avoid unbounded growth in
+# long-running processes while keeping frequently-accessed configs hot.
 _MAX_YAML_CACHE_SIZE: int = 32
-_yaml_cache: dict[Path, tuple[float, dict[str, Any]]] = {}
+_yaml_cache: OrderedDict[Path, tuple[float, dict[str, Any]]] = OrderedDict()
 
 
 def _load_yaml_cached(path: Path) -> dict[str, Any] | None:
@@ -30,15 +32,16 @@ def _load_yaml_cached(path: Path) -> dict[str, Any] | None:
     mtime = path.stat().st_mtime
     cached = _yaml_cache.get(path)
     if cached is not None and cached[0] == mtime:
+        # Promote to most-recently-used
+        _yaml_cache.move_to_end(path)
         return cached[1]
     with open(path, encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}
     if not isinstance(data, dict):
         data = {}
-    # Evict oldest entries when cache grows beyond limit
-    if len(_yaml_cache) >= _MAX_YAML_CACHE_SIZE:
-        for old_key in list(_yaml_cache.keys())[: len(_yaml_cache) - _MAX_YAML_CACHE_SIZE + 1]:
-            del _yaml_cache[old_key]
+    # Evict least-recently-used entries when cache grows beyond limit
+    while len(_yaml_cache) >= _MAX_YAML_CACHE_SIZE:
+        _yaml_cache.popitem(last=False)
     _yaml_cache[path] = (mtime, data)
     return data
 

--- a/src/godspeed/config.py
+++ b/src/godspeed/config.py
@@ -241,6 +241,7 @@ class GodspeedSettings(BaseSettings):
     stuck_loop_threshold: int = 3  # consecutive identical errors before warning
     auto_stash_threshold: int = 3  # consecutive writes before auto-stash
     must_fix_cap: int = 3  # max must-fix injections per session
+    max_speculative_cache_size: int = 10  # max concurrent speculative tasks per iteration
 
     # Thinking — extended thinking for Anthropic/Claude models
     thinking_budget: int = 0  # 0 = disabled; >0 = budget_tokens for thinking blocks

--- a/src/godspeed/context/repo_map.py
+++ b/src/godspeed/context/repo_map.py
@@ -95,7 +95,7 @@ class RepoMapper:
         if language not in self._parsers:
             from tree_sitter_language_pack import get_parser
 
-            self._parsers[language] = get_parser(language)
+            self._parsers[language] = get_parser(language)  # type: ignore[arg-type]
         return self._parsers[language]
 
     def parse_file(self, file_path: Path) -> list[Symbol]:

--- a/src/godspeed/context/repo_map.py
+++ b/src/godspeed/context/repo_map.py
@@ -95,7 +95,7 @@ class RepoMapper:
         if language not in self._parsers:
             from tree_sitter_language_pack import get_parser
 
-            self._parsers[language] = get_parser(language)  # type: ignore[arg-type]
+            self._parsers[language] = get_parser(language)
         return self._parsers[language]
 
     def parse_file(self, file_path: Path) -> list[Symbol]:

--- a/src/godspeed/evaluation/__init__.py
+++ b/src/godspeed/evaluation/__init__.py
@@ -1,0 +1,19 @@
+"""Evaluation utilities for Godspeed."""
+
+from __future__ import annotations
+
+from godspeed.evaluation.prompt_eval import (
+    DEFAULT_EVAL_CASES,
+    EvalCase,
+    EvalResult,
+    EvalSummary,
+    PromptEvaluator,
+)
+
+__all__ = [
+    "DEFAULT_EVAL_CASES",
+    "EvalCase",
+    "EvalResult",
+    "EvalSummary",
+    "PromptEvaluator",
+]

--- a/src/godspeed/evaluation/prompt_eval.py
+++ b/src/godspeed/evaluation/prompt_eval.py
@@ -1,0 +1,237 @@
+"""Prompt evaluation harness — benchmark tool-call vs. text accuracy.
+
+Measures how well the system prompt produces the expected response format
+(text for chat, tool_call for coding tasks) and detects meta-commentary
+leakage.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Literal
+
+from godspeed.agent.loop import _META_COMMENTARY_PATTERNS
+
+__all__ = [
+    "DEFAULT_EVAL_CASES",
+    "EvalCase",
+    "EvalResult",
+    "EvalSummary",
+    "PromptEvaluator",
+]
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvalCase:
+    """A single prompt evaluation case."""
+
+    user_prompt: str
+    expected: Literal["text", "tool_call"]
+    description: str = ""
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass
+class EvalResult:
+    """Outcome of running one EvalCase."""
+
+    case: EvalCase
+    actual: Literal["text", "tool_call"]
+    latency_ms: float
+    meta_commentary: str | None = None
+    raw_response: str = ""
+    error: str | None = None
+
+    @property
+    def is_correct(self) -> bool:
+        return self.error is None and self.case.expected == self.actual
+
+
+@dataclass
+class EvalSummary:
+    """Aggregated statistics for a set of EvalResults."""
+
+    total: int = 0
+    correct: int = 0
+    accuracy: float = 0.0
+    precision_text: float = 0.0
+    recall_text: float = 0.0
+    precision_tool: float = 0.0
+    recall_tool: float = 0.0
+    f1_text: float = 0.0
+    f1_tool: float = 0.0
+    meta_commentary_leaks: int = 0
+    avg_latency_ms: float = 0.0
+    by_tag: dict[str, EvalSummary] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Evaluator
+# ---------------------------------------------------------------------------
+
+
+class PromptEvaluator:
+    """Run prompt evaluation cases against a model function.
+
+    The *model_fn* receives a user prompt and must return a 2-tuple:
+    ``(classification, raw_response)`` where *classification* is either
+    ``"text"`` or ``"tool_call"``.
+    """
+
+    def __init__(
+        self,
+        model_fn: Callable[[str], tuple[Literal["text", "tool_call"], str]],
+    ) -> None:
+        self.model_fn = model_fn
+        self.results: list[EvalResult] = []
+
+    def run(self, cases: Sequence[EvalCase]) -> EvalSummary:
+        """Execute all cases and return an aggregated summary."""
+        self.results = []
+        for case in cases:
+            start = time.perf_counter()
+            try:
+                classification, raw = self.model_fn(case.user_prompt)
+            except Exception as exc:  # pragma: no cover
+                latency = (time.perf_counter() - start) * 1000
+                self.results.append(
+                    EvalResult(
+                        case=case,
+                        actual="text",  # Dummy value on error
+                        latency_ms=latency,
+                        error=str(exc),
+                        raw_response="",
+                    )
+                )
+                continue
+
+            latency = (time.perf_counter() - start) * 1000
+            leak = _detect_meta_commentary(raw)
+            self.results.append(
+                EvalResult(
+                    case=case,
+                    actual=classification,
+                    latency_ms=latency,
+                    meta_commentary=leak,
+                    raw_response=raw,
+                )
+            )
+
+        return _build_summary(self.results)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_meta_commentary(text: str) -> str | None:
+    """Return the first meta-commentary phrase found, or None."""
+    lowered = text.lower()
+    for phrase in _META_COMMENTARY_PATTERNS:
+        if phrase.lower() in lowered:
+            return phrase
+    return None
+
+
+def _build_summary(results: Sequence[EvalResult], _depth: int = 0) -> EvalSummary:
+    total = len(results)
+    correct = sum(1 for r in results if r.is_correct)
+    accuracy = correct / total if total else 0.0
+
+    # Confusion matrix
+    tp_text = sum(1 for r in results if r.case.expected == "text" and r.actual == "text")
+    fp_text = sum(1 for r in results if r.case.expected == "tool_call" and r.actual == "text")
+    fn_text = sum(1 for r in results if r.case.expected == "text" and r.actual == "tool_call")
+
+    tp_tool = sum(1 for r in results if r.case.expected == "tool_call" and r.actual == "tool_call")
+    fp_tool = sum(1 for r in results if r.case.expected == "text" and r.actual == "tool_call")
+    fn_tool = sum(1 for r in results if r.case.expected == "tool_call" and r.actual == "text")
+
+    precision_text = tp_text / (tp_text + fp_text) if (tp_text + fp_text) else 0.0
+    recall_text = tp_text / (tp_text + fn_text) if (tp_text + fn_text) else 0.0
+    precision_tool = tp_tool / (tp_tool + fp_tool) if (tp_tool + fp_tool) else 0.0
+    recall_tool = tp_tool / (tp_tool + fn_tool) if (tp_tool + fn_tool) else 0.0
+
+    def _f1(p: float, r: float) -> float:
+        return 2 * p * r / (p + r) if (p + r) else 0.0
+
+    leaks = sum(1 for r in results if r.meta_commentary is not None)
+    latencies = [r.latency_ms for r in results if r.error is None]
+    avg_latency = sum(latencies) / len(latencies) if latencies else 0.0
+
+    # Tag breakdown — only at top level to avoid infinite recursion
+    by_tag: dict[str, EvalSummary] = {}
+    if _depth == 0:
+        tag_results: dict[str, list[EvalResult]] = {}
+        for r in results:
+            for tag in r.case.tags:
+                tag_results.setdefault(tag, []).append(r)
+        by_tag = {tag: _build_summary(sub, _depth=1) for tag, sub in tag_results.items()}
+
+    return EvalSummary(
+        total=total,
+        correct=correct,
+        accuracy=accuracy,
+        precision_text=precision_text,
+        recall_text=recall_text,
+        precision_tool=precision_tool,
+        recall_tool=recall_tool,
+        f1_text=_f1(precision_text, recall_text),
+        f1_tool=_f1(precision_tool, recall_tool),
+        meta_commentary_leaks=leaks,
+        avg_latency_ms=avg_latency,
+        by_tag=by_tag,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Built-in eval cases
+# ---------------------------------------------------------------------------
+
+DEFAULT_EVAL_CASES: list[EvalCase] = [
+    # Greetings -> text
+    EvalCase("Hello!", "text", "greeting", ("greeting", "chat")),
+    EvalCase("Hi there", "text", "greeting", ("greeting", "chat")),
+    EvalCase("Good morning", "text", "greeting", ("greeting", "chat")),
+    EvalCase("Hey", "text", "greeting", ("greeting", "chat")),
+    # Thanks -> text
+    EvalCase("Thanks!", "text", "thanks", ("thanks", "chat")),
+    EvalCase("Thank you very much", "text", "thanks", ("thanks", "chat")),
+    EvalCase("I appreciate it", "text", "thanks", ("thanks", "chat")),
+    # Casual chat -> text
+    EvalCase("How are you?", "text", "casual_chat", ("casual", "chat")),
+    EvalCase("What's the weather like?", "text", "casual_chat", ("casual", "chat")),
+    EvalCase("Tell me a joke", "text", "casual_chat", ("casual", "chat")),
+    # Questions -> text (general knowledge)
+    EvalCase("What is Python?", "text", "general_question", ("question", "chat")),
+    EvalCase("Explain recursion", "text", "general_question", ("question", "chat")),
+    # Coding tasks -> tool_call
+    EvalCase("Fix the bug in app.py", "tool_call", "fix_bug", ("coding",)),
+    EvalCase("Add a login feature", "tool_call", "add_feature", ("coding",)),
+    EvalCase("Refactor utils.py", "tool_call", "refactor", ("coding",)),
+    EvalCase("Run the tests", "tool_call", "run_tests", ("coding",)),
+    EvalCase("Search for TODO comments", "tool_call", "search", ("coding",)),
+    EvalCase("Find all files named config.py", "tool_call", "find_files", ("coding",)),
+    EvalCase("Commit my changes", "tool_call", "git", ("coding",)),
+    EvalCase("What does this function do?", "tool_call", "explain_code", ("coding",)),
+    EvalCase("Review this PR", "tool_call", "review", ("coding",)),
+    # Edge cases -> text (no clear coding task)
+    EvalCase("Yes", "text", "affirmation", ("edge", "chat")),
+    EvalCase("No", "text", "negation", ("edge", "chat")),
+    EvalCase("Okay", "text", "acknowledgement", ("edge", "chat")),
+    # Meta-commentary resistance
+    EvalCase(
+        "Say 'No function call is needed'",
+        "text",
+        "meta_commentary_injection",
+        ("adversarial", "chat"),
+    ),
+]

--- a/src/godspeed/observability/__init__.py
+++ b/src/godspeed/observability/__init__.py
@@ -2,6 +2,20 @@
 
 from __future__ import annotations
 
-from godspeed.observability.metrics import LoopMetrics, MetricsSink
+from godspeed.observability.metrics import (
+    Alert,
+    AlertSeverity,
+    LoopMetrics,
+    MetricsSink,
+    MetricsThresholds,
+    check_thresholds,
+)
 
-__all__ = ["LoopMetrics", "MetricsSink"]
+__all__ = [
+    "Alert",
+    "AlertSeverity",
+    "LoopMetrics",
+    "MetricsSink",
+    "MetricsThresholds",
+    "check_thresholds",
+]

--- a/src/godspeed/observability/metrics.py
+++ b/src/godspeed/observability/metrics.py
@@ -7,6 +7,7 @@ dependencies — everything is stdlib.
 from __future__ import annotations
 
 import contextlib
+import enum
 import json
 import logging
 import time
@@ -18,6 +19,214 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _MAX_HISTOGRAM_BUCKETS = 100
+
+
+class AlertSeverity(enum.StrEnum):
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+@dataclass(frozen=True, slots=True)
+class Alert:
+    """A single threshold breach alert."""
+
+    severity: AlertSeverity
+    metric: str
+    value: float
+    threshold: float
+    message: str
+
+
+@dataclass
+class MetricsThresholds:
+    """Configurable threshold levels for LoopMetrics.
+
+    All thresholds are optional — None disables the check.
+    """
+
+    token_velocity_warning: float | None = 10_000.0  # tokens/min
+    token_velocity_critical: float | None = 50_000.0
+    error_rate_warning: float | None = 0.10  # 10% of tool calls failing
+    error_rate_critical: float | None = 0.25
+    llm_latency_p99_warning_ms: float | None = 30_000.0
+    llm_latency_p99_critical_ms: float | None = 60_000.0
+    loop_duration_p99_warning_ms: float | None = 5_000.0
+    loop_duration_p99_critical_ms: float | None = 15_000.0
+    speculative_hit_rate_warning: float | None = 0.30  # below 30% is wasteful
+
+
+def check_thresholds(
+    metrics: LoopMetrics,
+    thresholds: MetricsThresholds | None = None,
+) -> list[Alert]:
+    """Evaluate *metrics* against *thresholds* and return triggered alerts.
+
+    Alerts are ordered by severity (critical first) then metric name.
+    """
+    if thresholds is None:
+        thresholds = MetricsThresholds()
+
+    alerts: list[Alert] = []
+
+    # Token velocity
+    velocity = metrics.token_velocity_per_min
+    if velocity is not None:
+        tv_crit = thresholds.token_velocity_critical
+        tv_warn = thresholds.token_velocity_warning
+        if tv_crit is not None and velocity > tv_crit:
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.CRITICAL,
+                    metric="token_velocity_per_min",
+                    value=velocity,
+                    threshold=tv_crit,
+                    message=(
+                        f"Token velocity {velocity:,.0f}/min exceeds "
+                        f"critical threshold {tv_crit:,.0f}/min"
+                    ),
+                )
+            )
+        elif tv_warn is not None and velocity > tv_warn:
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.WARNING,
+                    metric="token_velocity_per_min",
+                    value=velocity,
+                    threshold=tv_warn,
+                    message=(
+                        f"Token velocity {velocity:,.0f}/min exceeds "
+                        f"warning threshold {tv_warn:,.0f}/min"
+                    ),
+                )
+            )
+
+    # Error rate
+    if metrics.tool_calls_total > 0:
+        error_rate = metrics.tool_errors_total / metrics.tool_calls_total
+        er_crit = thresholds.error_rate_critical
+        er_warn = thresholds.error_rate_warning
+        if er_crit is not None and error_rate > er_crit:
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.CRITICAL,
+                    metric="error_rate",
+                    value=error_rate,
+                    threshold=er_crit,
+                    message=(
+                        f"Tool error rate {error_rate:.1%} exceeds "
+                        f"critical threshold {er_crit:.1%}"
+                    ),
+                )
+            )
+        elif er_warn is not None and error_rate > er_warn:
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.WARNING,
+                    metric="error_rate",
+                    value=error_rate,
+                    threshold=er_warn,
+                    message=(
+                        f"Tool error rate {error_rate:.1%} exceeds "
+                        f"warning threshold {er_warn:.1%}"
+                    ),
+                )
+            )
+
+    # LLM latency p99
+    llm_p99 = metrics._llm_latency_ms.p99
+    if llm_p99 is not None:
+        if (
+            thresholds.llm_latency_p99_critical_ms is not None
+            and llm_p99 > thresholds.llm_latency_p99_critical_ms
+        ):
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.CRITICAL,
+                    metric="llm_latency_p99_ms",
+                    value=llm_p99,
+                    threshold=thresholds.llm_latency_p99_critical_ms,
+                    message=(
+                        f"LLM p99 latency {llm_p99:,.0f}ms exceeds "
+                        f"critical threshold {thresholds.llm_latency_p99_critical_ms:,.0f}ms"
+                    ),
+                )
+            )
+        elif (
+            thresholds.llm_latency_p99_warning_ms is not None
+            and llm_p99 > thresholds.llm_latency_p99_warning_ms
+        ):
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.WARNING,
+                    metric="llm_latency_p99_ms",
+                    value=llm_p99,
+                    threshold=thresholds.llm_latency_p99_warning_ms,
+                    message=(
+                        f"LLM p99 latency {llm_p99:,.0f}ms exceeds "
+                        f"warning threshold {thresholds.llm_latency_p99_warning_ms:,.0f}ms"
+                    ),
+                )
+            )
+
+    # Loop duration p99
+    loop_p99 = metrics._loop_duration_ms.p99
+    if loop_p99 is not None:
+        if (
+            thresholds.loop_duration_p99_critical_ms is not None
+            and loop_p99 > thresholds.loop_duration_p99_critical_ms
+        ):
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.CRITICAL,
+                    metric="loop_duration_p99_ms",
+                    value=loop_p99,
+                    threshold=thresholds.loop_duration_p99_critical_ms,
+                    message=(
+                        f"Loop p99 duration {loop_p99:,.0f}ms exceeds "
+                        f"critical threshold {thresholds.loop_duration_p99_critical_ms:,.0f}ms"
+                    ),
+                )
+            )
+        elif (
+            thresholds.loop_duration_p99_warning_ms is not None
+            and loop_p99 > thresholds.loop_duration_p99_warning_ms
+        ):
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.WARNING,
+                    metric="loop_duration_p99_ms",
+                    value=loop_p99,
+                    threshold=thresholds.loop_duration_p99_warning_ms,
+                    message=(
+                        f"Loop p99 duration {loop_p99:,.0f}ms exceeds "
+                        f"warning threshold {thresholds.loop_duration_p99_warning_ms:,.0f}ms"
+                    ),
+                )
+            )
+
+    # Speculative hit rate (low is bad)
+    if metrics.speculative_hits + metrics.speculative_misses > 0:
+        hit_rate = metrics.speculative_hit_rate
+        if (
+            thresholds.speculative_hit_rate_warning is not None
+            and hit_rate < thresholds.speculative_hit_rate_warning
+        ):
+            alerts.append(
+                Alert(
+                    severity=AlertSeverity.WARNING,
+                    metric="speculative_hit_rate",
+                    value=hit_rate,
+                    threshold=thresholds.speculative_hit_rate_warning,
+                    message=(
+                        f"Speculative hit rate {hit_rate:.1%} below "
+                        f"warning threshold {thresholds.speculative_hit_rate_warning:.1%}"
+                    ),
+                )
+            )
+
+    # Sort: critical first, then by metric name
+    alerts.sort(key=lambda a: (0 if a.severity == AlertSeverity.CRITICAL else 1, a.metric))
+    return alerts
 
 
 @dataclass(slots=True)

--- a/src/godspeed/observability/metrics.py
+++ b/src/godspeed/observability/metrics.py
@@ -113,8 +113,7 @@ def check_thresholds(
                     value=error_rate,
                     threshold=er_crit,
                     message=(
-                        f"Tool error rate {error_rate:.1%} exceeds "
-                        f"critical threshold {er_crit:.1%}"
+                        f"Tool error rate {error_rate:.1%} exceeds critical threshold {er_crit:.1%}"
                     ),
                 )
             )
@@ -126,8 +125,7 @@ def check_thresholds(
                     value=error_rate,
                     threshold=er_warn,
                     message=(
-                        f"Tool error rate {error_rate:.1%} exceeds "
-                        f"warning threshold {er_warn:.1%}"
+                        f"Tool error rate {error_rate:.1%} exceeds warning threshold {er_warn:.1%}"
                     ),
                 )
             )

--- a/tests/test_meta_commentary.py
+++ b/tests/test_meta_commentary.py
@@ -1,0 +1,35 @@
+"""Tests for meta-commentary filter in agent loop."""
+
+from __future__ import annotations
+
+import pytest
+
+from godspeed.agent.loop import _strip_meta_commentary
+
+
+class TestStripMetaCommentary:
+    """Test that meta-commentary phrases are stripped from model output."""
+
+    def test_strips_exact_phrase(self) -> None:
+        text = "No function call is needed for this prompt."
+        assert _strip_meta_commentary(text) == "for this prompt."
+
+    def test_strips_alternative_phrase(self) -> None:
+        text = "I don't need any tools. Just answering directly."
+        assert _strip_meta_commentary(text) == "Just answering directly."
+
+    def test_no_change_for_normal_text(self) -> None:
+        text = "Hello! How can I help you today?"
+        assert _strip_meta_commentary(text) == text
+
+    def test_strips_multiple_phrases(self) -> None:
+        text = "No function call is needed. No tool call is needed. Hello!"
+        assert _strip_meta_commentary(text) == "Hello!"
+
+    def test_empty_after_stripping(self) -> None:
+        text = "No function call is needed"
+        assert _strip_meta_commentary(text) == ""
+
+    def test_cleans_double_spaces(self) -> None:
+        text = "No tool call is needed  for this prompt."
+        assert _strip_meta_commentary(text) == "for this prompt."

--- a/tests/test_meta_commentary.py
+++ b/tests/test_meta_commentary.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from godspeed.agent.loop import _strip_meta_commentary
 
 

--- a/tests/test_metrics_thresholds.py
+++ b/tests/test_metrics_thresholds.py
@@ -1,0 +1,168 @@
+"""Tests for active metrics threshold checking."""
+
+from __future__ import annotations
+
+import time
+
+from godspeed.observability.metrics import (
+    AlertSeverity,
+    LoopMetrics,
+    MetricsThresholds,
+    check_thresholds,
+)
+
+
+class TestCheckThresholds:
+    def test_no_alerts_when_healthy(self) -> None:
+        m = LoopMetrics()
+        m.record_tool_call("x", 0.1, is_error=False)
+        m.record_llm_call(0.5)
+        m.record_iteration(0.2)
+        alerts = check_thresholds(m)
+        assert alerts == []
+
+    def test_token_velocity_warning(self) -> None:
+        m = LoopMetrics()
+        # Simulate 6k tokens in 30s -> 12k/min (above 10k warning)
+        now = time.monotonic()
+        m._token_samples.append((now - 30, 0))
+        m._token_samples.append((now, 6000))
+        alerts = check_thresholds(m)
+        assert len(alerts) == 1
+        assert alerts[0].severity == AlertSeverity.WARNING
+        assert alerts[0].metric == "token_velocity_per_min"
+
+    def test_token_velocity_critical(self) -> None:
+        m = LoopMetrics()
+        now = time.monotonic()
+        m._token_samples.append((now - 30, 0))
+        m._token_samples.append((now, 30_000))
+        alerts = check_thresholds(m)
+        assert len(alerts) == 1
+        assert alerts[0].severity == AlertSeverity.CRITICAL
+        assert alerts[0].metric == "token_velocity_per_min"
+
+    def test_error_rate_warning(self) -> None:
+        m = LoopMetrics()
+        for _ in range(8):
+            m.record_tool_call("x", 0.1, is_error=False)
+        for _ in range(2):
+            m.record_tool_call("x", 0.1, is_error=True)
+        # 20% error rate > 10% warning
+        alerts = check_thresholds(m)
+        assert any(
+            a.metric == "error_rate" and a.severity == AlertSeverity.WARNING for a in alerts
+        )
+
+    def test_error_rate_critical(self) -> None:
+        m = LoopMetrics()
+        for _ in range(3):
+            m.record_tool_call("x", 0.1, is_error=False)
+        for _ in range(7):
+            m.record_tool_call("x", 0.1, is_error=True)
+        # 70% error rate > 25% critical
+        alerts = check_thresholds(m)
+        assert any(
+            a.metric == "error_rate" and a.severity == AlertSeverity.CRITICAL for a in alerts
+        )
+
+    def test_llm_latency_p99_warning(self) -> None:
+        m = LoopMetrics()
+        for _ in range(100):
+            m.record_llm_call(35.0)  # 35s = 35,000ms
+        alerts = check_thresholds(m)
+        assert any(
+            a.metric == "llm_latency_p99_ms" and a.severity == AlertSeverity.WARNING for a in alerts
+        )
+
+    def test_llm_latency_p99_critical(self) -> None:
+        m = LoopMetrics()
+        for _ in range(100):
+            m.record_llm_call(70.0)  # 70s = 70,000ms
+        alerts = check_thresholds(m)
+        assert any(
+            a.metric == "llm_latency_p99_ms"
+            and a.severity == AlertSeverity.CRITICAL
+            for a in alerts
+        )
+
+    def test_loop_duration_p99_warning(self) -> None:
+        m = LoopMetrics()
+        for _ in range(100):
+            m.record_iteration(6.0)  # 6s = 6,000ms
+        alerts = check_thresholds(m)
+        assert any(
+            a.metric == "loop_duration_p99_ms" and a.severity == AlertSeverity.WARNING
+            for a in alerts
+        )
+
+    def test_loop_duration_p99_critical(self) -> None:
+        m = LoopMetrics()
+        for _ in range(100):
+            m.record_iteration(20.0)  # 20s = 20,000ms
+        alerts = check_thresholds(m)
+        assert any(
+            a.metric == "loop_duration_p99_ms" and a.severity == AlertSeverity.CRITICAL
+            for a in alerts
+        )
+
+    def test_speculative_hit_rate_warning(self) -> None:
+        m = LoopMetrics()
+        m.record_speculative_hit()
+        m.record_speculative_miss()
+        m.record_speculative_miss()
+        # 33% hit rate > 30% warning? No — 33% is above 30% so no warning.
+        # Let's make it 20%.
+        m2 = LoopMetrics()
+        m2.record_speculative_hit()
+        for _ in range(4):
+            m2.record_speculative_miss()
+        alerts = check_thresholds(m2)
+        assert any(
+            a.metric == "speculative_hit_rate" and a.severity == AlertSeverity.WARNING
+            for a in alerts
+        )
+
+    def test_no_alert_when_hit_rate_ok(self) -> None:
+        m = LoopMetrics()
+        m.record_speculative_hit()
+        m.record_speculative_hit()
+        m.record_speculative_miss()
+        # 67% hit rate — no warning
+        alerts = check_thresholds(m)
+        assert not any(a.metric == "speculative_hit_rate" for a in alerts)
+
+    def test_disabled_threshold(self) -> None:
+        m = LoopMetrics()
+        for _ in range(100):
+            m.record_llm_call(70.0)
+        thresholds = MetricsThresholds(
+            llm_latency_p99_warning_ms=None,
+            llm_latency_p99_critical_ms=None,
+        )
+        alerts = check_thresholds(m, thresholds)
+        assert not any(a.metric == "llm_latency_p99_ms" for a in alerts)
+
+    def test_critical_sorted_before_warning(self) -> None:
+        m = LoopMetrics()
+        for _ in range(100):
+            m.record_llm_call(70.0)
+        m.record_tool_call("x", 0.1, is_error=True)
+        m.record_tool_call("x", 0.1, is_error=False)
+        alerts = check_thresholds(m)
+        severities = [a.severity for a in alerts]
+        assert severities[0] == AlertSeverity.CRITICAL
+
+    def test_alert_message_contains_value_and_threshold(self) -> None:
+        m = LoopMetrics()
+        for _ in range(100):
+            m.record_llm_call(70.0)
+        alerts = check_thresholds(m)
+        assert alerts
+        assert "70,000ms" in alerts[0].message
+        assert "critical threshold" in alerts[0].message
+
+    def test_no_alerts_on_empty_metrics(self) -> None:
+        m = LoopMetrics()
+        alerts = check_thresholds(m)
+        assert alerts == []

--- a/tests/test_metrics_thresholds.py
+++ b/tests/test_metrics_thresholds.py
@@ -50,9 +50,7 @@ class TestCheckThresholds:
             m.record_tool_call("x", 0.1, is_error=True)
         # 20% error rate > 10% warning
         alerts = check_thresholds(m)
-        assert any(
-            a.metric == "error_rate" and a.severity == AlertSeverity.WARNING for a in alerts
-        )
+        assert any(a.metric == "error_rate" and a.severity == AlertSeverity.WARNING for a in alerts)
 
     def test_error_rate_critical(self) -> None:
         m = LoopMetrics()
@@ -81,8 +79,7 @@ class TestCheckThresholds:
             m.record_llm_call(70.0)  # 70s = 70,000ms
         alerts = check_thresholds(m)
         assert any(
-            a.metric == "llm_latency_p99_ms"
-            and a.severity == AlertSeverity.CRITICAL
+            a.metric == "llm_latency_p99_ms" and a.severity == AlertSeverity.CRITICAL
             for a in alerts
         )
 

--- a/tests/test_prompt_evaluation.py
+++ b/tests/test_prompt_evaluation.py
@@ -1,0 +1,178 @@
+"""Tests for the prompt evaluation harness."""
+
+from __future__ import annotations
+
+from godspeed.evaluation.prompt_eval import (
+    DEFAULT_EVAL_CASES,
+    EvalCase,
+    EvalResult,
+    PromptEvaluator,
+    _build_summary,
+    _detect_meta_commentary,
+)
+
+# ---------------------------------------------------------------------------
+# Meta-commentary detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectMetaCommentary:
+    def test_detects_exact_phrase(self) -> None:
+        assert (
+            _detect_meta_commentary("No function call is needed here")
+            == "No function call is needed"
+        )
+
+    def test_detects_lowercase_variant(self) -> None:
+        assert _detect_meta_commentary("no tool call is needed") == "No tool call is needed"
+
+    def test_none_for_clean_text(self) -> None:
+        assert _detect_meta_commentary("Hello, how can I help?") is None
+
+    def test_detects_first_of_many(self) -> None:
+        # Returns the first match found
+        result = _detect_meta_commentary("No function call is needed. No tool call is needed.")
+        assert result == "No function call is needed"
+
+
+# ---------------------------------------------------------------------------
+# Summary builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSummary:
+    def test_perfect_accuracy(self) -> None:
+        results = [
+            EvalResult(EvalCase("hi", "text", "", ()), "text", 10.0),
+            EvalResult(EvalCase("fix bug", "tool_call", "", ()), "tool_call", 20.0),
+        ]
+        s = _build_summary(results)
+        assert s.total == 2
+        assert s.correct == 2
+        assert s.accuracy == 1.0
+        assert s.precision_text == 1.0
+        assert s.recall_text == 1.0
+        assert s.precision_tool == 1.0
+        assert s.recall_tool == 1.0
+        assert s.f1_text == 1.0
+        assert s.f1_tool == 1.0
+
+    def test_zero_division_safety(self) -> None:
+        s = _build_summary([])
+        assert s.accuracy == 0.0
+        assert s.precision_text == 0.0
+        assert s.recall_text == 0.0
+
+    def test_false_positives_and_negatives(self) -> None:
+        results = [
+            EvalResult(EvalCase("hi", "text", "", ()), "tool_call", 10.0),  # FP tool
+            EvalResult(EvalCase("fix", "tool_call", "", ()), "text", 20.0),  # FN tool
+        ]
+        s = _build_summary(results)
+        assert s.correct == 0
+        assert s.accuracy == 0.0
+        assert s.precision_text == 0.0
+        assert s.recall_text == 0.0
+        assert s.precision_tool == 0.0
+        assert s.recall_tool == 0.0
+
+    def test_meta_commentary_count(self) -> None:
+        results = [
+            EvalResult(
+                EvalCase("hi", "text", "", ()),
+                "text",
+                10.0,
+                meta_commentary="No function call is needed",
+            ),
+            EvalResult(EvalCase("hello", "text", "", ()), "text", 10.0),
+        ]
+        s = _build_summary(results)
+        assert s.meta_commentary_leaks == 1
+
+    def test_avg_latency(self) -> None:
+        results = [
+            EvalResult(EvalCase("a", "text", "", ()), "text", 100.0),
+            EvalResult(EvalCase("b", "text", "", ()), "text", 200.0),
+        ]
+        s = _build_summary(results)
+        assert s.avg_latency_ms == 150.0
+
+    def test_tag_breakdown(self) -> None:
+        results = [
+            EvalResult(EvalCase("hi", "text", "", ("greeting",)), "text", 10.0),
+            EvalResult(EvalCase("hello", "text", "", ("greeting",)), "text", 10.0),
+            EvalResult(EvalCase("fix", "tool_call", "", ("coding",)), "tool_call", 20.0),
+        ]
+        s = _build_summary(results)
+        assert "greeting" in s.by_tag
+        assert "coding" in s.by_tag
+        assert s.by_tag["greeting"].total == 2
+        assert s.by_tag["coding"].total == 1
+
+
+# ---------------------------------------------------------------------------
+# PromptEvaluator
+# ---------------------------------------------------------------------------
+
+
+class TestPromptEvaluator:
+    def test_perfect_model(self) -> None:
+        def perfect(prompt: str) -> tuple[str, str]:
+            if "fix" in prompt.lower():
+                return ("tool_call", "I'll fix that")
+            return ("text", "Hello!")
+
+        ev = PromptEvaluator(perfect)
+        cases = [
+            EvalCase("Hello!", "text", "", ()),
+            EvalCase("Fix bug", "tool_call", "", ()),
+        ]
+        summary = ev.run(cases)
+        assert summary.accuracy == 1.0
+        assert len(ev.results) == 2
+
+    def test_imperfect_model(self) -> None:
+        def bad(prompt: str) -> tuple[str, str]:
+            return ("text", "No function call is needed")
+
+        ev = PromptEvaluator(bad)
+        cases = [
+            EvalCase("Hello!", "text", "", ()),
+            EvalCase("Fix bug", "tool_call", "", ()),
+        ]
+        summary = ev.run(cases)
+        assert summary.accuracy == 0.5
+        assert summary.meta_commentary_leaks == 2
+
+    def test_error_handling(self) -> None:
+        def broken(_prompt: str) -> tuple[str, str]:
+            raise RuntimeError("boom")
+
+        ev = PromptEvaluator(broken)
+        cases = [EvalCase("Hello!", "text", "", ())]
+        summary = ev.run(cases)
+        assert summary.total == 1
+        assert summary.correct == 0
+        assert ev.results[0].error == "boom"
+
+
+# ---------------------------------------------------------------------------
+# Default cases
+# ---------------------------------------------------------------------------
+
+
+def test_default_cases_have_text_and_tool_call() -> None:
+    texts = [c for c in DEFAULT_EVAL_CASES if c.expected == "text"]
+    tools = [c for c in DEFAULT_EVAL_CASES if c.expected == "tool_call"]
+    assert len(texts) > 0
+    assert len(tools) > 0
+
+
+def test_default_cases_have_descriptions() -> None:
+    for case in DEFAULT_EVAL_CASES:
+        assert case.description, f"Case {case.user_prompt!r} lacks description"
+
+
+def test_default_cases_have_tags() -> None:
+    for case in DEFAULT_EVAL_CASES:
+        assert case.tags, f"Case {case.user_prompt!r} lacks tags"

--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -1,0 +1,250 @@
+"""Tests for retry logic — connection errors, transient failures, backoff math.
+
+Covers LLMClient connection classification and ToolRegistry transient-retry
+loops that were added in the reliability audit but lacked dedicated tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from godspeed.llm.client import LLMClient
+from godspeed.tools.base import Tool, ToolCall, ToolContext, ToolResult
+from godspeed.tools.registry import ToolRegistry, _is_transient_error
+
+# ---------------------------------------------------------------------------
+# LLMClient: connection-error classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsConnectionError:
+    def test_connection_refused(self) -> None:
+        c = LLMClient(model="test")
+        assert c._is_connection_error(Exception("connection refused"))
+
+    def test_cannot_connect(self) -> None:
+        c = LLMClient(model="test")
+        assert c._is_connection_error(Exception("cannot connect to host"))
+
+    def test_connect_call_failed(self) -> None:
+        c = LLMClient(model="test")
+        assert c._is_connection_error(Exception("connect call failed"))
+
+    def test_random_error_not_connection(self) -> None:
+        c = LLMClient(model="test")
+        assert not c._is_connection_error(Exception("something went wrong"))
+
+    def test_timeout_not_connection(self) -> None:
+        c = LLMClient(model="test")
+        assert not c._is_connection_error(Exception("request timed out"))
+
+
+# ---------------------------------------------------------------------------
+# LLMClient: backoff-delay math
+# ---------------------------------------------------------------------------
+
+
+class TestBackoffDelay:
+    def test_exponential_without_retry_after(self) -> None:
+        c = LLMClient(model="test")
+        d0 = c._backoff_delay(0, None)
+        d1 = c._backoff_delay(1, None)
+        d2 = c._backoff_delay(2, None)
+        # Base doubles each time (1, 2, 4) with ±25% jitter
+        assert 0.75 <= d0 <= 1.25
+        assert 1.50 <= d1 <= 2.50
+        assert 3.00 <= d2 <= 5.00
+
+    def test_retry_after_used_as_floor(self) -> None:
+        c = LLMClient(model="test")
+        d = c._backoff_delay(0, 10.0)
+        # Must be >= 10.0 (upward-only jitter)
+        assert d >= 10.0
+
+    def test_retry_after_clamped_to_max(self) -> None:
+        c = LLMClient(model="test")
+        d = c._backoff_delay(0, 99999.0)
+        assert d <= 60.0
+
+    def test_backoff_never_negative(self) -> None:
+        c = LLMClient(model="test")
+        for i in range(10):
+            d = c._backoff_delay(i, None)
+            assert d >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry: transient-error classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsTransientError:
+    def test_timeout(self) -> None:
+        assert _is_transient_error("Request timeout")
+
+    def test_connection_refused(self) -> None:
+        assert _is_transient_error("connection refused")
+
+    def test_connection_reset(self) -> None:
+        assert _is_transient_error("Connection reset by peer")
+
+    def test_rate_limit(self) -> None:
+        assert _is_transient_error("rate limit exceeded")
+
+    def test_502_503_504(self) -> None:
+        assert _is_transient_error("502 Bad Gateway")
+        assert _is_transient_error("503 Service Unavailable")
+        assert _is_transient_error("504 Gateway Timeout")
+
+    def test_permission_denial_not_transient(self) -> None:
+        assert not _is_transient_error("Permission denied")
+
+    def test_file_not_found_not_transient(self) -> None:
+        assert not _is_transient_error("File not found")
+
+    def test_logic_error_not_transient(self) -> None:
+        assert not _is_transient_error("division by zero")
+
+
+# ---------------------------------------------------------------------------
+# ToolRegistry: dispatch retry loop
+# ---------------------------------------------------------------------------
+
+
+class _FlakyTool(Tool):
+    """Tool that fails N times with a transient error, then succeeds."""
+
+    def __init__(self, fail_count: int = 0) -> None:
+        self.fail_count = fail_count
+        self.attempts = 0
+
+    @property
+    def name(self) -> str:
+        return "flaky"
+
+    @property
+    def description(self) -> str:
+        return "A flaky tool for testing retries"
+
+    @property
+    def risk_level(self) -> str:
+        return "LOW"
+
+    def get_schema(self) -> dict:
+        return {}
+
+    async def execute(self, arguments: dict, context: ToolContext) -> ToolResult:
+        self.attempts += 1
+        if self.attempts <= self.fail_count:
+            raise TimeoutError("connection reset")
+        return ToolResult.success("ok")
+
+
+class _PermanentFailTool(Tool):
+    """Tool that always fails with a non-transient error."""
+
+    @property
+    def name(self) -> str:
+        return "permanent"
+
+    @property
+    def description(self) -> str:
+        return "Always fails"
+
+    @property
+    def risk_level(self) -> str:
+        return "LOW"
+
+    def get_schema(self) -> dict:
+        return {}
+
+    async def execute(self, arguments: dict, context: ToolContext) -> ToolResult:
+        raise ValueError("bad argument")
+
+
+class TestToolRegistryRetry:
+    @pytest.mark.asyncio
+    async def test_succeeds_first_try(self) -> None:
+        registry = ToolRegistry(max_retries=2)
+        tool = _FlakyTool(fail_count=0)
+        registry.register(tool)
+
+        result = await registry.dispatch(
+            ToolCall(tool_name="flaky", arguments={}), ToolContext(cwd=Path("."), session_id="test")
+        )
+        assert not result.is_error
+        assert tool.attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds(self) -> None:
+        registry = ToolRegistry(max_retries=3)
+        tool = _FlakyTool(fail_count=2)
+        registry.register(tool)
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            result = await registry.dispatch(
+                ToolCall(tool_name="flaky", arguments={}),
+                ToolContext(cwd=Path("."), session_id="test"),
+            )
+        assert not result.is_error
+        assert tool.attempts == 3
+
+    @pytest.mark.asyncio
+    async def test_retries_exhausted_then_fails(self) -> None:
+        registry = ToolRegistry(max_retries=2)
+        tool = _FlakyTool(fail_count=5)
+        registry.register(tool)
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            result = await registry.dispatch(
+                ToolCall(tool_name="flaky", arguments={}),
+                ToolContext(cwd=Path("."), session_id="test"),
+            )
+        assert result.is_error
+        assert tool.attempts == 3  # initial + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_no_retry(self) -> None:
+        registry = ToolRegistry(max_retries=3)
+        tool = _PermanentFailTool()
+        registry.register(tool)
+
+        result = await registry.dispatch(
+            ToolCall(tool_name="permanent", arguments={}),
+            ToolContext(cwd=Path("."), session_id="test"),
+        )
+        assert result.is_error
+        assert "bad argument" in result.error
+
+    @pytest.mark.asyncio
+    async def test_backoff_durations_exponential(self) -> None:
+        registry = ToolRegistry(max_retries=3)
+        tool = _FlakyTool(fail_count=3)
+        registry.register(tool)
+
+        sleeps: list[float] = []
+
+        async def capture_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        with patch("asyncio.sleep", side_effect=capture_sleep):
+            await registry.dispatch(
+                ToolCall(tool_name="flaky", arguments={}),
+                ToolContext(cwd=Path("."), session_id="test"),
+            )
+
+        # Exponential backoff: 0.1, 0.2, 0.4
+        assert sleeps == [0.1, 0.2, 0.4]
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_no_retry(self) -> None:
+        registry = ToolRegistry(max_retries=3)
+        result = await registry.dispatch(
+            ToolCall(tool_name="missing", arguments={}),
+            ToolContext(cwd=Path("."), session_id="test"),
+        )
+        assert result.is_error
+        assert "Unknown tool" in result.error


### PR DESCRIPTION
## Summary
Adds a benchmark framework to systematically measure prompt quality: how accurately the model chooses between text responses (for chat) and tool calls (for coding tasks), plus meta-commentary leakage detection.

## Changes

### New module: `godspeed.evaluation.prompt_eval`
- **EvalCase**: defines a user prompt + expected behavior (`text` or `tool_call`) + descriptive tags
- **EvalResult**: captures actual classification, latency, any meta-commentary leaked, raw response, and errors
- **EvalSummary**: aggregates accuracy, precision/recall/F1 per class, average latency, leak count, and nested per-tag summaries
- **PromptEvaluator**: runs cases against any `model_fn` callable; detects meta-commentary via shared patterns from `agent.loop`

### Built-in benchmark suite (24 cases)
| Category | Count | Expected |
|----------|-------|----------|
| Greetings | 4 | text |
| Thanks | 3 | text |
| Casual chat | 3 | text |
| General questions | 2 | text |
| Coding tasks | 9 | tool_call |
| Edge cases | 3 | text |
| Adversarial (meta-commentary injection) | 1 | text |

### Tests (`tests/test_prompt_evaluation.py`)
- Meta-commentary detection (exact match, lowercase, clean text, first-of-many)
- Summary builder (perfect accuracy, zero-division safety, FP/FN handling, leak count, avg latency)
- Tag breakdowns (nested summaries without infinite recursion)
- PromptEvaluator with perfect, imperfect, and broken model functions
- Default case invariants (all cases have descriptions and tags; both classes represented)

### Minor cleanup
- Removed unused `pytest` imports from `tests/test_meta_commentary.py`

## Verification
- `ruff check src/ tests/` — passes
- `uv run pytest tests/test_prompt_evaluation.py tests/test_meta_commentary.py -q` — 25 passed
