### PR TITLE
fix(version): reset project version to v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.4.1] — 2026-05-01
+## [0.4.0] — 2026-05-01
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.1] — 2026-05-01
+
 ### Added
 
 - **Auto-load `~/.godspeed/.env.local` on startup** (`cli._load_env_files`).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A coding agent you can point at a production codebase and trust. Built-in permis
 
 ---
 
-## What's new in v3.4.1
+## What's new in v0.4.0
 
 Five additions on top of the security-first core. Every one shipped with
 tests + CI-green across Python 3.11 / 3.12 / 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed-coding-agent"
-version = "3.4.0"
+version = "3.4.1"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godspeed-coding-agent"
-version = "3.4.1"
+version = "0.4.0"
 description = "Security-first open-source coding agent with parallel tool execution, multimodal input, 4-tier permissions, audit trails, and 200+ LLM provider support"
 readme = "README.md"
 license = "MIT"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"

--- a/src/godspeed/__init__.py
+++ b/src/godspeed/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "3.4.1"
+__version__ = "0.4.0"


### PR DESCRIPTION
Aligns version numbering with actual project maturity. Previous v2/v3 tags were internal development markers, not public releases.