### PR TITLE
docs: add GitHub Discussions link to README (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 A coding agent you can point at a production codebase and trust. Built-in permissions, audit trails, schema-validated tool calls, and automatic retries — so the agent writes safe code without babysitting.
 
-[Getting Started](#getting-started) | [Features](#features) | [Architecture](#architecture) | [Configuration](#configuration) | [Contributing](CONTRIBUTING.md)
+[Getting Started](#getting-started) | [Features](#features) | [Architecture](#architecture) | [Configuration](#configuration) | [Discussions](https://github.com/omnipotence-eth/godspeed-coding-agent/discussions) | [Contributing](CONTRIBUTING.md)
 
 </div>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ This roadmap describes the path from the current Alpha to a stable v1.0 release.
 
 **Goal:** Build trust through external usage, gather feedback, and establish governance.
 
-- [ ] Enable GitHub Discussions for informal feedback
+- [x] Enable GitHub Discussions for informal feedback
 - [ ] File `good first issue` items to guide new contributors
 - [ ] Add VS Code extension (basic: send prompt, display tool calls, diff viewer)
 - [ ] Improve error messages and onboarding (first-run wizard, `--tutorial` flag)


### PR DESCRIPTION
## Summary
This prepares the repository for GitHub Discussions as outlined in #136. 

Since I do not have admin access to flip the toggle in Settings > General, this PR handles the codebase updates:
* Added a link to the Discussions tab in the README navigation bar.
* Checked off the Phase 2 roadmap item.

Once an admin enables the Discussions feature in the repo settings and pins the welcome post, this PR can be merged to expose the link to users!

Closes #136