### PR TITLE
chore(release): bump version to 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.1] — 2026-05-01
+
 ### Added
 
 - **Auto-load `~/.godspeed/.env.local` on startup** (`cli._load_env_files`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed-coding-agent"
-version = "3.4.0"
+version = "3.4.1"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"


### PR DESCRIPTION
Version bump: 3.4.0 → 3.4.1. Tag v3.4.1 already pushed.