### PR TITLE
fix(tools): remove quoted type annotation (UP037)

### DIFF
--- a/src/godspeed/tools/deep_analysis.py
+++ b/src/godspeed/tools/deep_analysis.py
@@ -115,7 +115,7 @@ class DeepAnalysisTool(Tool):
             return ToolResult.failure(f"deep_analysis failed: {exc}")
 
 
-async def _run_step(llm: Any, prompt: str, step_label: str) -> tuple[str, "str | ToolResult"]:
+async def _run_step(llm: Any, prompt: str, step_label: str) -> tuple[str, str | ToolResult]:
     """Run one step of the analysis pipeline. Returns (prompt_text, response_content).
 
     On success the second element is the response string. On failure it is a


### PR DESCRIPTION
Fix ruff UP037 lint error in CI — remove unnecessary quotes from \str | ToolResult\ union type annotation since \rom __future__ import annotations\ is already present.