### PR TITLE
feat(tui): enhance welcome banner with config summary (dir, tools, deny rules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bash-only SWE-bench agent loop** (`experiments/swebench_lite/run_in_loop.sh`) —
   Pure-bash agent runner using curl + jq for tool dispatch. Zero Python
   framework dependency for the agent loop itself.
+- **Enhanced TUI welcome banner** — Session start now displays project
+  directory, registered tool count, and deny rule count alongside the
+  existing version, model, and permission mode. The banner gives users
+  immediate visibility into the session configuration without needing
+  to run `/tools` or `/permissions`.
 
 ### Fixed
 

--- a/src/godspeed/tui/app.py
+++ b/src/godspeed/tui/app.py
@@ -229,11 +229,21 @@ class TUIApp:
         tool_errors = 0
         tool_denied = 0
 
-        # Display welcome without tools/deny-rules clutter
+        # Display welcome with config summary
+        tool_names = (
+            [t.name for t in self._tool_registry.list_tools()] if self._tool_registry else None
+        )
+        deny_patterns = (
+            [r.pattern for r in self._permission_engine.deny_rules]
+            if self._permission_engine
+            else None
+        )
         format_welcome(
             model=self._llm_client.model,
             project_dir=str(self._tool_context.cwd),
             permission_mode=self._get_permission_mode(),
+            tools=tool_names,
+            deny_rules=deny_patterns,
         )
 
         try:

--- a/src/godspeed/tui/output.py
+++ b/src/godspeed/tui/output.py
@@ -744,6 +744,20 @@ def format_welcome(
         line += f"  {styled(f'[{mode_str}]', DIM)}"
     console.print(line)
 
+    # Project directory
+    console.print(f"  dir: {styled(project_dir, DIM)}")
+
+    # Tools and rules summary
+    config_parts: list[str] = []
+    if tools is not None:
+        config_parts.append(f"{len(tools)} tools")
+    if deny_rules is not None:
+        config_parts.append(
+            f"{len(deny_rules)} deny rules" if len(deny_rules) > 0 else "no deny rules"
+        )
+    if config_parts:
+        console.print(f"  config: {styled(' | '.join(config_parts), DIM)}")
+
     # Top commands hint
     console.print(f"  {styled('/help /clear /quit', DIM)}")
 


### PR DESCRIPTION
## Summary

Enhances the TUI welcome banner displayed at session start to show configuration details:

- **Project directory** -- visible at a glance, especially important when running with `--project`
- **Tool count** -- how many tools are registered in the current session
- **Deny rule count** -- visibility into the security posture from the first screen

### Files changed

- `src/godspeed/tui/output.py` -- format_welcome() now renders dir, tool count, and deny rule count
- `src/godspeed/tui/app.py` -- passes tool_names and deny_patterns to format_welcome()
- `CHANGELOG.md` -- [Unreleased] entry

### Verification

- ruff check -- clean
- ruff format -- clean
- mypy -- no issues
- pytest -k welcome or output -- 132 passed, 1 skipped
