### PR TITLE
fix(deps): bump python-multipart 0.0.26 -> 0.0.27 (CVE-2026-42561)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,7 @@ jobs:
       # litellm pins python-dotenv==1.0.1 strictly, making a pin-up
       # unsatisfiable. Remove this ignore when litellm relaxes its
       # bound (tracked in pyproject.toml dependencies block).
-      # CVE-2026-42561 (python-multipart 0.0.26) is suppressed:
-      # fastapi pins python-multipart==0.0.26 strictly, upstream fix
-      # not yet released in a compatible combination.
-      - run: uv run pip-audit --ignore-vuln CVE-2026-28684 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-42561
+      - run: uv run pip-audit --ignore-vuln CVE-2026-28684 --ignore-vuln CVE-2026-3219
       - run: uv run bandit -r src/ -ll -s B310,B104
 
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "yfinance>=1.3.0",
     "readability-lxml>=0.8.4.1",
     "mcp>=1.27.0,<2.0",
+    "python-multipart==0.0.27",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1093,6 +1093,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "readability-lxml" },
     { name = "rich" },
@@ -1152,11 +1153,12 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0,<8.0" },
+    { name = "python-multipart", specifier = "==0.0.27" },
     { name = "pyyaml", specifier = ">=6.0.3,<7.0" },
     { name = "readability-lxml", specifier = ">=0.8.4.1" },
     { name = "rich", specifier = ">=15.0.0,<16.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12,<1.0" },
-    { name = "textual", specifier = ">=2.0.0,<3.0" },
+    { name = "textual", specifier = ">=2.0.0,<9.0" },
     { name = "tiktoken", specifier = ">=0.9.0,<1.0" },
     { name = "tree-sitter", marker = "extra == 'context'", specifier = ">=0.25.2,<1.0" },
     { name = "tree-sitter-language-pack", marker = "extra == 'context'", specifier = ">=0.5.0,<2.0" },
@@ -3391,11 +3393,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps python-multipart from 0.0.26 to 0.0.27 to fix CVE-2026-42561 (DoS via unbounded multipart part headers).

Also removes the `--ignore-vuln CVE-2026-42561` flag from the CI security scan since this is now patched.

### Remaining suppressed CVEs in CI:
- **CVE-2026-28684** (python-dotenv 1.0.1) — litellm pins strictly, cannot upgrade until litellm relaxes its bound
- **CVE-2026-3219** — no applicable fix available