### PR TITLE
fix(test): tighten test directory permissions

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -36,7 +36,7 @@ def _run_doctor(
         read_only.mkdir()
         monkeypatch.setattr(cli, "DEFAULT_GLOBAL_DIR", read_only)
         if os.name != "nt":
-            os.chmod(str(read_only), 0o555)  # noqa: S103
+            os.chmod(str(read_only), 0o500)  # noqa: S103
 
     # Patch out LiteLLM validation so tests don't need real keys
     def _fake_validate(*args, **kwargs):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -36,7 +36,7 @@ def _run_doctor(
         read_only.mkdir()
         monkeypatch.setattr(cli, "DEFAULT_GLOBAL_DIR", read_only)
         if os.name != "nt":
-            os.chmod(str(read_only), 0o500)  # noqa: S103
+            os.chmod(str(read_only), 0o500)
 
     # Patch out LiteLLM validation so tests don't need real keys
     def _fake_validate(*args, **kwargs):


### PR DESCRIPTION
Changes 0o555 to 0o500 on the read-only test directory in test_doctor.py to resolve CodeQL alert #100 (overly permissive file permissions).